### PR TITLE
fix(azents-web): widen goal edit input

### DIFF
--- a/typescript/apps/azents-web/src/features/chat/components/TodoPreviewBar.stories.tsx
+++ b/typescript/apps/azents-web/src/features/chat/components/TodoPreviewBar.stories.tsx
@@ -70,6 +70,17 @@ export const GoalAndTodo: Story = {
   },
 };
 
+export const LongGoal: Story = {
+  args: {
+    goal: {
+      objective:
+        "Remove per-user OAuth handling and consolidate generic MCP, Notion, and Sentry toolkits under ToolkitConfig-level OAuth behavior",
+      status: "active",
+    },
+    todo: { items: [] },
+  },
+};
+
 export const PausedGoal: Story = {
   args: {
     goal: {

--- a/typescript/apps/azents-web/src/features/chat/components/TodoPreviewBar.tsx
+++ b/typescript/apps/azents-web/src/features/chat/components/TodoPreviewBar.tsx
@@ -288,7 +288,7 @@ function GoalSection({
               gap="xs"
               align="flex-start"
               wrap="nowrap"
-              style={{ minWidth: 0 }}
+              style={{ flex: 1, minWidth: 0 }}
             >
               <IconTargetArrow
                 aria-hidden="true"
@@ -310,7 +310,7 @@ function GoalSection({
                   aria-label={t("editGoal")}
                 />
               ) : (
-                <Text size="sm" lh={rem(20)} style={{ minWidth: 0 }}>
+                <Text size="sm" lh={rem(20)} style={{ flex: 1, minWidth: 0 }}>
                   {goal.objective}
                 </Text>
               )}


### PR DESCRIPTION
## Summary

azents-web chat progress modal now lets the Goal edit field use the available row width.

- Expand the Goal text/edit region so it fills the space left by the status badge.
- Add a long Goal Storybook fixture to keep this layout easy to review.

## Test Plan

- `pnpm run format --filter=@azents/web`
- `pnpm run lint --filter=@azents/web`
- `pnpm run typecheck --filter=@azents/web`
- `pnpm run build-storybook --filter=@azents/web`
