### PR TITLE
[codex] Implement deterministic tool snapshots

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -17,10 +17,10 @@ Design documents are accumulated records and are not listed individually in this
 |---|---|---|---|---|
 | [Agent Domain Spec](spec/domain/agent.md) | agent | @Hardtack | 2026-06-18 | 35 |
 | [Conversation & Events](spec/domain/conversation.md) | conversation | @Hardtack | 2026-06-28 | 75 |
-| [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-06-23 | 6 |
+| [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-06-29 | 7 |
 | [Memory](spec/domain/memory.md) | memory | @Hardtack | 2026-05-10 | 1 |
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-06-21 | 1 |
-| [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-06-28 | 37 |
+| [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-06-29 | 38 |
 | [User & Authentication](spec/domain/user-auth.md) | user-auth | @Hardtack | 2026-06-18 | 4 |
 | [Workspace & Membership](spec/domain/workspace.md) | workspace | @Hardtack | 2026-06-27 | 21 |
 
@@ -38,7 +38,7 @@ _8 documents_
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-06-16 | 6 |
 | [Context Compaction](spec/flow/context-compaction.md) | @Hardtack | 2026-06-27 | 12 |
 | [File Exchange Storage](spec/flow/file-exchange-storage.md) | @Hardtack | 2026-06-27 | 8 |
-| [MCP OAuth Flow](spec/flow/mcp-oauth.md) | @Hardtack | 2026-06-23 | 3 |
+| [MCP OAuth Flow](spec/flow/mcp-oauth.md) | @Hardtack | 2026-06-29 | 4 |
 | [Periodic Execution Flow Spec](spec/flow/periodic-execution.md) | - | 2026-06-27 | 2 |
 | [Run Resume](spec/flow/run-resume.md) | @Hardtack | 2026-06-25 | 7 |
 | [Session Context Inspector](spec/flow/session-context-inspector.md) | @Hardtack | 2026-06-27 | 9 |

--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -134,8 +134,9 @@ _14 documents_
 - [ADR-0082: Add Agent Workspace File Management Operations](adr/0082-agent-workspace-file-management.md)
 - [ADR-0083: User Stop Terminates Session-Owned Runtime Exec Processes](adr/0083-runtime-exec-user-stop-termination.md)
 - [ADR-0084: Failed-run Error Retry and Finalization](adr/0084-failed-run-error-retry.md)
+- [ADR-0085: Deterministic Tool Catalog, MCP Tool Snapshots, and Stable Toolkit Prompts](adr/0085-deterministic-tool-catalog-and-mcp-snapshots.md)
 
-_85 documents_
+_86 documents_
 
 ## Issues (Bug Tracking)
 
@@ -165,4 +166,4 @@ _3 documents_
 
 ## Statistics
 
-- Total documents: 318
+- Total documents: 319

--- a/docs/azents/adr/0085-deterministic-tool-catalog-and-mcp-snapshots.md
+++ b/docs/azents/adr/0085-deterministic-tool-catalog-and-mcp-snapshots.md
@@ -1,0 +1,260 @@
+---
+title: "ADR-0085: Deterministic Tool Catalog, MCP Tool Snapshots, and Stable Toolkit Prompts"
+created: 2026-06-28
+tags: [architecture, backend, engine, toolkit, mcp, llm]
+---
+# ADR-0085: Deterministic Tool Catalog, MCP Tool Snapshots, and Stable Toolkit Prompts
+
+## Context
+
+Azents sends model-visible tools through the Responses API top-level `tools` field. This is distinct from Codex's internal `additional_tools` input item used by its Responses Lite path. `additional_tools` does not solve cache instability by itself: changing any model-visible tool schema or order still changes the provider-facing request prefix.
+
+The current optimization problem is that Azents' model-visible tool catalog can be non-deterministic even when the user-facing toolkit configuration has not changed. Provider prompt caches are sensitive to tool schema and order, so the same session can lose cache locality when the tool array changes unnecessarily.
+
+Known instability sources include:
+
+- MCP-based toolkits returning tools in external server order.
+- MCP tool discovery completing after the first run has already started.
+- MCP loading/error states changing model-visible tools, such as exposing a retry tool.
+- GitHub multi-installation MCP tools becoming available at different times.
+- Goal or Todo tools regressing into state-dependent visibility.
+- Provider-hosted tools preserving upstream order when multiple hosted tools are present.
+- Final `ToolCatalog.native_tools` preserving upstream insertion order rather than applying a canonical order.
+- Toolkit prompts embedding transient state such as MCP loading/error state, current Goal state, or current Todo list.
+
+A previous Azents implementation waited for MCP tool lists on every user input. That made runs very slow, with responses delayed by more than a minute when MCP servers were slow or unstable. MCP server availability must therefore not become a synchronous dependency for normal run startup.
+
+System prompt stability matters for the same cache locality reason as tool schema stability. Azents assembles model instructions from the agent prompt, toolkit prompt fragments, and turn-injected hook prompts. The agent prompt and configuration-derived toolkit prompts are expected to change when configuration changes. Transient toolkit state should not be injected into the system prompt unless it is deliberately part of the agent instruction model.
+
+## Research notes
+
+### Codex
+
+Codex starts MCP clients asynchronously, but its general MCP tool build path awaits the managed client when no cached tool list exists. It also supports required MCP servers and validates those during session initialization.
+
+Codex applies strong deterministic normalization before model exposure:
+
+- MCP tools are normalized from raw server/tool identity into model-visible names.
+- Name collisions are resolved with deterministic hash suffixes.
+- Tool candidates are sorted by raw identity before being exposed.
+- Namespace tools are sorted by function name.
+- Codex Apps can use cached tools while startup is still in progress or after startup failure.
+
+This is useful evidence for canonical ordering and snapshot fallback, but Codex's blocking behavior is not directly suitable for Azents because Azents previously observed unacceptable latency when waiting for MCP list calls on input handling.
+
+### opencode
+
+opencode connects MCP servers and stores listed tool definitions in process state. It updates the stored definitions when the MCP server emits a tool-list-changed notification.
+
+Before sending an LLM request, opencode sorts the final tool object by tool name:
+
+```ts
+tools: Object.fromEntries(
+  Object.entries(tools).toSorted(([a], [b]) => a.localeCompare(b))
+)
+```
+
+This provides a simple and relevant precedent for Azents: even if upstream tool construction order varies, the provider-facing tool catalog should be canonicalized at the final request boundary.
+
+## Decision
+
+### ADR-0085-D1. Canonicalize provider-facing tool order
+
+Azents will make the final model-visible tool list deterministic. The provider-facing `native_tools` array must be sorted by a stable key, initially `tool.spec.name`.
+
+Toolkit-level tool generation should also avoid relying on external ordering. MCP-derived tools should be sorted before snapshotting and wrapping. Multi-source toolkits, such as GitHub multi-installation and GCP multi-service toolkits, should use explicit deterministic ordering for source groups and raw tool names.
+
+Configuration-dependent tool differences are acceptable. For example, Kubernetes read/write mode, enabled GCP services, enabled GitHub toolsets, attached toolkits, and runtime tools enabled/disabled may change the tool catalog. The requirement is that the same configuration snapshot and loaded toolkit state produce the same provider-facing tool list.
+
+### ADR-0085-D2. Keep MCP tool discovery off the run critical path
+
+Azents will not wait synchronously for MCP `list_tools` during normal LLM request preparation.
+
+MCP servers are external dependencies and may be slow or unstable. A slow MCP server must not delay ordinary user input processing or make Azents appear unavailable. This intentionally differs from Codex's general MCP await path and preserves Azents' lazy-loading direction.
+
+### ADR-0085-D3. Store MCP tool snapshots in Azents Toolkit State
+
+MCP tool catalogs will be stored as session-bound Toolkit State using the existing `ToolkitStateStore` / `ToolkitStateHandle` abstraction.
+
+The MCP toolkit's model-visible tools are derived from the latest successful snapshot stored in Toolkit State, not directly from live MCP server state during `update_context()`.
+
+A snapshot should contain enough data to reconstruct model-visible tool specs and route tool calls to the raw MCP tool, including at least:
+
+- raw MCP tool name;
+- model-visible tool name;
+- description;
+- input schema;
+- relevant server/toolkit identity or config hash needed for validation and routing;
+- snapshot metadata such as schema version, loaded timestamp, and tool hash.
+
+The exact payload schema is an implementation detail, but partial snapshots must not be exposed.
+
+### ADR-0085-D4. Use background refresh with atomic snapshot replacement
+
+MCP `list_tools` refresh runs in the background. `update_context()` reads the current Toolkit State snapshot and returns immediately.
+
+Refresh policy:
+
+- If no snapshot exists, expose no MCP tools.
+- If a snapshot exists, expose that snapshot immediately.
+- Start or continue background refresh when appropriate.
+- On refresh success, build the complete deterministic tool snapshot and replace the stored snapshot once.
+- On refresh failure, keep the previous successful snapshot unchanged.
+- Do not expose intermediate or partially loaded MCP tool lists.
+
+This gives stale-while-revalidate behavior: model-visible tools are stable in steady state, while background refresh can eventually replace the snapshot after a complete successful discovery.
+
+### ADR-0085-D5. Do not expose MCP loading, retry, or status pseudo-tools
+
+Azents will not add model-visible retry/status/setup tools solely to represent MCP loading or discovery failure.
+
+If the initial MCP snapshot is absent, the MCP toolkit exposes no tools. If refresh later succeeds, the next catalog build can expose the stored snapshot. If refresh fails and a previous snapshot exists, the old snapshot remains visible; if no previous snapshot exists, no MCP tools are visible.
+
+Retry is an internal background refresh concern, not a model-visible capability. This avoids low-value tool calls and prevents loading/error states from changing the tool catalog.
+
+### ADR-0085-D6. Keep Goal and Todo tools model-visible regardless of stored state
+
+Goal toolkit tools should remain model-visible regardless of the current goal state. State-specific behavior should be handled by tool execution and prompt text, not by adding/removing goal tools from the catalog.
+
+Todo toolkit tools should likewise remain model-visible regardless of whether the current todo list is empty or populated. Todo state may change the prompt fragment and UI snapshot, but it must not change the tool definition set.
+
+This keeps the provider-facing tool list stable across normal Goal/Todo state transitions.
+
+### ADR-0085-D7. Sort provider-hosted tools when multiple hosted tools are present
+
+Provider-hosted tools, such as hosted web search, are lowered separately from client-executed function tools. They are configuration/model dependent, so their presence may legitimately change when the run's model or configured builtin tools change.
+
+When multiple hosted tools are present, Azents should apply a deterministic order before sending the provider request. For the current optimization scope, only ordering is in scope; no behavior change is required for provider-hosted tool selection.
+
+### ADR-0085-D8. Apply the snapshot lifecycle to all MCP-backed toolkits
+
+The MCP snapshot policy applies to every toolkit whose model-visible tools are derived from MCP `list_tools`, not only to the generic MCP toolkit implementation.
+
+Toolkits that simply specialize authentication or filtering should use the common MCP snapshot implementation directly. Dedicated wrapper toolkits, such as GCP, AWS, GitHub, Sentry, or Notion when they do not directly inherit the generic lifecycle, must still follow the same lifecycle contract:
+
+- `update_context()` reads only the latest successful Toolkit State snapshot and does not await live MCP discovery.
+- Initial missing snapshot exposes no tools.
+- Refresh runs in the background.
+- Refresh success replaces the stored snapshot once, after a complete deterministic snapshot is built.
+- Refresh failure keeps the previous successful snapshot unchanged.
+- Loading, retry, and status pseudo-tools are not exposed to the model.
+
+Wrapper payload schemas may be toolkit-specific. Multi-source wrappers should use component-based snapshots where useful. For example, GCP may store one component per service, and GitHub may store one component per installation. A refresh may merge successful refreshed components with previous components for failed sources, then save the merged toolkit snapshot atomically once. Final exposure must flatten components in deterministic order.
+
+### ADR-0085-D9. Keep Toolkit prompts stable and avoid transient state injection
+
+Toolkit prompts should describe stable instructions, configuration, and constraints. They should not embed transient runtime state merely to inform the model that a toolkit is loading, failed, or currently has a particular stored state.
+
+MCP loading/error state must not be injected into toolkit prompts. With snapshot-backed MCP tools, an absent snapshot simply means no MCP tools are exposed yet.
+
+Goal and Todo toolkit prompts should be fixed instruction text. Current Goal state and current Todo list must not be injected into the system prompt for normal runs. The model can call the relevant tools when it needs current state, and Goal continuation already supplies follow-up execution when an active goal requires it. Re-injecting Goal state during compaction may be reconsidered later, but it is not part of this decision.
+
+Future UI work may expose per-toolkit state directly to users instead of routing that state through the model system prompt.
+
+### ADR-0085-D10. Return compact acknowledgements from state-update tools
+
+State-update tools should avoid echoing large updated state payloads when the model does not need them.
+
+In particular, `update_todo` should return a compact acknowledgement such as `Done` rather than echoing the full Todo list JSON. The stored Todo state and UI snapshot remain the source of truth for user-visible Todo state. This reduces redundant transcript growth and avoids feeding the same state back into the model unnecessarily.
+
+Goal update/create tools may also use compact acknowledgement responses when the updated state is not needed for immediate reasoning, while `get_goal` remains available for explicit state retrieval.
+
+### ADR-0085-D11. Keep Memory prompt injection as designed
+
+Memory summaries and memory rules are intentionally injected through the system prompt. Memory changes may affect prompt-cache locality, and that is accepted for this decision because Memory prompt injection is part of the current product design.
+
+### ADR-0085-D12. Treat configuration-derived Toolkit prompts as legitimate cache boundaries
+
+Toolkit prompts derived from explicit configuration are allowed to change when configuration changes. Examples include GCP project/service configuration, Kubernetes cluster and read/write mode configuration, Google Analytics default property, runtime allowed/denied domains, and registered runtime projects.
+
+These prompts should still be assembled deterministically. Lists inside configuration-derived prompts should use stable ordering when the underlying configuration does not intentionally define an order.
+
+Large runtime/project context prompts are a separate topic and are intentionally left for a later discussion.
+
+### ADR-0085-D14. Treat AGENTS.md as a `read` tool result appendix, not a Toolkit prompt
+
+AGENTS.md instructions should not be injected through Toolkit prompt fragments. They are better modeled as an appendix to file observation results: when the agent reads a file, applicable AGENTS.md instructions for that file path are appended to the `read` tool result.
+
+This keeps AGENTS.md content out of the stable system prompt and therefore out of the provider prompt-cache prefix. It also removes the need to store AGENTS.md contents in Toolkit State or refresh them in the background. AGENTS.md content is read fresh when it is appended, and any later AGENTS.md edits are represented by the agent's own file-edit tool results rather than by mutating previously provided instructions.
+
+AGENTS.md discovery must not create or touch the runtime solely to discover `/workspace/agent/AGENTS.md`. Runtime use is triggered only by explicit runtime file tools. The root workspace AGENTS.md is an applicable candidate for read paths under `/workspace/agent`. Registered Project AGENTS.md files are applicable for read paths inside their registered project roots. Nested AGENTS.md candidates are discovered along the path from the applicable root to the target file's directory.
+
+To keep behavior simple, Azents initially appends AGENTS.md instructions only to successful `read` tool results. Other file tools such as `write`, `edit`, `delete`, `grep`, `glob`, `import_file`, and `present_file` do not receive AGENTS.md appendices in this decision.
+
+Dedupe is path-based and stored in session-bound Toolkit State. The state stores only paths that have already been appended; it does not store AGENTS.md contents. Session compaction clears this dedupe path set so applicable AGENTS.md files may be appended again after compaction.
+
+The appendix should be appended after the original read result, using the same AGENTS.md content cap policy as existing AGENTS.md loading. It is acceptable to append after the original read result has already been output-capped because AGENTS.md content has its own cap and the appendix is expected to be small enough for this purpose.
+
+### ADR-0085-D13. Remove legacy per-user GitHub PAT behavior outside this optimization scope
+
+GitHub `per_user_pat` behavior is legacy and conflicts with the current toolkit-level integration direction. It should be removed rather than optimized. Per-user setup pseudo-tools should not remain as a model-visible path for GitHub toolkit availability.
+
+This cleanup is not part of the immediate tool-catalog optimization scope because the path is not expected to be used.
+
+## Consequences
+
+### Positive
+
+- MCP server latency no longer blocks normal run preparation.
+- Slow or failing MCP servers are isolated from Azents' core run availability.
+- Loaded MCP tool catalogs become stable across runs until a complete refresh succeeds.
+- Provider prompt-cache locality improves because model-visible tool order is canonical.
+- Retry/status pseudo-tools no longer pollute the model-visible tool list.
+- Goal/Todo lifecycle changes no longer change the tool catalog or system prompt.
+- Todo updates avoid echoing redundant Todo state into the transcript.
+
+### Negative
+
+- On a new session with no MCP snapshot, MCP tools are unavailable until background refresh succeeds.
+- A stale snapshot may expose a tool that the MCP server later removed or changed. In that case, the tool call should fail as a tool-level observation and trigger/allow a future refresh; it must not destabilize the whole run.
+- Persisting tool snapshots in Toolkit State introduces a schema and migration surface.
+- Background refresh needs concurrency control and backoff to avoid repeatedly hitting unhealthy MCP servers.
+- Removing current Goal/Todo state from the system prompt means the model must call `get_goal` or rely on tool results/continuations when it needs exact current state.
+
+## Implementation notes
+
+Initial implementation should prioritize:
+
+1. Sort final provider-facing client-executed tools by tool name.
+2. Sort provider-hosted tools when more than one hosted tool is present.
+3. Sort MCP-derived tools before snapshotting/wrapping.
+4. Store MCP successful snapshots in session-bound Toolkit State for generic MCP and MCP-backed wrapper toolkits.
+5. Make MCP-backed `update_context()` implementations read snapshots without awaiting live MCP discovery.
+6. Remove MCP retry/status pseudo-tool exposure.
+7. Keep Goal/Todo tool definitions fixed across stored state changes.
+8. Replace Goal/Todo dynamic state prompts with fixed instruction prompts.
+9. Change `update_todo` to return a compact acknowledgement instead of the full Todo state JSON.
+10. Move AGENTS.md injection from Toolkit prompts to successful `read` tool result appendices with Toolkit State path dedupe reset on compaction.
+11. Add observability for `tool_count`, canonical `tool_names_hash`, full `tools_schema_hash`, `system_prompt_hash`, snapshot age, refresh outcome, and refresh duration.
+
+The immediate non-MCP tool scope is intentionally narrow: final tool ordering, hosted-tool ordering, and regression coverage for Goal/Todo fixed tool definitions. Background task and subagent tool injection are known future redesign areas and are not part of this optimization pass.
+
+The immediate system-prompt scope is also narrow: remove transient MCP status prompts, make Goal/Todo prompts fixed, keep Memory prompt injection as-is, and keep configuration-derived Toolkit prompts as legitimate cache boundaries. Project/root agent instruction prompts require separate discussion.
+
+Refresh concurrency should avoid duplicate refreshes for the same session/toolkit. A process-local task guard may be sufficient for the first implementation, but Toolkit State metadata or a lightweight lease may be needed if multiple workers can refresh the same session toolkit concurrently.
+
+## Alternatives
+
+### Wait for MCP tools before every run
+
+Rejected. Azents previously experienced more than one minute of run startup delay when MCP tool discovery was awaited on every input. This makes external MCP server health part of Azents' core availability and is not acceptable.
+
+### Expose retry/status tools while MCP is loading
+
+Rejected. These tools have low task value and make the model-visible tool list depend on transient loading/error state. Background refresh and observability should handle retry/status internally.
+
+### Inject current Goal/Todo state into the system prompt
+
+Rejected. Goal and Todo state changes are frequent and do not need to be part of the stable instruction prefix. The model can retrieve current Goal state through tools when needed, Todo state is available through the Todo UI/state store, and Goal continuation already handles active-goal follow-up. This can be revisited for compaction-specific recovery if evidence shows the state must be reintroduced after summarization.
+
+### Echo complete Todo state from `update_todo`
+
+Rejected. Echoing the full Todo list after every update adds redundant transcript content and can reintroduce unnecessary state churn. A compact acknowledgement is sufficient for the model after a successful state update.
+
+### Keep snapshots only in toolkit instance memory
+
+Rejected for the decision target. Instance memory can still hold non-serializable runtime details such as an in-flight refresh task, but the tool snapshot source of truth should be the existing session-bound Toolkit State abstraction so it survives toolkit instance reuse boundaries within the session design.
+
+### Use Codex `additional_tools`
+
+Rejected for this problem. Azents already passes tool schemas through the Responses API top-level `tools` field. Moving schemas into an `additional_tools` input item would not solve catalog instability and is not known to be a stable provider-compatible path for Azents' LiteLLM-based execution.

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -14,10 +14,10 @@ Details of all living specs. Synchronized from frontmatter.
 |---|---|---|---|---|
 | agent | [Agent Domain Spec](domain/agent.md) | @Hardtack | 2026-06-18 | 35 |
 | conversation | [Conversation & Events](domain/conversation.md) | @Hardtack | 2026-06-28 | 75 |
-| goal | [Goal Domain Spec](domain/goal.md) | - | 2026-06-23 | 6 |
+| goal | [Goal Domain Spec](domain/goal.md) | - | 2026-06-29 | 7 |
 | memory | [Memory](domain/memory.md) | @Hardtack | 2026-05-10 | 1 |
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-06-21 | 1 |
-| toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-06-28 | 37 |
+| toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-06-29 | 38 |
 | user-auth | [User & Authentication](domain/user-auth.md) | @Hardtack | 2026-06-18 | 4 |
 | workspace | [Workspace & Membership](domain/workspace.md) | @Hardtack | 2026-06-27 | 21 |
 
@@ -33,7 +33,7 @@ Details of all living specs. Synchronized from frontmatter.
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-06-16 | 6 |
 | [Context Compaction](flow/context-compaction.md) | @Hardtack | 2026-06-27 | 12 |
 | [File Exchange Storage](flow/file-exchange-storage.md) | @Hardtack | 2026-06-27 | 8 |
-| [MCP OAuth Flow](flow/mcp-oauth.md) | @Hardtack | 2026-06-23 | 3 |
+| [MCP OAuth Flow](flow/mcp-oauth.md) | @Hardtack | 2026-06-29 | 4 |
 | [Periodic Execution Flow Spec](flow/periodic-execution.md) | - | 2026-06-27 | 2 |
 | [Run Resume](flow/run-resume.md) | @Hardtack | 2026-06-25 | 7 |
 | [Session Context Inspector](flow/session-context-inspector.md) | @Hardtack | 2026-06-27 | 9 |

--- a/docs/azents/spec/domain/goal.md
+++ b/docs/azents/spec/domain/goal.md
@@ -15,8 +15,8 @@ code_paths:
   - python/apps/azents/src/azents/services/chat/**
   - python/apps/azents/src/azents/api/public/chat/v1/**
   - typescript/apps/azents-web/src/features/chat/**
-last_verified_at: 2026-06-23
-spec_version: 6
+last_verified_at: 2026-06-29
+spec_version: 7
 ---
 
 # Goal Domain Spec
@@ -61,6 +61,8 @@ Goal Toolkit exposes these unprefixed tools in turns that have session context:
 - `get_goal`: read the current session Goal.
 - `create_goal`: create a new Goal when no unfinished Goal exists.
 - `update_goal`: mark the active Goal `complete` or `blocked`.
+
+The exposed Goal tool set is fixed across empty, active, blocked, paused, and complete state. Goal state changes must not add or remove model-visible Goal tools.
 
 Creation and update rules:
 
@@ -166,6 +168,11 @@ Forbidden behavior:
 
 Goal control prompts are not stored as frontend-only copy or WebSocket-only payloads. The runtime
 stores normalized state and metadata, then materializes model-visible prompt prose at lowering time.
+
+The Goal Toolkit prompt itself is fixed instruction text. It does not include the current Goal
+objective or status. A model that needs exact current state must call `get_goal`; active-goal idle
+continuation carries the objective through continuation metadata instead of duplicating it in the
+Toolkit prompt.
 
 Lowering rules:
 

--- a/docs/azents/spec/domain/toolkit.md
+++ b/docs/azents/spec/domain/toolkit.md
@@ -33,8 +33,8 @@ code_paths:
 api_routes:
   - /toolkit/v1
   - /shell-environment/v1
-last_verified_at: 2026-06-28
-spec_version: 37
+last_verified_at: 2026-06-29
+spec_version: 38
 ---
 
 # Toolkit
@@ -117,6 +117,8 @@ github__azents__get_file_contents
 
 The slug prefix is only a tool-call namespace. Toolkit State uses its own `toolkit_namespace` field and is not derived automatically from the model-visible tool name.
 
+Final provider-facing client tools are canonicalized by model-visible tool name before lowering to the model request. Toolkit-local generation may use whatever construction order is convenient, but `ToolCatalog.native_tools` is name-sorted so identical toolkit configuration and identical successful toolkit state produce stable function-tool ordering. Provider-hosted tools are also sorted by stable semantic name/config before request lowering when more than one hosted tool is present.
+
 ### Toolkit CRUD / Setup UI
 
 azents-web provides workspace-scoped toolkit management screens.
@@ -173,6 +175,20 @@ Runtime loads `mcp_oauth_connections` by `toolkit_id`, refreshes near-expiry tok
 
 Toolkit config responses include an `oauth_connection` summary for UI status/actions. The toolkit edit page exposes connect/reconnect/disconnect actions for generic MCP OAuth, Notion, and Sentry.
 
+### MCP Tool Snapshot Lifecycle
+
+MCP-backed toolkits must keep `list_tools` discovery off the normal run preparation critical path.
+
+- `update_context()` reads the latest successful session-bound Toolkit State snapshot and returns immediately.
+- If no successful snapshot exists, the toolkit exposes no MCP tools.
+- Background refresh lists tools, sorts them deterministically, builds a complete serializable snapshot, then atomically replaces the stored snapshot.
+- Refresh failure keeps the previous successful snapshot unchanged. If there is no previous snapshot, no tools are exposed.
+- Loading, retry, setup, and status pseudo-tools are not model-visible MCP availability controls.
+- MCP loading/error text is not injected into Toolkit prompts.
+- Generic MCP, Notion, and Sentry use the common MCP snapshot lifecycle. AWS, GCP, and GitHub MCP wrapper paths follow the same non-blocking/no-loading-prompt exposure contract and sort component/tool output deterministically.
+
+Snapshot payload stores only serializable tool metadata needed to rebuild model-visible wrappers, including raw MCP name, model-visible name, description, input schema, server URL, transport mode, loaded timestamp, and a stable tool hash. Runtime-only objects such as background tasks, auth callbacks, SigV4 auth, token providers, and artifact sinks stay in process memory.
+
 ### Credential Isolation
 
 Strong invariant: **raw credential is never exposed in agent prompt**.
@@ -191,7 +207,7 @@ Shell is composed of the builtin/runtime toolkit (`exec_command` / `write_stdin`
 - Shell file tools guide LLM-facing path surface for durable working files under Provider-reported Agent Workspace and temporary files under `/tmp/**`. User upload is copied to Runtime by `import_file` using `exchange://{object_key}` file-location URI, and internal artifact is copied with `artifact://{storage_key}` file-location URI. `/tmp/**` destination import warns that result can disappear after Runtime restart and returns original URI for reimport. `present_file` exports only files under durable Agent Workspace as user-visible `exchange://{object_key}` attachment.
 - `grep` file tool accepts both file path and directory path. Directory path searches recursively by default. Built-in heavy-directory excludes such as `.git`, `node_modules`, `.next`, and build/cache directories are applied by default. `exclude` adds caller-provided exclude patterns on top of those defaults; `disable_default_excludes: true` explicitly scans paths that the defaults would skip. Grep also enforces searched-file and scanned-byte safety caps so sparse matches across very large workspaces do not monopolize Runtime operation time.
 - `glob` file tool accepts absolute path patterns. Recursive patterns such as `**` search below the non-glob prefix and may return matching directories as well as files so directory-oriented patterns like `/workspace/agent/.claude/skills/*` are visible to agents. Built-in heavy-directory excludes such as `.git`, `node_modules`, `.next`, and build/cache directories are applied by default. `exclude` adds caller-provided exclude patterns on top of those defaults; `disable_default_excludes: true` explicitly scans paths that the defaults would skip.
-- Shell prompt guides LLM to prefer dedicated file tools for filesystem work: use `read` instead of `cat`, `grep` instead of shell `grep`/`rg`, `write`/`edit` instead of shell redirection or `sed` when possible. Use `exec_command` for command execution, package installation, or when dedicated tool does not fit. Use `write_stdin` with empty `chars` to poll a running process.
+- Shell prompt guides LLM to prefer dedicated file tools for filesystem work: use `read` instead of `cat`, `grep` instead of shell `grep`/`rg`, `write`/`edit` instead of shell redirection or `sed` when possible. Use `exec_command` for command execution, package installation, or when dedicated tool does not fit. Use `write_stdin` with empty `chars` to poll a running process. Runtime config prompts sort registered projects and domain lists deterministically.
 - `exec_command(command, workdir?, yield_time_ms?, max_output_bytes?)` starts a pipe-based Runner-owned process. If the process exits within the yield window, the tool result includes final output and exit code. If it is still running, the result includes collected output plus a process `process_id` for later interaction. `yield_time_ms` defaults to 10000 ms and accepts the 250-30000 ms range.
 - `write_stdin(process_id, chars = "", yield_time_ms?, max_output_bytes?)` writes to an existing process. Empty `chars` is the poll primitive and only drains unread output. Non-empty writes default to 250 ms and cap at 30000 ms; empty polls default to 5000 ms and allow 5000-300000 ms. Missing/expired/terminated process ids are returned as normal tool observations with structured metadata rather than assistant/system failures. Per ADR-0083, user stop requests TERM for all live exec processes owned by the stopped `AgentSession`; worker graceful shutdown/handover does not TERM runner-owned exec processes by itself.
 - Runtime process tool results are text for model visibility plus generic `metadata` on the client tool result payload. Metadata includes process status, process id when present, exit code when exited, truncation facts, and missing reason when unavailable. The engine preserves this metadata generically and does not branch on exec-specific keys.
@@ -227,26 +243,30 @@ Injected prompt returned by `on_turn_start` is passed to engine as event hook pr
 
 `deny` decision from `on_before_tool_call` short-circuits on first deny, returns deny message as tool output, and does not run handler. `on_after_tool_call` forms provider-order pipeline. If earlier provider returns `replace_output`, next provider receives replaced `output_text`; final replacement applies only to SDK output text channel. Image artifact block is preserved and output cap is reapplied after replacement.
 
-AGENTS.md instruction loader now registers `on_before_tool_call` in `hooks()` mapping to observe file-tool target path, rather than directly calling legacy `on_before_tool_call()`.
+AGENTS.md instruction loader registers runtime hooks through `hooks()`. It does not inject AGENTS.md content into Toolkit prompts.
 
 ### AGENTS.md Instruction Loading
 
-Shell builtin runtime injects Agent Workspace instruction file into system prompt.
+Shell runtime treats AGENTS.md as a successful `read` tool result appendix, not as a Toolkit/system prompt fragment.
 
-- Root instruction: `<Agent Workspace>/AGENTS.md`
-  - `BuiltinToolkit` injects as prompt block `Session Workspace Instructions`.
-  - If DB Runtime state is workspace-readable and Provider-reported workspace path exists, sends Runner file operation by `agent_runtime_id` to read live file.
-  - On live read success, update agent_id-keyed in-process snapshot.
-  - If no active Runtime, use snapshot fallback. Do not start Runtime start/reset just to load root instruction.
-- Project-scoped instruction: ancestor `AGENTS.md` inside registered Project
-  - `SandboxToolkit` observes target path of path-explicit file tools (`read`, `read_image`, `write`, `edit`, `delete`, `grep`, `glob`, `import_file`, `present_file`) in `on_before_tool_call()`.
-  - If observed path is inside registered Project, candidate `AGENTS.md` files are generated from Project root to target directory and scheduled for background refresh. Candidate becomes active only when live read confirms regular file exists.
-  - `AGENTS.md` inside unregistered folder is not auto-loaded.
-  - Active AGENTS file is cached in Toolkit State. `update_context()` renders only cached content immediately; cache miss or periodic refresh schedules background task. Cache miss does not wait for live read; once cache is populated, prompt reflects it from next turn.
-  - background refresh removes missing/not-file candidate from `active_project_paths` and `project_contents`. Temporary live read failure keeps existing cached content as fallback.
-  - `on_session_compact` clears both Project-scoped `active_project_paths` and `project_contents`. Workspace root instruction state remains. When file tool target path is observed again, candidates are live-read and only existing Project `AGENTS.md` is reactivated.
-  - background refresh over 10 seconds logs warn.
-- Prompt ordering: root instruction block first, Project instruction block after it. Project block uses path sort for stable ordering.
+- Root instruction candidate is `/workspace/agent/AGENTS.md` for read targets under `/workspace/agent`.
+- Registered Project instruction candidates are `AGENTS.md` files from the Project root to the read target directory, parent-to-child.
+- Candidate content is read fresh from Runtime file storage only while handling a successful `read` result.
+- Missing and non-file candidates are ignored.
+- Reading an `AGENTS.md` file does not append that same file as its own appendix.
+- `write`, `edit`, `delete`, `grep`, `glob`, `import_file`, `present_file`, and `read_image` do not append AGENTS.md instructions in this contract.
+- Toolkit State stores only a sorted dedupe path list under namespace `builtin`, state name `agents_md_appendix_dedupe`; it does not store AGENTS.md content.
+- `on_session_compact` clears the dedupe path list so future reads may append current AGENTS.md content again.
+- Appendix content uses the existing AGENTS.md content cap and is appended after the original read output in a `<system-reminder>` block.
+- Prompt builds and toolkit startup must not start or touch Runtime solely to discover AGENTS.md.
+
+The shell runtime prompt contains only fixed guidance that read results may include `<system-reminder>` AGENTS.md appendix blocks and that the agent should follow them for the paths they apply to.
+
+### Goal/Todo Prompt and Result Stability
+
+Goal and Todo auto-bound toolkits expose fixed tool definitions independent of current stored state. Their Toolkit prompts are fixed instruction text and do not include the current Goal objective/status or Todo list. The model can call `get_goal` when it needs exact Goal state; Todo UI/state snapshots remain the user-visible source of truth for Todo state.
+
+`update_todo` persists the new state and publishes `TodoStateChanged`, but returns compact acknowledgement text (`Done`) instead of echoing the full Todo JSON.
 
 ### Activation Conditions by Toolkit
 

--- a/docs/azents/spec/flow/mcp-oauth.md
+++ b/docs/azents/spec/flow/mcp-oauth.md
@@ -17,8 +17,8 @@ code_paths:
   - python/apps/azents/src/azents/rdb/models/toolkit.py
   - typescript/apps/azents-web/src/features/toolkits/**
   - typescript/apps/azents-web/src/trpc/routers/toolkit.ts
-last_verified_at: 2026-06-23
-spec_version: 3
+last_verified_at: 2026-06-29
+spec_version: 4
 ---
 
 # MCP OAuth Flow
@@ -133,7 +133,9 @@ sequenceDiagram
         AS-->>Runtime: new token set
         Runtime->>DB: Update encrypted tokens
     end
-    Runtime->>MCP: list_tools with Bearer token
+    Runtime-->>Runtime: update_context reads latest successful tool snapshot without waiting for list_tools
+    Runtime->>MCP: background list_tools refresh with Bearer token
+    Runtime->>DB: atomically replace successful deterministic tool snapshot
     Runtime->>MCP: call_tool with Bearer token
     alt call_tool returns 401
         Runtime->>DB: SELECT connection FOR UPDATE
@@ -202,6 +204,10 @@ Toolkit config responses include `oauth_connection` when a toolkit has a connect
 | Missing connection | Exchange without prior connect | 404 | Restart connect |
 | Refresh invalid_grant | Provider revoked or rotated away refresh token | `reconnect_required` | Manager reconnects |
 | 401 after retry | Refresh failed or token still rejected | Tool call returns MCP auth error | Manager reconnects or fixes provider scopes |
+
+Runtime `list_tools` failure is not a run-startup failure. If a previous successful snapshot exists,
+the old snapshot remains model-visible. If no snapshot exists, no MCP tools are exposed and no MCP
+loading/error prompt or retry pseudo-tool is added to the model-visible surface.
 
 ## Cryptography
 

--- a/python/apps/azents/src/azents/engine/events/litellm_responses.py
+++ b/python/apps/azents/src/azents/engine/events/litellm_responses.py
@@ -6,6 +6,7 @@ import contextlib
 import dataclasses
 import datetime
 import hashlib
+import json
 import os
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Sequence
 from typing import Any, Protocol, cast, runtime_checkable
@@ -508,7 +509,14 @@ def _lower_hosted_tools(
         model_developer=model_developer,
     )
 
-    for tool in hosted_tools:
+    for tool in sorted(
+        hosted_tools,
+        key=lambda item: (
+            item.name,
+            bool(item.config),
+            json.dumps(item.config, sort_keys=True, separators=(",", ":")),
+        ),
+    ):
         if tool.name != "web_search":
             continue
         if tool.name not in supported:

--- a/python/apps/azents/src/azents/engine/events/litellm_responses_test.py
+++ b/python/apps/azents/src/azents/engine/events/litellm_responses_test.py
@@ -1181,6 +1181,30 @@ class TestLiteLLMResponsesLowerer:
 
         assert request.tools == [{"type": "web_search"}]
 
+    def test_lowers_hosted_tools_in_deterministic_order(self) -> None:
+        """Sort hosted tools by semantic name/config before provider request."""
+        capabilities = ModelCapabilities()
+        capabilities.built_in_tools.supported = ["web_search"]
+        lowerer = LiteLLMResponsesLowerer(
+            provider="openai",
+            model="gpt-5.1",
+            provider_id=LLMProvider.OPENAI,
+            hosted_tools=[
+                BuiltinToolSpec(
+                    name="web_search", config={"search_context_size": "low"}
+                ),
+                BuiltinToolSpec(name="web_search", config={}),
+            ],
+            model_capabilities=capabilities,
+        )
+
+        request = lowerer.lower([], model="gpt-5.1")
+
+        assert request.tools == [
+            {"type": "web_search"},
+            {"type": "web_search", "search_context_size": "low"},
+        ]
+
     def test_lowers_google_web_search_hosted_tool(self) -> None:
         """Lower Google web_search opt-in to google_search tool shape."""
         capabilities = ModelCapabilities()

--- a/python/apps/azents/src/azents/engine/events/tools.py
+++ b/python/apps/azents/src/azents/engine/events/tools.py
@@ -53,7 +53,7 @@ class ToolCatalog:
                 "parameters": tool.spec.input_schema,
                 "strict": False,
             }
-            for tool in self.tools.values()
+            for tool in sorted(self.tools.values(), key=lambda item: item.spec.name)
         ]
 
 

--- a/python/apps/azents/src/azents/engine/events/tools_test.py
+++ b/python/apps/azents/src/azents/engine/events/tools_test.py
@@ -151,6 +151,45 @@ async def test_build_tool_catalog_prefixes_and_lowers_native_schema() -> None:
     assert request.tools == catalog.native_tools
 
 
+async def test_native_tools_are_sorted_by_function_name() -> None:
+    """Canonicalize provider-facing native tool order by function name."""
+    tools = [
+        FunctionTool(
+            spec=FunctionToolSpec(
+                name=name,
+                description=f"{name} tool.",
+                input_schema={"type": "object"},
+            ),
+            handler=_echo,
+        )
+        for name in ["zeta", "alpha", "middle"]
+    ]
+
+    catalog = await build_tool_catalog(
+        toolkit_bindings=[
+            ToolkitBinding(
+                toolkit=_InlineToolkit(tool),
+                slug="",
+                use_prefix=False,
+            )
+            for tool in tools
+        ],
+        context=TurnContext(
+            user_id=None,
+            workspace_id="workspace-1",
+            model="gpt-5.1",
+            run_id="run-1",
+            publish_event=_noop_publish,
+        ),
+    )
+
+    assert [tool["name"] for tool in catalog.native_tools] == [
+        "alpha",
+        "middle",
+        "zeta",
+    ]
+
+
 async def test_client_tool_executor_returns_event_result() -> None:
     """Convert Tool handler result to event client_tool_result."""
     catalog = await build_tool_catalog(

--- a/python/apps/azents/src/azents/engine/tools/aws.py
+++ b/python/apps/azents/src/azents/engine/tools/aws.py
@@ -304,7 +304,7 @@ class AwsToolkit(Toolkit[AwsToolkitConfig]):
             return
 
         tools: list[FunctionTool] = []
-        for mcp_tool in mcp_tools:
+        for mcp_tool in sorted(mcp_tools, key=lambda tool: tool.name):
             tools.append(
                 wrap_mcp_tool(
                     mcp_tool=mcp_tool,
@@ -328,7 +328,11 @@ class AwsToolkit(Toolkit[AwsToolkitConfig]):
         """
         self._refresh_artifact_sink(context)
         if not self._entered:
-            return await self._sync_update_context()
+            return ToolkitState(
+                status=ToolkitStatus.ENABLED,
+                tools=self._bg_tools or [],
+                prompt=self._build_prompt(),
+            )
 
         # Return immediately based on background status (keep previous tools)
         cached = self._bg_tools or []
@@ -337,14 +341,14 @@ class AwsToolkit(Toolkit[AwsToolkitConfig]):
             return ToolkitState(
                 status=ToolkitStatus.ENABLED,
                 tools=cached,
-                prompt="Loading tools..." if not cached else "",
+                prompt=self._build_prompt(),
             )
 
         if self._bg_error is not None:
             return ToolkitState(
                 status=ToolkitStatus.ENABLED,
                 tools=cached,
-                prompt=self._bg_error if not cached else "",
+                prompt=self._build_prompt(),
             )
 
         if self._bg_tools is not None:
@@ -358,7 +362,7 @@ class AwsToolkit(Toolkit[AwsToolkitConfig]):
         return ToolkitState(
             status=ToolkitStatus.ENABLED,
             tools=[],
-            prompt="Waiting for connection...",
+            prompt=self._build_prompt(),
         )
 
     async def _sync_update_context(self) -> ToolkitState:
@@ -383,7 +387,7 @@ class AwsToolkit(Toolkit[AwsToolkitConfig]):
             )
 
         tools: list[FunctionTool] = []
-        for mcp_tool in mcp_tools:
+        for mcp_tool in sorted(mcp_tools, key=lambda tool: tool.name):
             tools.append(
                 wrap_mcp_tool(
                     mcp_tool=mcp_tool,

--- a/python/apps/azents/src/azents/engine/tools/aws_test.py
+++ b/python/apps/azents/src/azents/engine/tools/aws_test.py
@@ -107,6 +107,7 @@ class TestAwsToolkitUpdateContext:
             new_callable=AsyncMock,
             return_value=(mock_tools, False),
         ):
+            await toolkit._connect_and_list_tools()  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
             state = await toolkit.update_context(ctx)
 
         assert len(state.tools) == 2
@@ -120,12 +121,7 @@ class TestAwsToolkitUpdateContext:
         toolkit = _make_toolkit(region="ap-northeast-2")
         ctx = _make_context()
 
-        with patch(
-            "azents.engine.tools.aws.mcp_list_tools",
-            new_callable=AsyncMock,
-            return_value=([], False),
-        ):
-            state = await toolkit.update_context(ctx)
+        state = await toolkit.update_context(ctx)
 
         assert "ap-northeast-2" in state.prompt
 
@@ -137,12 +133,7 @@ class TestAwsToolkitUpdateContext:
         )
         ctx = _make_context()
 
-        with patch(
-            "azents.engine.tools.aws.mcp_list_tools",
-            new_callable=AsyncMock,
-            return_value=([], False),
-        ):
-            state = await toolkit.update_context(ctx)
+        state = await toolkit.update_context(ctx)
 
         assert "arn:aws:iam::123456789012:role/MyRole" in state.prompt
 
@@ -152,12 +143,7 @@ class TestAwsToolkitUpdateContext:
         toolkit = _make_toolkit(role_arn=None)
         ctx = _make_context()
 
-        with patch(
-            "azents.engine.tools.aws.mcp_list_tools",
-            new_callable=AsyncMock,
-            return_value=([], False),
-        ):
-            state = await toolkit.update_context(ctx)
+        state = await toolkit.update_context(ctx)
 
         assert "Assumed Role" not in state.prompt
 
@@ -184,7 +170,7 @@ class TestAwsToolkitConnectionFailure:
             state = await toolkit.update_context(ctx)
 
         assert state.tools == []
-        assert "connection failed" in state.prompt.lower()
+        assert "connection failed" not in state.prompt.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +207,7 @@ class TestAwsToolkitBackgroundConnect:
                 # connection in progress -> loading
                 state = await toolkit.update_context(ctx)
                 assert state.tools == []
-                assert state.prompt == "Loading tools..."
+                assert "Loading" not in state.prompt
 
                 # connection complete
                 connect_event.set()
@@ -255,7 +241,7 @@ class TestAwsToolkitBackgroundConnect:
 
                 state = await toolkit.update_context(ctx)
                 assert state.tools == []
-                assert "AWS MCP server connection failed" in state.prompt
+                assert "AWS MCP server connection failed" not in state.prompt
 
     @pytest.mark.asyncio
     async def test_aexit_cancels_task(self) -> None:
@@ -279,8 +265,8 @@ class TestAwsToolkitBackgroundConnect:
         assert toolkit._bg_task is None  # noqa: SLF001  # pyright: ignore[reportPrivateUsage] -- directly validate background task cleanup in tests
 
     @pytest.mark.asyncio
-    async def test_fallback_sync_without_aenter(self) -> None:
-        """Synchronous connection fallback when called without __aenter__."""
+    async def test_without_aenter_does_not_sync_discover_tools(self) -> None:
+        """update_context without __aenter__ does not synchronously list tools."""
         toolkit = _make_toolkit()
         ctx = _make_context()
 
@@ -293,5 +279,5 @@ class TestAwsToolkitBackgroundConnect:
         ):
             state = await toolkit.update_context(ctx)
 
-        assert len(state.tools) == 1
+        assert state.tools == []
         assert "us-east-1" in state.prompt

--- a/python/apps/azents/src/azents/engine/tools/builtin.py
+++ b/python/apps/azents/src/azents/engine/tools/builtin.py
@@ -692,7 +692,10 @@ class RuntimeToolkit(ProjectAgentsPromptMixin, Toolkit[ShellToolkitConfig]):
         if self._excluded_tools:
             tools = [t for t in tools if t.spec.name not in self._excluded_tools]
 
-        projects = await self._load_projects(session_id=self._session_id)
+        projects = sorted(
+            await self._load_projects(session_id=self._session_id),
+            key=lambda project: project.path,
+        )
         self._last_projects = projects
         agents_prompt = await self._load_project_agents_prompt(file_ss, projects)
         prompt = self._render_config_prompt(
@@ -746,6 +749,9 @@ class RuntimeToolkit(ProjectAgentsPromptMixin, Toolkit[ShellToolkitConfig]):
             "possible. Use `exec_command` for command execution, package "
             "installation, and cases where no dedicated tool fits. Use "
             "`write_stdin` with empty chars to poll a running process.",
+            "Tool results may include `<system-reminder>` blocks with relevant "
+            "AGENTS.md instructions for files you read. Follow those instructions "
+            "for the paths they apply to.",
             "Recommended locations:",
             "- `/workspace/agent/` — Durable working files for this agent runtime",
             "- `/tmp/` — Temporary scratch space for the current runtime instance",
@@ -781,9 +787,11 @@ class RuntimeToolkit(ProjectAgentsPromptMixin, Toolkit[ShellToolkitConfig]):
 
         config = self._config
         if config.allowed_domains:
-            parts.append(f"Allowed domains: {', '.join(config.allowed_domains)}")
+            parts.append(
+                f"Allowed domains: {', '.join(sorted(config.allowed_domains))}"
+            )
         if config.denied_domains:
-            parts.append(f"Denied domains: {', '.join(config.denied_domains)}")
+            parts.append(f"Denied domains: {', '.join(sorted(config.denied_domains))}")
         return "\n".join(parts)
 
 

--- a/python/apps/azents/src/azents/engine/tools/builtin_agents.py
+++ b/python/apps/azents/src/azents/engine/tools/builtin_agents.py
@@ -17,6 +17,7 @@ from azents.engine.hooks.types import (
     BeforeToolCallHookContext,
     RuntimeHooks,
     SessionCompactHookContext,
+    ToolOutputReplace,
 )
 from azents.engine.tooling.toolkit_state import (
     ToolkitStateHandle,
@@ -42,6 +43,7 @@ AGENTS_BACKGROUND_REFRESH_WARN_SECONDS = 10.0
 AGENTS_TOOLKIT_NAMESPACE = "builtin"
 ROOT_AGENTS_TOOLKIT_STATE_NAME = "root_agents_instruction"
 PROJECT_AGENTS_TOOLKIT_STATE_NAME = "project_agents_instructions"
+AGENTS_APPENDIX_DEDUPE_TOOLKIT_STATE_NAME = "agents_md_appendix_dedupe"
 
 
 class RootAgentsInstructionState(ToolkitStateModel):
@@ -57,6 +59,13 @@ class ProjectAgentsInstructionState(ToolkitStateModel):
     schema_version: int = 1
     project_contents: dict[str, str] = Field(default_factory=dict)
     active_project_paths: set[str] = Field(default_factory=set)
+
+
+class AgentsAppendixDedupeState(ToolkitStateModel):
+    """AGENTS.md read-result appendix dedupe Toolkit State payload."""
+
+    schema_version: int = 1
+    appended_paths: list[str] = Field(default_factory=list)
 
 
 class AgentsInstructionStateStore(Protocol):
@@ -104,6 +113,21 @@ class AgentsInstructionStateStore(Protocol):
         ],
     ) -> None:
         """Retry-apply mutator to latest Project AGENTS.md state."""
+        ...
+
+    async def load_appendix_dedupe(
+        self, agent_id: str, session_id: str
+    ) -> AgentsAppendixDedupeState:
+        """Fetch AGENTS.md appendix dedupe state."""
+        ...
+
+    async def update_appendix_dedupe(
+        self,
+        agent_id: str,
+        session_id: str,
+        mutator: Callable[[AgentsAppendixDedupeState], AgentsAppendixDedupeState],
+    ) -> None:
+        """Retry-apply mutator to latest appendix dedupe state."""
         ...
 
 
@@ -194,6 +218,32 @@ class ToolkitAgentsInstructionStateStore:
                 mutator=mutator,
             )
 
+    async def load_appendix_dedupe(
+        self, agent_id: str, session_id: str
+    ) -> AgentsAppendixDedupeState:
+        """Fetch AGENTS.md appendix dedupe state."""
+        async with self._session_manager() as session:
+            handle = self._make_appendix_dedupe_handle(session, agent_id, session_id)
+            if handle is None:
+                return AgentsAppendixDedupeState()
+            return await handle.load(default_factory=AgentsAppendixDedupeState)
+
+    async def update_appendix_dedupe(
+        self,
+        agent_id: str,
+        session_id: str,
+        mutator: Callable[[AgentsAppendixDedupeState], AgentsAppendixDedupeState],
+    ) -> None:
+        """Retry-apply mutator to latest appendix dedupe state."""
+        async with self._session_manager() as session:
+            handle = self._make_appendix_dedupe_handle(session, agent_id, session_id)
+            if handle is None:
+                return
+            await handle.update(
+                default_factory=AgentsAppendixDedupeState,
+                mutator=mutator,
+            )
+
     def _make_project_handle(
         self,
         session: AsyncSession,
@@ -232,6 +282,26 @@ class ToolkitAgentsInstructionStateStore:
         return ToolkitStateStore(session=session).handle(
             identity,
             RootAgentsInstructionState,
+        )
+
+    def _make_appendix_dedupe_handle(
+        self,
+        session: AsyncSession,
+        agent_id: str,
+        session_id: str,
+    ) -> ToolkitStateHandle[AgentsAppendixDedupeState] | None:
+        """Create AGENTS.md appendix dedupe handle for agent/session identity."""
+        if not agent_id or not session_id:
+            return None
+        identity = ToolkitStateIdentity(
+            agent_id=agent_id,
+            session_id=session_id,
+            toolkit_namespace=AGENTS_TOOLKIT_NAMESPACE,
+            state_name=AGENTS_APPENDIX_DEDUPE_TOOLKIT_STATE_NAME,
+        )
+        return ToolkitStateStore(session=session).handle(
+            identity,
+            AgentsAppendixDedupeState,
         )
 
 
@@ -461,16 +531,9 @@ class RootAgentsPromptMixin:
         domain_config: RuntimeDomainConfig,
         user_id: str | None,
     ) -> str:
-        """Read root AGENTS.md prompt from persistent store."""
+        """Do not inject root AGENTS.md into Toolkit prompts."""
         del workspace_id, domain_config, user_id
-        state = await self._load_root_agents_state()
-        content = state.root_content
-        if not content:
-            return ""
-        return render_agents_block(
-            "Session Workspace Instructions",
-            [(ROOT_AGENTS_PATH, content)],
-        )
+        return ""
 
     async def _load_root_agents_state(self) -> RootAgentsInstructionState:
         """Fetch persistent root AGENTS.md instruction state."""
@@ -512,22 +575,14 @@ class ProjectAgentsPromptMixin:
     async def _on_before_tool_call_hook(
         self, context: BeforeToolCallHookContext
     ) -> None:
-        """Connect runtime hook context to existing AGENTS.md before observer."""
-        await self.on_before_tool_call(
-            ToolCallHookContext(
-                tool_name=context.tool_name,
-                toolkit_slug=context.toolkit_slug,
-                args_json=context.args_json,
-                session_id=context.session_id,
-                agent_id=context.agent_id,
-                workspace_id=context.workspace_id,
-                run_id=context.run_id,
-            )
-        )
+        """AGENTS.md discovery is not performed before tool execution."""
+        del context
 
-    async def _on_after_tool_call_hook(self, context: AfterToolCallHookContext) -> None:
-        """Connect runtime hook context to existing AGENTS.md after observer."""
-        await self.on_after_tool_call(
+    async def _on_after_tool_call_hook(
+        self, context: AfterToolCallHookContext
+    ) -> ToolOutputReplace | None:
+        """Append applicable AGENTS.md instructions after successful read."""
+        return await self.append_agents_after_read(
             ToolCallHookContext(
                 tool_name=context.tool_name,
                 toolkit_slug=context.toolkit_slug,
@@ -545,124 +600,92 @@ class ProjectAgentsPromptMixin:
     async def _on_session_compact_hook(
         self, context: SessionCompactHookContext
     ) -> None:
-        """Clear all Project AGENTS.md active/cache on compaction."""
+        """Clear AGENTS.md appendix dedupe on compaction."""
         del context
         self._active_agents_paths = set()
         self._pending_agents_refresh_paths = set()
-        await self._update_project_agents_state(
-            lambda state: state.model_copy(
-                update={"project_contents": {}, "active_project_paths": set()}
-            )
+        await self._update_appendix_dedupe_state(
+            lambda state: state.model_copy(update={"appended_paths": []})
         )
 
     async def on_before_tool_call(self, context: ToolCallHookContext) -> None:
-        """Enable existing Project AGENTS.md candidates for file target path."""
-        candidates: set[str] = set()
-        for ref in extract_tool_path_refs(context.tool_name, context.args_json):
-            candidates.update(
-                agents_candidates_for_path(
-                    ref.path,
-                    self._last_projects,
-                    directory=ref.directory,
-                )
-            )
-        file_storage = self._agents_file_storage
-        if file_storage is None:
-            return
-        self._schedule_project_agents_refresh(
-            file_storage=file_storage,
-            paths=candidates,
-        )
+        """Do not live-discover AGENTS.md before tool execution."""
+        del context
 
-    async def on_after_tool_call(
+    async def append_agents_after_read(
         self,
         context: ToolCallHookContext,
         outcome: ToolCallHookOutcome,
-    ) -> None:
-        """Update persistent instruction state after AGENTS.md write/delete."""
-        if outcome.error is not None:
-            return
-        paths = [
+    ) -> ToolOutputReplace | None:
+        """Append applicable AGENTS.md instructions to successful read results."""
+        if outcome.error is not None or outcome.output is None:
+            return None
+        tool_name = _base_tool_name(context.tool_name)
+        if tool_name != "read":
+            return None
+        refs = extract_tool_path_refs(tool_name, context.args_json)
+        if not refs:
+            return None
+        target_path = refs[0].path
+        if not _is_under_workspace_root(target_path):
+            return None
+        file_storage = self._agents_file_storage
+        if file_storage is None:
+            return None
+        dedupe = await self._load_appendix_dedupe_state()
+        already_appended = set(dedupe.appended_paths)
+        candidates = _agents_appendix_candidates_for_path(
+            target_path,
+            self._last_projects,
+            directory=refs[0].directory,
+        )
+        candidates = [
             path
-            for path in extract_tool_paths(context.tool_name, context.args_json)
-            if posixpath.basename(path) == AGENTS_FILENAME
+            for path in candidates
+            if path != target_path and path not in already_appended
         ]
-        if not paths:
-            return
-        root_paths = [path for path in paths if path == ROOT_AGENTS_PATH]
-        project_paths = [path for path in paths if path != ROOT_AGENTS_PATH]
-        if root_paths:
-            await self._update_root_agents_state(
-                lambda state: apply_root_agents_tool_update(
-                    state,
-                    context.tool_name,
-                    context.args_json,
-                )
-            )
-        if project_paths:
-
-            def _mutate(
-                state: ProjectAgentsInstructionState,
-            ) -> ProjectAgentsInstructionState:
-                active_project_paths = set(state.active_project_paths)
-                for path in project_paths:
-                    state = apply_project_agents_tool_update(
-                        state,
-                        path,
-                        context.tool_name,
-                        context.args_json,
-                    )
-                    if project_for_path(path, self._last_projects) is None:
-                        continue
-                    if context.tool_name == "delete":
-                        active_project_paths.discard(path)
-                    else:
-                        active_project_paths.add(path)
-                return state.model_copy(
-                    update={"active_project_paths": active_project_paths}
-                )
-
-            await self._update_project_agents_state(_mutate)
+        files = await self._read_existing_agents_files(file_storage, candidates)
+        if not files:
+            return None
+        appended_paths = sorted(already_appended | {path for path, _ in files})
+        await self._update_appendix_dedupe_state(
+            lambda state: state.model_copy(update={"appended_paths": appended_paths})
+        )
+        logger.info(
+            "Appended AGENTS.md instructions to read result",
+            extra={
+                "agent_id": self._runtime_agent_id,
+                "session_id": self._runtime_session_id,
+                "appended_path_count": len(files),
+                "dedupe_skipped_path_count": len(candidates) - len(files),
+            },
+        )
+        return ToolOutputReplace(
+            output_text=f"{outcome.output}\n\n{render_agents_appendix(files)}"
+        )
 
     async def _load_project_agents_prompt(
         self,
         file_storage: FileStorage,
         projects: list[SessionWorkspaceProject],
     ) -> str:
-        """Render active Project-scoped AGENTS.md prompt from cache."""
+        """Register storage/projects without injecting AGENTS.md into prompt."""
         self._agents_file_storage = file_storage
-        state = await self._load_project_agents_state()
-        self._active_agents_paths.update(state.active_project_paths)
-        valid_paths = {
-            path
-            for path in self._active_agents_paths
-            if project_for_path(path, projects) is not None
-        }
-        self._active_agents_paths = valid_paths
-        should_read_live = (
-            self._agents_turns_since_live_read >= AGENTS_LIVE_READ_INTERVAL_TURNS
-        )
-        if should_read_live:
-            self._agents_turns_since_live_read = 0
-        else:
-            self._agents_turns_since_live_read += 1
+        self._last_projects = sorted(projects, key=lambda project: project.path)
+        return ""
 
-        project_contents = dict(state.project_contents)
-        rendered = [
-            (path, content)
-            for path in sorted(valid_paths)
-            if (content := project_contents.get(path)) is not None
-        ]
-        await self._update_project_agents_state(
-            lambda state: state.model_copy(update={"active_project_paths": valid_paths})
-        )
-        missing_paths = {path for path in valid_paths if path not in project_contents}
-        refresh_paths = valid_paths if should_read_live else missing_paths
-        self._schedule_project_agents_refresh(
-            file_storage=file_storage,
-            paths=refresh_paths,
-        )
-        return render_project_agents_block(rendered)
+    async def _read_existing_agents_files(
+        self,
+        file_storage: FileStorage,
+        paths: Sequence[str],
+    ) -> list[tuple[str, str]]:
+        """Read existing AGENTS.md files in deterministic order."""
+        files: list[tuple[str, str]] = []
+        for path in paths:
+            content = await self._read_agents_file(file_storage, path, fallback=None)
+            if content is not None:
+                files.append((path, content))
+        return files
 
     def _schedule_project_agents_refresh(
         self,
@@ -815,6 +838,81 @@ class ProjectAgentsPromptMixin:
             self._runtime_session_id,
             mutator,
         )
+
+    async def _load_appendix_dedupe_state(self) -> AgentsAppendixDedupeState:
+        """Fetch persistent AGENTS.md appendix dedupe state."""
+        if self._agents_store is None:
+            return AgentsAppendixDedupeState()
+        return await self._agents_store.load_appendix_dedupe(
+            self._runtime_agent_id,
+            self._runtime_session_id,
+        )
+
+    async def _update_appendix_dedupe_state(
+        self,
+        mutator: Callable[[AgentsAppendixDedupeState], AgentsAppendixDedupeState],
+    ) -> None:
+        """Retry-update persistent AGENTS.md appendix dedupe state."""
+        if self._agents_store is None:
+            return
+        await self._agents_store.update_appendix_dedupe(
+            self._runtime_agent_id,
+            self._runtime_session_id,
+            mutator,
+        )
+
+
+def render_agents_appendix(files: Sequence[tuple[str, str]]) -> str:
+    """Render AGENTS.md instructions as a read result appendix."""
+    if not files:
+        return ""
+    parts = [
+        "<system-reminder>",
+        "Relevant AGENTS.md instructions for the accessed path:",
+    ]
+    for path, content in files:
+        parts.extend(["", f"### {path}", "", content])
+    parts.append("</system-reminder>")
+    return "\n".join(parts)
+
+
+def _agents_appendix_candidates_for_path(
+    path: str,
+    projects: Sequence[SessionWorkspaceProject],
+    *,
+    directory: bool = False,
+) -> list[str]:
+    """Return root/project AGENTS.md candidates applicable to target path."""
+    normalized = _normalize_runtime_path(path)
+    if normalized is None or not _is_under_workspace_root(normalized):
+        return []
+    candidates = [ROOT_AGENTS_PATH]
+    candidates.extend(
+        agents_candidates_for_path(normalized, projects, directory=directory)
+    )
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        ordered.append(candidate)
+    return ordered
+
+
+def _base_tool_name(tool_name: str) -> str:
+    """Return unprefixed tool name."""
+    if "__" not in tool_name:
+        return tool_name
+    return tool_name.split("__", 1)[1]
+
+
+def _is_under_workspace_root(path: str) -> bool:
+    """Return whether path is inside the agent workspace root."""
+    normalized = posixpath.normpath(path)
+    return normalized == SESSION_WORKSPACE_ROOT or normalized.startswith(
+        f"{SESSION_WORKSPACE_ROOT}/"
+    )
 
 
 def _normalize_runtime_path(path: str) -> str | None:

--- a/python/apps/azents/src/azents/engine/tools/builtin_test.py
+++ b/python/apps/azents/src/azents/engine/tools/builtin_test.py
@@ -19,7 +19,12 @@ from azents.core.enums import (
     RuntimeProviderObservedState,
     RuntimeRunnerState,
 )
-from azents.core.tools import ShellToolkitConfig, ToolkitState, TurnContext
+from azents.core.tools import (
+    ShellToolkitConfig,
+    ToolCallHookOutcome,
+    ToolkitState,
+    TurnContext,
+)
 from azents.engine.events.engine_events import (
     RuntimeProcessOutputDeltaEvent,
     RuntimeReadyEvent,
@@ -36,7 +41,7 @@ from azents.engine.run.types import (
 from azents.engine.tools import builtin as builtin_module
 from azents.engine.tools.builtin import BuiltinToolkit, RuntimeToolkit
 from azents.engine.tools.builtin_agents import (
-    AGENTS_LIVE_READ_INTERVAL_TURNS,
+    AgentsAppendixDedupeState,
     ProjectAgentsInstructionState,
     RootAgentsInstructionState,
 )
@@ -153,6 +158,7 @@ class _FakeAgentsInstructionStateStore:
     def __init__(self) -> None:
         self.root_states: dict[tuple[str, str], RootAgentsInstructionState] = {}
         self.project_states: dict[tuple[str, str], ProjectAgentsInstructionState] = {}
+        self.dedupe_states: dict[tuple[str, str], AgentsAppendixDedupeState] = {}
 
     async def load_root(
         self, agent_id: str, session_id: str
@@ -206,6 +212,24 @@ class _FakeAgentsInstructionStateStore:
         """Apply project state update."""
         state = await self.load_project(agent_id, session_id)
         await self.save_project(agent_id, session_id, mutator(state))
+
+    async def load_appendix_dedupe(
+        self, agent_id: str, session_id: str
+    ) -> AgentsAppendixDedupeState:
+        """Return stored appendix dedupe state."""
+        return self.dedupe_states.get(
+            (agent_id, session_id), AgentsAppendixDedupeState()
+        )
+
+    async def update_appendix_dedupe(
+        self,
+        agent_id: str,
+        session_id: str,
+        mutator: Callable[[AgentsAppendixDedupeState], AgentsAppendixDedupeState],
+    ) -> None:
+        """Apply appendix dedupe state update."""
+        state = await self.load_appendix_dedupe(agent_id, session_id)
+        self.dedupe_states[(agent_id, session_id)] = mutator(state)
 
 
 class _FakeRunnerOperations:
@@ -582,13 +606,6 @@ def _make_toolkit(
     return toolkit
 
 
-async def _drain_agents_refresh(toolkit: RuntimeToolkit) -> None:
-    """Wait until AGENTS.md background refresh task completes for tests."""
-    task = cast(Any, toolkit)._agents_refresh_task
-    if task is not None:
-        await task
-
-
 def _make_project(*, path: str) -> SessionWorkspaceProject:
     """Create SessionWorkspaceProject for tests."""
     now = datetime.now(UTC)
@@ -728,242 +745,75 @@ class TestRuntimeToolkitUpdateContext:
         assert "Registered Projects" not in state.prompt
 
     @pytest.mark.asyncio
-    async def test_project_agents_loaded_after_project_file_access(self) -> None:
-        """Project AGENTS is included after loaded Project file access."""
+    async def test_read_appends_root_and_project_agents(self) -> None:
+        """Successful read appends applicable AGENTS.md files parent-to-child."""
         toolkit = _make_toolkit(
             projects=[_make_project(path="/workspace/agent/app")],
             storage_files={
-                "/workspace/agent/app/AGENTS.md": b"PROJECT_AGENT_RULE",
-                "/workspace/agent/app/src/file.py": b"print('hi')",
-            },
-        )
-        await toolkit.update_context(_make_context())
-
-        await toolkit.on_before_tool_call(
-            MagicMock(
-                tool_name="read",
-                args_json='{"path": "/workspace/agent/app/src/file.py"}',
-            )
-        )
-        state = await toolkit.update_context(_make_context())
-        assert "Project Instructions" not in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-
-        assert "Project Instructions" in state.prompt
-        assert "/workspace/agent/app/AGENTS.md" in state.prompt
-        assert "PROJECT_AGENT_RULE" in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_project_agents_cache_miss_refresh_does_not_block_prompt(
-        self,
-    ) -> None:
-        """Cache miss live read runs in background and does not block update_context."""
-        toolkit = _make_toolkit(
-            projects=[_make_project(path="/workspace/agent/app")],
-            storage_files={
-                "/workspace/agent/app/AGENTS.md": b"PROJECT_AGENT_RULE",
-                "/workspace/agent/app/src/file.py": b"print('hi')",
-            },
-        )
-        runner_operations = cast(
-            _FakeRunnerOperations,
-            cast(Any, toolkit)._test_runner_operations,
-        )
-        stat_started = asyncio.Event()
-        stat_continue = asyncio.Event()
-        runner_operations.stat_started_event = stat_started
-        runner_operations.stat_continue_event = stat_continue
-        await toolkit.update_context(_make_context())
-        await toolkit.on_before_tool_call(
-            MagicMock(
-                tool_name="read",
-                args_json='{"path": "/workspace/agent/app/src/file.py"}',
-            )
-        )
-
-        state = await toolkit.update_context(_make_context())
-        await asyncio.wait_for(stat_started.wait(), timeout=1)
-
-        assert "Project Instructions" not in state.prompt
-        assert cast(Any, toolkit)._agents_refresh_task is not None
-
-        stat_continue.set()
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-
-        assert "PROJECT_AGENT_RULE" in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_project_agents_ignores_directory_named_agents_md(self) -> None:
-        """Do not read AGENTS.md candidate when it is not a file."""
-        toolkit = _make_toolkit(
-            projects=[_make_project(path="/workspace/agent/app")],
-            storage_files={
-                "/workspace/agent/app/AGENTS.md/nested.txt": b"NOT_A_RULE",
-                "/workspace/agent/app/src/file.py": b"print('hi')",
-            },
-        )
-        await toolkit.update_context(_make_context())
-
-        await toolkit.on_before_tool_call(
-            MagicMock(
-                tool_name="read",
-                args_json='{"path": "/workspace/agent/app/src/file.py"}',
-            )
-        )
-        state = await toolkit.update_context(_make_context())
-        assert "NOT_A_RULE" not in state.prompt
-        assert "Project Instructions" not in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-
-        assert "NOT_A_RULE" not in state.prompt
-        assert "Project Instructions" not in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_project_agents_prunes_missing_candidates_from_active_state(
-        self,
-    ) -> None:
-        """Do not leave nonexistent AGENTS candidate in active/cache state."""
-        toolkit = _make_toolkit(
-            projects=[_make_project(path="/workspace/agent/app")],
-            storage_files={
-                "/workspace/agent/app/src/file.py": b"print('hi')",
-            },
-        )
-        await toolkit.update_context(_make_context())
-
-        await toolkit.on_before_tool_call(
-            MagicMock(
-                tool_name="read",
-                args_json='{"path": "/workspace/agent/app/src/file.py"}',
-            )
-        )
-        await _drain_agents_refresh(toolkit)
-
-        store = cast(_FakeAgentsInstructionStateStore, cast(Any, toolkit)._agents_store)
-        state = await store.load_project("agent-1", "session-1")
-        assert state.active_project_paths == set()
-        assert state.project_contents == {}
-
-    @pytest.mark.asyncio
-    async def test_project_agents_ignores_not_directory_stat_failures(
-        self,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Silently ignore not-directory stat failure for AGENTS candidate."""
-        toolkit = _make_toolkit(
-            projects=[_make_project(path="/workspace/agent/app")],
-            storage_files={
+                "/workspace/agent/AGENTS.md": b"ROOT_RULE",
                 "/workspace/agent/app/AGENTS.md": b"PROJECT_RULE",
-                "/workspace/agent/app/frontend/src/file.py": b"print('hi')",
+                "/workspace/agent/app/src/AGENTS.md": b"SRC_RULE",
+                "/workspace/agent/app/src/file.py": b"print('hi')",
             },
         )
-        await toolkit.update_context(_make_context())
+        state = await toolkit.update_context(_make_context())
+        assert "ROOT_RULE" not in state.prompt
+        assert "PROJECT_RULE" not in state.prompt
 
-        await toolkit.on_before_tool_call(
+        decision = await toolkit.append_agents_after_read(
             MagicMock(
-                tool_name="grep",
-                args_json=(
-                    '{"path": "/workspace/agent/app/frontend/src/file.py", '
-                    '"pattern": "hi"}'
-                ),
-            )
-        )
-        state = await toolkit.update_context(_make_context())
-        assert "Project Instructions" not in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-        runner_operations = cast(
-            _FakeRunnerOperations,
-            cast(Any, toolkit)._test_runner_operations,
+                tool_name="read",
+                args_json='{"path": "/workspace/agent/app/src/file.py"}',
+            ),
+            ToolCallHookOutcome(output="FILE_CONTENT", error=None),
         )
 
-        assert "PROJECT_RULE" in state.prompt
-        assert "file.py/AGENTS.md" not in state.prompt
-        assert "/workspace/agent/app/frontend/src/file.py/AGENTS.md" in (
-            runner_operations.stat_calls
+        assert decision is not None
+        assert decision.output_text.startswith("FILE_CONTENT")
+        assert decision.output_text.index("ROOT_RULE") < decision.output_text.index(
+            "PROJECT_RULE"
         )
-        assert "Failed to read project AGENTS.md" not in caplog.text
+        assert decision.output_text.index("PROJECT_RULE") < decision.output_text.index(
+            "SRC_RULE"
+        )
 
     @pytest.mark.asyncio
-    async def test_project_agents_ignored_outside_loaded_project(self) -> None:
-        """AGENTS in unregistered folder is not included in prompt."""
+    async def test_read_appends_agents_only_once_until_compaction(self) -> None:
+        """AGENTS.md appendix is deduped by path until compaction clears state."""
+        agents_store = _FakeAgentsInstructionStateStore()
         toolkit = _make_toolkit(
+            agents_store=agents_store,
             projects=[_make_project(path="/workspace/agent/app")],
             storage_files={
-                "/workspace/agent/unregistered/AGENTS.md": b"SHOULD_NOT_APPEAR",
-                "/workspace/agent/unregistered/file.py": b"print('hi')",
+                "/workspace/agent/AGENTS.md": b"ROOT_RULE",
+                "/workspace/agent/app/AGENTS.md": b"PROJECT_RULE",
+                "/workspace/agent/app/file.py": b"print('hi')",
             },
         )
         await toolkit.update_context(_make_context())
 
-        await toolkit.on_before_tool_call(
-            MagicMock(
-                tool_name="read",
-                args_json='{"path": "/workspace/agent/unregistered/file.py"}',
-            )
-        )
-        state = await toolkit.update_context(_make_context())
-
-        assert "SHOULD_NOT_APPEAR" not in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_project_agents_refresh_existing_active_file(self) -> None:
-        """Active AGENTS file reflects changed content on next turn refresh."""
-        files = {"/workspace/agent/app/AGENTS.md": b"OLD_RULE"}
-        toolkit = _make_toolkit(
-            projects=[_make_project(path="/workspace/agent/app")],
-            storage_files=files,
-        )
-        await toolkit.update_context(_make_context())
-        await toolkit.on_before_tool_call(
+        first = await toolkit.append_agents_after_read(
             MagicMock(
                 tool_name="read",
                 args_json='{"path": "/workspace/agent/app/file.py"}',
-            )
+            ),
+            ToolCallHookOutcome(output="ONE", error=None),
         )
-        state = await toolkit.update_context(_make_context())
-        assert "OLD_RULE" not in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-        assert "OLD_RULE" in state.prompt
-
-        cast(Any, toolkit)._test_runner_operations.files[
-            "/workspace/agent/app/AGENTS.md"
-        ] = b"NEW_RULE"
-        cast(
-            Any, toolkit
-        )._agents_turns_since_live_read = AGENTS_LIVE_READ_INTERVAL_TURNS
-        state = await toolkit.update_context(_make_context())
-        assert "OLD_RULE" in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-
-        assert "NEW_RULE" in state.prompt
-        assert "OLD_RULE" not in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_project_agents_compaction_clears_project_instruction_state(
-        self,
-    ) -> None:
-        """compaction hook clears all Project AGENTS active/cache state."""
-        files = {"/workspace/agent/app/AGENTS.md": b"OLD_RULE"}
-        toolkit = _make_toolkit(
-            projects=[_make_project(path="/workspace/agent/app")],
-            storage_files=files,
-        )
-        await toolkit.update_context(_make_context())
-        await toolkit.on_before_tool_call(
+        second = await toolkit.append_agents_after_read(
             MagicMock(
                 tool_name="read",
-                args_json='{"path": "/workspace/agent/app/file.py"}',
-            )
+                args_json='{"path": "/workspace/agent/app/other.py"}',
+            ),
+            ToolCallHookOutcome(output="TWO", error=None),
         )
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-        assert "OLD_RULE" in state.prompt
+
+        assert first is not None
+        assert second is None
+        dedupe = await agents_store.load_appendix_dedupe("agent-1", "session-1")
+        assert dedupe.appended_paths == [
+            "/workspace/agent/AGENTS.md",
+            "/workspace/agent/app/AGENTS.md",
+        ]
 
         hook = toolkit.hooks().get("on_session_compact")
         assert hook is not None
@@ -975,83 +825,84 @@ class TestRuntimeToolkitUpdateContext:
                 run_id="run-1",
             )
         )
-        state = await toolkit.update_context(_make_context())
-
-        assert "OLD_RULE" not in state.prompt
-        store = cast(_FakeAgentsInstructionStateStore, cast(Any, toolkit)._agents_store)
-        saved_state = await store.load_project("agent-1", "session-1")
-        assert saved_state.active_project_paths == set()
-        assert saved_state.project_contents == {}
-
-        await toolkit.on_before_tool_call(
+        third = await toolkit.append_agents_after_read(
             MagicMock(
                 tool_name="read",
-                args_json='{"path": "/workspace/agent/app/file.py"}',
-            )
+                args_json='{"path": "/workspace/agent/app/again.py"}',
+            ),
+            ToolCallHookOutcome(output="THREE", error=None),
         )
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
-        assert "OLD_RULE" in state.prompt
+
+        assert third is not None
+        assert "ROOT_RULE" in third.output_text
 
     @pytest.mark.asyncio
-    async def test_directory_tool_activates_nested_agents(self) -> None:
-        """directory tool enables ancestor AGENTS up to target directory."""
+    async def test_reading_agents_file_does_not_append_itself(self) -> None:
+        """Reading AGENTS.md itself does not append the same file as appendix."""
         toolkit = _make_toolkit(
             projects=[_make_project(path="/workspace/agent/app")],
             storage_files={
+                "/workspace/agent/AGENTS.md": b"ROOT_RULE",
                 "/workspace/agent/app/AGENTS.md": b"PROJECT_RULE",
-                "/workspace/agent/app/frontend/AGENTS.md": b"FRONTEND_RULE",
-                "/workspace/agent/app/frontend/src/AGENTS.md": b"SRC_RULE",
             },
         )
         await toolkit.update_context(_make_context())
 
-        await toolkit.on_before_tool_call(
+        decision = await toolkit.append_agents_after_read(
             MagicMock(
-                tool_name="grep",
-                args_json=(
-                    '{"path": "/workspace/agent/app/frontend/src", "pattern": "TODO"}'
-                ),
-            )
+                tool_name="read",
+                args_json='{"path": "/workspace/agent/app/AGENTS.md"}',
+            ),
+            ToolCallHookOutcome(output="PROJECT_RULE", error=None),
         )
-        state = await toolkit.update_context(_make_context())
-        assert "Project Instructions" not in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
 
-        assert "PROJECT_RULE" in state.prompt
-        assert "FRONTEND_RULE" in state.prompt
-        assert "SRC_RULE" in state.prompt
+        assert decision is not None
+        assert "ROOT_RULE" in decision.output_text
+        assert decision.output_text.count("PROJECT_RULE") == 1
 
     @pytest.mark.asyncio
-    async def test_project_agents_prompt_omits_over_budget_files(self) -> None:
-        """Items exceeding Project AGENTS prompt budget are omitted from prompt."""
-        storage_files = {
-            f"/workspace/agent/app/dir-{index}/AGENTS.md": f"RULE_{index}".encode()
-            for index in range(25)
-        }
+    async def test_non_read_tools_do_not_append_agents(self) -> None:
+        """AGENTS.md appendix is limited to successful read results."""
         toolkit = _make_toolkit(
             projects=[_make_project(path="/workspace/agent/app")],
-            storage_files=storage_files,
+            storage_files={
+                "/workspace/agent/AGENTS.md": b"ROOT_RULE",
+                "/workspace/agent/app/AGENTS.md": b"PROJECT_RULE",
+            },
         )
         await toolkit.update_context(_make_context())
 
-        for index in range(25):
-            await toolkit.on_before_tool_call(
-                MagicMock(
-                    tool_name="read",
-                    args_json=json.dumps(
-                        {"path": f"/workspace/agent/app/dir-{index}/file.py"}
-                    ),
-                )
-            )
-        state = await toolkit.update_context(_make_context())
-        assert "Project Instructions" not in state.prompt
-        await _drain_agents_refresh(toolkit)
-        state = await toolkit.update_context(_make_context())
+        decision = await toolkit.append_agents_after_read(
+            MagicMock(
+                tool_name="write",
+                args_json='{"path": "/workspace/agent/app/file.py", "content": "x"}',
+            ),
+            ToolCallHookOutcome(output="WROTE", error=None),
+        )
 
-        assert "RULE_0" in state.prompt
-        assert "additional AGENTS.md instruction file(s) were omitted" in state.prompt
+        assert decision is None
+
+    @pytest.mark.asyncio
+    async def test_missing_or_non_file_agents_candidates_are_ignored(self) -> None:
+        """Missing and non-file AGENTS.md candidates are not appended."""
+        toolkit = _make_toolkit(
+            projects=[_make_project(path="/workspace/agent/app")],
+            storage_files={
+                "/workspace/agent/app/AGENTS.md/nested.txt": b"NOT_A_RULE",
+                "/workspace/agent/app/file.py": b"print('hi')",
+            },
+        )
+        await toolkit.update_context(_make_context())
+
+        decision = await toolkit.append_agents_after_read(
+            MagicMock(
+                tool_name="read",
+                args_json='{"path": "/workspace/agent/app/file.py"}',
+            ),
+            ToolCallHookOutcome(output="FILE", error=None),
+        )
+
+        assert decision is None
 
 
 # ---------------------------------------------------------------------------
@@ -1134,7 +985,7 @@ class TestBuiltinToolkitMemoryPrompt:
 
     @pytest.mark.asyncio
     async def test_root_agents_loaded_from_persistent_state(self) -> None:
-        """persistent root AGENTS.md state is included in prompt."""
+        """persistent root AGENTS.md state is not included in prompt."""
         agents_store = _FakeAgentsInstructionStateStore()
         await agents_store.save_root(
             "agent-root-state-test",
@@ -1151,75 +1002,7 @@ class TestBuiltinToolkitMemoryPrompt:
 
         state = await toolkit.update_context(_make_context())
 
-        assert "SNAPSHOT_ROOT_RULE" in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_root_agents_snapshot_updated_by_write_with_size_cap(self) -> None:
-        """root AGENTS write hook updates snapshot after applying size cap."""
-        agents_store = _FakeAgentsInstructionStateStore()
-        toolkit = _make_builtin_toolkit(
-            config=ShellToolkitConfig(memory_enabled=False),
-            agent_id="agent-snapshot-test",
-            agents_store=agents_store,
-        )
-        big_content = "x" * (70 * 1024)
-
-        runtime_toolkit = _make_toolkit(
-            agent_id="agent-snapshot-test",
-            agents_store=agents_store,
-        )
-        await runtime_toolkit.on_after_tool_call(
-            MagicMock(
-                tool_name="write",
-                args_json=json.dumps(
-                    {"path": "/workspace/agent/AGENTS.md", "content": big_content}
-                ),
-            ),
-            MagicMock(error=None),
-        )
-        state = await toolkit.update_context(_make_context())
-
-        assert "Session Workspace Instructions" in state.prompt
-        assert "... (truncated)" in state.prompt
-
-    @pytest.mark.asyncio
-    async def test_root_agents_snapshot_updated_by_edit(self) -> None:
-        """root AGENTS edit hook does not leave existing snapshot stale."""
-        agent_id = "agent-edit-snapshot-test"
-        agents_store = _FakeAgentsInstructionStateStore()
-        runtime_toolkit = _make_toolkit(agent_id=agent_id, agents_store=agents_store)
-        await runtime_toolkit.on_after_tool_call(
-            MagicMock(
-                tool_name="write",
-                args_json=json.dumps(
-                    {"path": "/workspace/agent/AGENTS.md", "content": "OLD_RULE"}
-                ),
-            ),
-            MagicMock(error=None),
-        )
-        await runtime_toolkit.on_after_tool_call(
-            MagicMock(
-                tool_name="edit",
-                args_json=json.dumps(
-                    {
-                        "path": "/workspace/agent/AGENTS.md",
-                        "old_string": "OLD",
-                        "new_string": "NEW",
-                    }
-                ),
-            ),
-            MagicMock(error=None),
-        )
-        toolkit = _make_builtin_toolkit(
-            config=ShellToolkitConfig(memory_enabled=False),
-            agent_id=agent_id,
-            agents_store=agents_store,
-        )
-
-        state = await toolkit.update_context(_make_context())
-
-        assert "NEW_RULE" in state.prompt
-        assert "OLD_RULE" not in state.prompt
+        assert "SNAPSHOT_ROOT_RULE" not in state.prompt
 
 
 # ---------------------------------------------------------------------------

--- a/python/apps/azents/src/azents/engine/tools/gcp.py
+++ b/python/apps/azents/src/azents/engine/tools/gcp.py
@@ -280,7 +280,7 @@ class GcpToolkit(Toolkit[GcpToolkitConfig]):
     async def __aenter__(self) -> GcpToolkit:
         """Start per-service background parallel MCP connections."""
         self._entered = True
-        for server in self._server_configs:
+        for server in sorted(self._server_configs, key=lambda item: item.service.value):
             task = asyncio.create_task(self._connect_service(server))
             self._bg_tasks[server.service] = task
         return self
@@ -341,7 +341,7 @@ class GcpToolkit(Toolkit[GcpToolkitConfig]):
 
         is_writable = server.service in self._writable_services
         tools: list[FunctionTool] = []
-        for mcp_tool in mcp_tools:
+        for mcp_tool in sorted(mcp_tools, key=lambda tool: tool.name):
             if not is_writable and not _is_read_only_tool(mcp_tool):
                 continue
             tools.append(
@@ -367,15 +367,17 @@ class GcpToolkit(Toolkit[GcpToolkitConfig]):
         """
         self._refresh_artifact_sink(context)
         if not self._entered:
-            return await self._sync_update_context()
+            return ToolkitState(
+                status=ToolkitStatus.ENABLED,
+                tools=[],
+                prompt=self._render_config_prompt(),
+            )
 
         # Collect from background status
         tools: list[FunctionTool] = []
-        loading_services: list[str] = []
 
-        for server in self._server_configs:
+        for server in sorted(self._server_configs, key=lambda item: item.service.value):
             svc = server.service
-            task = self._bg_tasks.get(svc)
 
             if svc in self._bg_results:
                 # Connection complete: collect tools
@@ -383,18 +385,13 @@ class GcpToolkit(Toolkit[GcpToolkitConfig]):
             elif svc in self._bg_errors:
                 # Connection failure: skip (error already logged)
                 pass
-            elif task is not None and not task.done():
-                # Connection in progress
-                meta = GCP_SERVICE_CONFIG.get(svc)
-                desc = meta.description if meta else svc.value
-                loading_services.append(desc)
 
         prompt = self._render_config_prompt()
-        if loading_services:
-            loading_text = ", ".join(loading_services)
-            prompt = f"{prompt}\nLoading: {loading_text}"
-
-        return ToolkitState(status=ToolkitStatus.ENABLED, tools=tools, prompt=prompt)
+        return ToolkitState(
+            status=ToolkitStatus.ENABLED,
+            tools=sorted(tools, key=lambda tool: tool.spec.name),
+            prompt=prompt,
+        )
 
     async def _sync_update_context(self) -> ToolkitState:
         """Collect tools synchronously in parallel from per-service MCP servers."""
@@ -429,7 +426,7 @@ class GcpToolkit(Toolkit[GcpToolkitConfig]):
 
             server, mcp_tools, use_streamable_http = result
             is_writable = server.service in self._writable_services
-            for mcp_tool in mcp_tools:
+            for mcp_tool in sorted(mcp_tools, key=lambda tool: tool.name):
                 if not is_writable and not _is_read_only_tool(mcp_tool):
                     continue
 

--- a/python/apps/azents/src/azents/engine/tools/gcp_test.py
+++ b/python/apps/azents/src/azents/engine/tools/gcp_test.py
@@ -168,7 +168,9 @@ class TestGcpToolkitUpdateContext:
             "azents.engine.tools.gcp.mcp_list_tools",
             side_effect=mock_list_tools,
         ):
-            state = await toolkit.update_context(ctx)
+            async with toolkit:
+                await _wait_gcp_tasks(toolkit)
+                state = await toolkit.update_context(ctx)
 
         names = {t.spec.name for t in state.tools}
         assert "log_query" in names
@@ -230,7 +232,9 @@ class TestGcpToolkitReadOnlyFiltering:
             new_callable=AsyncMock,
             return_value=([read_tool, write_tool], False),
         ):
-            state = await toolkit.update_context(ctx)
+            async with toolkit:
+                await _wait_gcp_tasks(toolkit)
+                state = await toolkit.update_context(ctx)
 
         names = {t.spec.name for t in state.tools}
         assert "log_query" in names
@@ -253,7 +257,9 @@ class TestGcpToolkitReadOnlyFiltering:
             new_callable=AsyncMock,
             return_value=([read_tool, write_tool], False),
         ):
-            state = await toolkit.update_context(ctx)
+            async with toolkit:
+                await _wait_gcp_tasks(toolkit)
+                state = await toolkit.update_context(ctx)
 
         names = {t.spec.name for t in state.tools}
         assert "log_query" in names
@@ -316,7 +322,9 @@ class TestGcpToolkitConnectionFailure:
             "azents.engine.tools.gcp.mcp_list_tools",
             side_effect=mock_list_tools,
         ):
-            state = await toolkit.update_context(ctx)
+            async with toolkit:
+                await _wait_gcp_tasks(toolkit)
+                state = await toolkit.update_context(ctx)
 
         # Only logging service tools are returned
         assert len(state.tools) == 1
@@ -344,6 +352,12 @@ def _make_call_tool_result(text: str) -> MagicMock:
     result.content = [TextContent(type="text", text=text)]
     result.isError = False
     return result
+
+
+async def _wait_gcp_tasks(toolkit: GcpToolkit) -> None:
+    """Wait for background GCP MCP discovery tasks."""
+    for task in toolkit._bg_tasks.values():  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        await task
 
 
 # ---------------------------------------------------------------------------
@@ -374,11 +388,13 @@ class TestGcpToolHandlers:
                 return_value=mock_success,
             ) as mock_call,
         ):
-            state = await toolkit.update_context(ctx)
-            assert len(state.tools) == 1
-            tool = _find_tool(state.tools, "log_query")
+            async with toolkit:
+                await _wait_gcp_tasks(toolkit)
+                state = await toolkit.update_context(ctx)
+                assert len(state.tools) == 1
+                tool = _find_tool(state.tools, "log_query")
 
-            result = await tool.handler('{"filter": "severity=ERROR"}')
+                result = await tool.handler('{"filter": "severity=ERROR"}')
 
         assert result == "log query result"
         mock_call.assert_awaited_once()
@@ -408,9 +424,11 @@ class TestGcpToolHandlers:
                 side_effect=[http_401, mock_success],
             ) as mock_call,
         ):
-            state = await toolkit.update_context(ctx)
-            tool = _find_tool(state.tools, "log_query")
-            result = await tool.handler("{}")
+            async with toolkit:
+                await _wait_gcp_tasks(toolkit)
+                state = await toolkit.update_context(ctx)
+                tool = _find_tool(state.tools, "log_query")
+                result = await tool.handler("{}")
 
         assert result == "retried result"
         # Two calls: first (401) + retry (success)
@@ -460,7 +478,7 @@ class TestGcpToolkitBackgroundConnect:
                 # Both services connecting -> loading
                 state = await toolkit.update_context(ctx)
                 assert state.tools == []
-                assert "Loading" in state.prompt
+                assert "Loading" not in state.prompt
 
                 # Only logging complete
                 connect_events["logging"].set()
@@ -474,7 +492,7 @@ class TestGcpToolkitBackgroundConnect:
                 # Return only logging tools; monitoring still loading
                 assert len(state.tools) == 1
                 assert state.tools[0].spec.name == "log_query"
-                assert "Loading" in state.prompt
+                assert "Loading" not in state.prompt
 
                 # monitoring also complete
                 connect_events["monitoring"].set()
@@ -548,8 +566,8 @@ class TestGcpToolkitBackgroundConnect:
         assert len(toolkit._bg_tasks) == 0  # noqa: SLF001  # pyright: ignore[reportPrivateUsage] -- directly validate task cleanup in tests
 
     @pytest.mark.asyncio
-    async def test_fallback_sync_without_aenter(self) -> None:
-        """Synchronous parallel collection fallback when called without __aenter__."""
+    async def test_without_aenter_does_not_sync_discover_tools(self) -> None:
+        """update_context without __aenter__ does not synchronously list tools."""
         toolkit = _make_toolkit(services=[GcpService.LOGGING])
         ctx = _make_context()
 
@@ -560,5 +578,4 @@ class TestGcpToolkitBackgroundConnect:
         ):
             state = await toolkit.update_context(ctx)
 
-        assert len(state.tools) == 1
-        assert state.tools[0].spec.name == "log_query"
+        assert state.tools == []

--- a/python/apps/azents/src/azents/engine/tools/github.py
+++ b/python/apps/azents/src/azents/engine/tools/github.py
@@ -640,24 +640,18 @@ class GitHubToolkit(Toolkit[GitHubToolkitConfig]):
                 return ToolkitState(
                     status=ToolkitStatus.ENABLED,
                     tools=[],
-                    prompt=(
-                        f"GitHub tools for {binding.target.account_login} are still "
-                        "loading. Try again shortly."
-                    ),
+                    prompt="",
                 )
             if binding.lazy_mcp_error is not None:
                 return ToolkitState(
                     status=ToolkitStatus.ENABLED,
                     tools=[],
-                    prompt=(
-                        f"GitHub toolkit for {binding.target.account_login} "
-                        f"unavailable: {binding.lazy_mcp_error}"
-                    ),
+                    prompt="",
                 )
             return ToolkitState(
                 status=ToolkitStatus.ENABLED,
                 tools=[],
-                prompt=f"GitHub setup required for {binding.target.account_login}.",
+                prompt="",
             )
         return await binding.mcp_toolkit.update_context(context)
 
@@ -713,7 +707,13 @@ class GitHubToolkit(Toolkit[GitHubToolkitConfig]):
         """Merge and return MCP state for all installations."""
         tools: list[FunctionTool] = []
         prompts: list[str] = []
-        for binding in self._installation_bindings:
+        for binding in sorted(
+            self._installation_bindings,
+            key=lambda item: (
+                item.target.account_login,
+                item.target.installation_id,
+            ),
+        ):
             state = await self._installation_update_context(binding, context)
             if state.status != ToolkitStatus.ENABLED:
                 continue
@@ -738,7 +738,7 @@ class GitHubToolkit(Toolkit[GitHubToolkitConfig]):
         )
         return ToolkitState(
             status=ToolkitStatus.ENABLED,
-            tools=tools,
+            tools=sorted(tools, key=lambda tool: tool.spec.name),
             prompt="\n\n".join(
                 prompt for prompt in [mapping_prompt, *prompts] if prompt
             ),
@@ -784,18 +784,18 @@ class GitHubToolkit(Toolkit[GitHubToolkitConfig]):
                 return ToolkitState(
                     status=ToolkitStatus.ENABLED,
                     tools=[],
-                    prompt="GitHub tools are still loading. Try again shortly.",
+                    prompt="",
                 )
             if self._lazy_mcp_error is not None:
                 return ToolkitState(
                     status=ToolkitStatus.ENABLED,
                     tools=[],
-                    prompt=f"GitHub toolkit unavailable: {self._lazy_mcp_error}",
+                    prompt="",
                 )
             return ToolkitState(
                 status=ToolkitStatus.ENABLED,
                 tools=[],
-                prompt="GitHub setup required.",
+                prompt="",
             )
         return await self._mcp.update_context(context)
 

--- a/python/apps/azents/src/azents/engine/tools/goal.py
+++ b/python/apps/azents/src/azents/engine/tools/goal.py
@@ -208,7 +208,6 @@ class GoalToolkit(Toolkit[GoalToolkitConfig]):
         del context
         if not self._session_id:
             return ToolkitState(status=ToolkitStatus.ENABLED, tools=[], prompt="")
-        goal_state = await self._store.load(self._agent_id, self._session_id)
         return ToolkitState(
             status=ToolkitStatus.ENABLED,
             tools=[
@@ -228,7 +227,7 @@ class GoalToolkit(Toolkit[GoalToolkitConfig]):
                     session_id=self._session_id,
                 ),
             ],
-            prompt=render_goal_prompt(goal_state),
+            prompt=render_goal_prompt(),
         )
 
     def hooks(self) -> RuntimeHooks:
@@ -285,19 +284,10 @@ class GoalToolkitProvider(ToolkitProvider[GoalToolkitConfig]):
         return GoalToolkit(store=self._store)
 
 
-def render_goal_prompt(state: GoalState) -> str:
-    """Render prompt fragment containing current goal state."""
-    if not state.objective or state.status is None:
-        return _GOAL_PROMPT
-    return "\n".join(
-        [
-            _GOAL_PROMPT.rstrip(),
-            "",
-            "Current goal:",
-            f"- status: {state.status}",
-            f"- objective: {state.objective}",
-        ]
-    )
+def render_goal_prompt(state: GoalState | None = None) -> str:
+    """Render stable prompt fragment for goal tools."""
+    del state
+    return _GOAL_PROMPT
 
 
 def _now_iso() -> str:

--- a/python/apps/azents/src/azents/engine/tools/goal_test.py
+++ b/python/apps/azents/src/azents/engine/tools/goal_test.py
@@ -8,7 +8,12 @@ import pytest
 from azents.core.tools import TurnContext
 from azents.engine.hooks.types import SessionIdleHookContext
 from azents.engine.run.types import FunctionToolError
-from azents.engine.tools.goal import GoalState, GoalStatus, GoalToolkit
+from azents.engine.tools.goal import (
+    GoalState,
+    GoalStatus,
+    GoalToolkit,
+    render_goal_prompt,
+)
 
 
 async def test_goal_toolkit_exposes_goal_tools() -> None:
@@ -33,8 +38,18 @@ async def test_goal_toolkit_exposes_goal_tools() -> None:
         "create_goal",
         "update_goal",
     ]
-    assert "Ship goal" in state.prompt
-    store.load.assert_awaited_once_with("agent-1", "session-1")
+    assert "Ship goal" not in state.prompt
+    store.load.assert_not_awaited()
+
+
+def test_goal_prompt_is_stable_across_state() -> None:
+    """Current Goal state does not change the toolkit prompt."""
+    assert render_goal_prompt(GoalState()) == render_goal_prompt(
+        GoalState(objective="Ship goal", status="active")
+    )
+    assert render_goal_prompt(GoalState()) == render_goal_prompt(
+        GoalState(objective="Done goal", status="complete")
+    )
 
 
 async def test_goal_idle_hook_returns_continuation_for_active_goal() -> None:

--- a/python/apps/azents/src/azents/engine/tools/mcp.py
+++ b/python/apps/azents/src/azents/engine/tools/mcp.py
@@ -5,6 +5,7 @@ Connect to MCP server, fetch tool list, and wrap each as azents Tool.
 """
 
 import datetime
+import hashlib
 import json
 import logging
 from collections.abc import Awaitable, Callable
@@ -68,6 +69,10 @@ class McpToolkit(McpBasedToolkit[McpToolkitConfig]):
         proxy_url: str | None = None,
         session_type: SessionType = SessionType.USER,
         artifact_service: ArtifactService | None = None,
+        session_manager: SessionManager[AsyncSession] | None = None,
+        agent_id: str = "",
+        session_id: str = "",
+        state_name: str = "tool_snapshot",
     ) -> None:
         """Initialize McpToolkit.
 
@@ -84,6 +89,11 @@ class McpToolkit(McpBasedToolkit[McpToolkitConfig]):
         self._proxy_url = proxy_url
         self._session_type = session_type
         self._artifact_service = artifact_service
+        self._session_manager = session_manager
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self._state_namespace = "mcp"
+        self._state_name = state_name
         self._init_bg_state()
 
 
@@ -193,6 +203,13 @@ class McpToolkitProvider(ToolkitProvider[McpToolkitConfig]):
             if context.user_id is None
             else SessionType.USER,
             artifact_service=self._artifact_service,
+            session_manager=self._session_manager,
+            agent_id=context.agent_id,
+            session_id=context.session_id,
+            state_name=_mcp_snapshot_state_name(
+                toolkit_id=context.toolkit_id,
+                server_url=config.server_url,
+            ),
         )
 
 
@@ -234,6 +251,13 @@ def _make_oauth_refresh_callback(
             return connection.access_token
 
     return _refresh
+
+
+def _mcp_snapshot_state_name(*, toolkit_id: str, server_url: str) -> str:
+    """Return stable Toolkit State name for an MCP tool snapshot."""
+    raw = toolkit_id or server_url
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"tool_snapshot:{digest}"
 
 
 def _extract_static_secret(

--- a/python/apps/azents/src/azents/engine/tools/mcp_base.py
+++ b/python/apps/azents/src/azents/engine/tools/mcp_base.py
@@ -9,9 +9,12 @@ import asyncio
 import base64
 import binascii
 import dataclasses
+import datetime
+import hashlib
 import json
 import logging
 import mimetypes
+import time
 from abc import ABC
 from collections.abc import Awaitable, Callable
 from typing import Generic, TypeVar
@@ -32,6 +35,7 @@ from mcp.types import (
 )
 from mcp.types import Tool as McpBaseTool
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from azents.core.mcp_transport import call_tool as mcp_call_tool
 from azents.core.mcp_transport import list_tools as mcp_list_tools
@@ -50,11 +54,20 @@ from azents.engine.run.types import (
     FunctionToolSpec,
 )
 from azents.engine.tooling.make_tool import make_tool
+from azents.engine.tooling.toolkit_state import (
+    ToolkitStateHandle,
+    ToolkitStateIdentity,
+    ToolkitStateModel,
+    ToolkitStateStore,
+)
+from azents.rdb.session import SessionManager
 from azents.services.artifact import ArtifactService
 
 logger = logging.getLogger(__name__)
 
 McpConfigT = TypeVar("McpConfigT", bound=McpToolkitConfig)
+MCP_TOOL_SNAPSHOT_SCHEMA_VERSION = 1
+MCP_TOOL_SNAPSHOT_STATE_NAME = "tool_snapshot"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -71,6 +84,27 @@ class McpArtifactSink:
 ArtifactSinkGetter = Callable[[], McpArtifactSink | None]
 
 
+class McpToolSnapshotItem(BaseModel):
+    """Serializable MCP tool snapshot item."""
+
+    raw_name: str
+    model_name: str
+    description: str
+    input_schema: dict[str, object]
+    server_url: str
+    use_streamable_http: bool = False
+
+
+class McpToolSnapshotState(ToolkitStateModel):
+    """Latest successful MCP tool snapshot."""
+
+    schema_version: int = MCP_TOOL_SNAPSHOT_SCHEMA_VERSION
+    loaded_at: str | None = None
+    server_url: str = ""
+    tool_hash: str = ""
+    tools: list[McpToolSnapshotItem] = Field(default_factory=list)
+
+
 def build_mcp_artifact_sink(
     context: TurnContext,
     artifact_service: ArtifactService | None,
@@ -84,6 +118,36 @@ def build_mcp_artifact_sink(
         user_id=context.user_id,
         run_id=context.run_id,
         run_index=context.run_index,
+    )
+
+
+def _build_mcp_tool_snapshot(
+    *,
+    server_url: str,
+    mcp_tools: list[McpBaseTool],
+    use_streamable_http: bool,
+) -> McpToolSnapshotState:
+    """Build a deterministic serializable MCP tool snapshot."""
+    items = [
+        McpToolSnapshotItem(
+            raw_name=tool.name,
+            model_name=tool.name,
+            description=tool.description or "",
+            input_schema=tool.inputSchema,
+            server_url=server_url,
+            use_streamable_http=use_streamable_http,
+        )
+        for tool in sorted(mcp_tools, key=lambda item: item.name)
+    ]
+    payload = [item.model_dump(mode="json") for item in items]
+    tool_hash = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return McpToolSnapshotState(
+        loaded_at=datetime.datetime.now(datetime.UTC).isoformat(),
+        server_url=server_url,
+        tool_hash=tool_hash,
+        tools=items,
     )
 
 
@@ -498,6 +562,11 @@ class McpBasedToolkit(Toolkit[McpConfigT], ABC, Generic[McpConfigT]):
     _proxy_url: str | None
     _session_type: SessionType
     _artifact_service: ArtifactService | None
+    _session_manager: SessionManager[AsyncSession] | None
+    _agent_id: str
+    _session_id: str
+    _state_namespace: str
+    _state_name: str
 
     # Background connection status
     _bg_task: asyncio.Task[None] | None
@@ -516,6 +585,19 @@ class McpBasedToolkit(Toolkit[McpConfigT], ABC, Generic[McpConfigT]):
         self._bg_error = None
         self._artifact_sink = None
         self._entered = False
+        self._agent_id = getattr(self, "_agent_id", "")
+        self._session_id = getattr(self, "_session_id", "")
+        self._session_manager = getattr(self, "_session_manager", None)
+        self._state_namespace = getattr(self, "_state_namespace", "mcp")
+        self._state_name = getattr(self, "_state_name", MCP_TOOL_SNAPSHOT_STATE_NAME)
+
+    def set_agent_id(self, agent_id: str) -> None:
+        """Inject agent ID for Toolkit State identity."""
+        self._agent_id = agent_id
+
+    def set_session_id(self, session_id: str) -> None:
+        """Inject session ID for Toolkit State identity."""
+        self._session_id = session_id
 
     def _current_artifact_sink(self) -> McpArtifactSink | None:
         """Return Artifact sink for current run."""
@@ -544,7 +626,7 @@ class McpBasedToolkit(Toolkit[McpConfigT], ABC, Generic[McpConfigT]):
         """Start MCP server connection in background."""
         self._entered = True
 
-        self._bg_task = asyncio.create_task(self._connect_and_list_tools())
+        self._ensure_refresh_task()
         return self
 
     async def __aexit__(self, *exc: object) -> None:
@@ -557,13 +639,20 @@ class McpBasedToolkit(Toolkit[McpConfigT], ABC, Generic[McpConfigT]):
                 pass
         self._bg_task = None
 
+    def _ensure_refresh_task(self) -> None:
+        """Start background refresh unless one is already running."""
+        if self._bg_task is not None and not self._bg_task.done():
+            return
+        self._bg_task = asyncio.create_task(self._connect_and_list_tools())
+
     async def _connect_and_list_tools(self) -> None:
         """Connect to MCP server in background and collect tool list.
 
-        Store success/failure in internal state (_bg_tools / _bg_error).
+        Store a successful deterministic snapshot atomically in Toolkit State.
         """
         config = self._config
         headers = _build_auth_headers(config, self._secret)
+        started = time.monotonic()
 
         try:
             mcp_tools, use_streamable_http = await mcp_list_tools(
@@ -584,146 +673,133 @@ class McpBasedToolkit(Toolkit[McpConfigT], ABC, Generic[McpConfigT]):
                 self._bg_error = f"MCP server connection failed: {exc}"
             return
 
+        mcp_tools = sorted(mcp_tools, key=lambda item: item.name)
+        snapshot = _build_mcp_tool_snapshot(
+            server_url=config.server_url,
+            mcp_tools=mcp_tools,
+            use_streamable_http=use_streamable_http,
+        )
+        await self._save_tool_snapshot(snapshot)
+
         logger.info(
-            "MCP tools loaded",
+            "MCP tool snapshot refreshed",
             extra={
                 "server_url": config.server_url,
                 "tool_count": len(mcp_tools),
                 "tool_names": [t.name for t in mcp_tools],
+                "tool_hash": snapshot.tool_hash,
                 "transport": "streamable_http" if use_streamable_http else "sse",
+                "duration_seconds": round(time.monotonic() - started, 3),
             },
         )
 
         self._bg_error = (
             None  # Clear previous error when reconnection succeeds after retry
         )
-        self._bg_tools = [
-            wrap_mcp_tool(
-                mcp_tool,
-                config.server_url,
-                headers,
-                config.timeout,
-                use_streamable_http=use_streamable_http,
-                on_auth_failure=self._on_auth_failure,
-                proxy_url=self._proxy_url,
-                artifact_sink_getter=self._current_artifact_sink,
-            )
-            for mcp_tool in mcp_tools
-        ]
+        self._bg_tools = self._tools_from_snapshot(snapshot)
 
     async def update_context(self, context: TurnContext) -> ToolkitState:
         """Return current toolkit state immediately based on internal state.
 
 
-        Without __aenter__, fall back to synchronous connection.
-
         :param context: Context passed each turn
         :return: Current state (tools + prompt)
         """
         self._refresh_artifact_sink(context)
-
-        # Fallback without __aenter__: synchronous connection
-        if not self._entered:
-            return await self._sync_connect()
-
-        # Return immediately based on background task status
-        # Keep previous tools when present during reload
-        cached = self._bg_tools or []
-
-        if self._bg_task is not None and not self._bg_task.done():
-            if cached:
-                return ToolkitState(
-                    status=ToolkitStatus.ENABLED,
-                    tools=cached,
-                    prompt="",
-                )
-
-            # If connection is in progress and no usable tool exists, report status.
-            return ToolkitState(
-                status=ToolkitStatus.ENABLED,
-                tools=[],
-                prompt="Tools are still loading. Try again shortly.",
-            )
-
-        if self._bg_error is not None:
-            # Connection failure: include retry tool
-            return ToolkitState(
-                status=ToolkitStatus.ENABLED,
-                tools=[*cached, self._make_retry_tool()],
-                prompt=f"Connection failed: {self._bg_error}. "
-                "Call retry to attempt reconnection."
-                if not cached
-                else "",
-            )
-
-        if self._bg_tools is not None:
-            # Connection complete
-            return ToolkitState(
-                status=ToolkitStatus.ENABLED, tools=self._bg_tools, prompt=""
-            )
-
-        # When task was not started in __aenter__, e.g. per-user OAuth skip
-        return ToolkitState(
-            status=ToolkitStatus.ENABLED,
-            tools=[],
-            prompt="Waiting for connection...",
-        )
+        snapshot = await self._load_tool_snapshot()
+        tools = self._tools_from_snapshot(snapshot) if snapshot is not None else []
+        if snapshot is None and self._session_manager is None:
+            tools = self._bg_tools or []
+        self._bg_tools = tools or self._bg_tools
+        if self._entered:
+            self._ensure_refresh_task()
+        return ToolkitState(status=ToolkitStatus.ENABLED, tools=tools, prompt="")
 
     async def _sync_connect(self) -> ToolkitState:
-        """Connect to MCP server synchronously (backward compatibility fallback).
+        """Return the latest successful snapshot without synchronous discovery.
 
         Used when update_context() is called without __aenter__.
 
         :return: Current state (tools + prompt)
         """
-        config = self._config
-        headers = _build_auth_headers(config, self._secret)
+        snapshot = await self._load_tool_snapshot()
+        tools = self._tools_from_snapshot(snapshot) if snapshot is not None else []
+        return ToolkitState(status=ToolkitStatus.ENABLED, tools=tools, prompt="")
 
-        try:
-            mcp_tools, use_streamable_http = await mcp_list_tools(
-                config.server_url, headers, config.timeout, proxy_url=self._proxy_url
-            )
-        except Exception as exc:
-            if _is_http_auth_error(exc):
-                logger.warning(
-                    "MCP server auth failed",
-                    extra={"server_url": config.server_url},
-                )
-            else:
-                logger.exception(
-                    "Failed to connect to MCP server",
-                    extra={"server_url": config.server_url},
-                )
-            return ToolkitState(
-                status=ToolkitStatus.ENABLED,
-                tools=[],
-                prompt=f"MCP server connection failed: {config.server_url}",
-            )
+    async def _load_tool_snapshot(self) -> McpToolSnapshotState | None:
+        """Load the latest successful MCP tool snapshot from Toolkit State."""
+        if self._session_manager is None:
+            return None
+        async with self._session_manager() as session:
+            handle = self._tool_snapshot_handle(session)
+            if handle is None:
+                return None
+            snapshot = await handle.load(default_factory=McpToolSnapshotState)
+        if not snapshot.tools:
+            return None
+        if snapshot.server_url != self._config.server_url:
+            return None
+        return snapshot
 
-        logger.info(
-            "MCP tools loaded",
-            extra={
-                "server_url": config.server_url,
-                "tool_count": len(mcp_tools),
-                "tool_names": [t.name for t in mcp_tools],
-                "transport": "streamable_http" if use_streamable_http else "sse",
-            },
+    async def _save_tool_snapshot(self, snapshot: McpToolSnapshotState) -> None:
+        """Atomically save a successful MCP tool snapshot."""
+        if self._session_manager is None:
+            return
+        async with self._session_manager() as session:
+            handle = self._tool_snapshot_handle(session)
+            if handle is None:
+                return
+            await handle.load(default_factory=McpToolSnapshotState)
+            await handle.save(snapshot)
+
+    def _tool_snapshot_handle(
+        self,
+        session: AsyncSession,
+    ) -> ToolkitStateHandle[McpToolSnapshotState] | None:
+        """Create Toolkit State handle for MCP tool snapshot."""
+        if not self._agent_id or not self._session_id:
+            return None
+        identity = ToolkitStateIdentity(
+            agent_id=self._agent_id,
+            session_id=self._session_id,
+            toolkit_namespace=self._state_namespace,
+            state_name=self._state_name,
+        )
+        return ToolkitStateStore(session=session).handle(
+            identity,
+            McpToolSnapshotState,
         )
 
-        tools = [
-            wrap_mcp_tool(
+    def _tools_from_snapshot(
+        self, snapshot: McpToolSnapshotState
+    ) -> list[FunctionTool]:
+        """Rebuild FunctionTool wrappers from a stored snapshot."""
+        config = self._config
+        headers = _build_auth_headers(config, self._secret)
+        tools: list[FunctionTool] = []
+        for item in sorted(snapshot.tools, key=lambda tool: tool.model_name):
+            mcp_tool = McpBaseTool(
+                name=item.raw_name,
+                description=item.description,
+                inputSchema=item.input_schema,
+            )
+            tool = wrap_mcp_tool(
                 mcp_tool,
-                config.server_url,
+                item.server_url,
                 headers,
                 config.timeout,
-                use_streamable_http=use_streamable_http,
+                use_streamable_http=item.use_streamable_http,
                 on_auth_failure=self._on_auth_failure,
                 proxy_url=self._proxy_url,
                 artifact_sink_getter=self._current_artifact_sink,
             )
-            for mcp_tool in mcp_tools
-        ]
-        return ToolkitState(status=ToolkitStatus.ENABLED, tools=tools, prompt="")
+            if item.model_name != item.raw_name:
+                tool = dataclasses.replace(
+                    tool,
+                    spec=dataclasses.replace(tool.spec, name=item.model_name),
+                )
+            tools.append(tool)
+        return tools
 
     def _make_retry_tool(self) -> FunctionTool:
         """Tool provided on connection failure. Attempts reconnect on call.

--- a/python/apps/azents/src/azents/engine/tools/mcp_base_test.py
+++ b/python/apps/azents/src/azents/engine/tools/mcp_base_test.py
@@ -1,0 +1,133 @@
+"""MCP snapshot lifecycle tests."""
+
+import asyncio
+from unittest.mock import patch
+
+from mcp.types import Tool as McpBaseTool
+
+from azents.core.tools import McpToolkitConfig, TurnContext
+from azents.engine.tools.mcp import McpToolkit
+
+
+def _tool(name: str) -> McpBaseTool:
+    """Create MCP tool fixture."""
+    return McpBaseTool(
+        name=name,
+        description=f"{name} tool",
+        inputSchema={"type": "object", "properties": {}},
+    )
+
+
+def _context() -> TurnContext:
+    """Create turn context fixture."""
+    return TurnContext(
+        user_id="user-1",
+        workspace_id="workspace-1",
+        model="model",
+        run_id="run-1",
+        session_id="session-1",
+        publish_event=_publish,
+    )
+
+
+async def _publish(_event: object) -> None:
+    """No-op event publish."""
+
+
+async def _wait_refresh(toolkit: McpToolkit) -> None:
+    """Wait for MCP background refresh task."""
+    task = toolkit._bg_task  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+    if task is not None:
+        await task
+
+
+async def test_update_context_returns_immediately_without_snapshot() -> None:
+    """Slow MCP list_tools does not block request preparation."""
+    started = asyncio.Event()
+    continue_list = asyncio.Event()
+
+    async def slow_list_tools(
+        *_args: object, **_kwargs: object
+    ) -> tuple[list[object], bool]:
+        started.set()
+        await continue_list.wait()
+        return ([_tool("alpha")], False)
+
+    toolkit = McpToolkit(
+        config=McpToolkitConfig(server_url="https://example.com/mcp", auth_type="none")
+    )
+    with patch(
+        "azents.engine.tools.mcp_base.mcp_list_tools",
+        side_effect=slow_list_tools,
+    ):
+        async with toolkit:
+            await asyncio.wait_for(started.wait(), timeout=1)
+            state = await asyncio.wait_for(
+                toolkit.update_context(_context()), timeout=1
+            )
+            assert state.tools == []
+            assert state.prompt == ""
+
+            continue_list.set()
+
+
+async def test_background_refresh_success_exposes_sorted_tools_next_turn() -> None:
+    """Successful background refresh exposes deterministic tool order."""
+    toolkit = McpToolkit(
+        config=McpToolkitConfig(server_url="https://example.com/mcp", auth_type="none")
+    )
+    with patch(
+        "azents.engine.tools.mcp_base.mcp_list_tools",
+        return_value=([_tool("zeta"), _tool("alpha")], False),
+    ):
+        async with toolkit:
+            await _wait_refresh(toolkit)
+
+    state = await toolkit.update_context(_context())
+
+    assert [tool.spec.name for tool in state.tools] == ["alpha", "zeta"]
+    assert state.prompt == ""
+
+
+async def test_refresh_failure_preserves_previous_successful_snapshot() -> None:
+    """Failed refresh keeps the previous successful tool snapshot."""
+    toolkit = McpToolkit(
+        config=McpToolkitConfig(server_url="https://example.com/mcp", auth_type="none")
+    )
+    with patch(
+        "azents.engine.tools.mcp_base.mcp_list_tools",
+        return_value=([_tool("alpha")], False),
+    ):
+        async with toolkit:
+            await _wait_refresh(toolkit)
+    with patch(
+        "azents.engine.tools.mcp_base.mcp_list_tools",
+        side_effect=RuntimeError("boom"),
+    ):
+        async with toolkit:
+            await _wait_refresh(toolkit)
+
+    state = await toolkit.update_context(_context())
+
+    assert [tool.spec.name for tool in state.tools] == ["alpha"]
+    assert state.prompt == ""
+
+
+async def test_failed_refresh_without_snapshot_exposes_no_retry_tool_or_prompt() -> (
+    None
+):
+    """Initial MCP failure exposes no loading/retry/status pseudo-tool."""
+    toolkit = McpToolkit(
+        config=McpToolkitConfig(server_url="https://example.com/mcp", auth_type="none")
+    )
+    with patch(
+        "azents.engine.tools.mcp_base.mcp_list_tools",
+        side_effect=RuntimeError("boom"),
+    ):
+        async with toolkit:
+            await _wait_refresh(toolkit)
+
+    state = await toolkit.update_context(_context())
+
+    assert state.tools == []
+    assert state.prompt == ""

--- a/python/apps/azents/src/azents/engine/tools/todo.py
+++ b/python/apps/azents/src/azents/engine/tools/todo.py
@@ -1,6 +1,5 @@
 """Session-scoped todo Toolkit State tools."""
 
-import json
 from collections.abc import Awaitable, Callable
 from typing import Literal, Self
 
@@ -180,7 +179,6 @@ class TodoToolkit(Toolkit[TodoToolkitConfig]):
                 tools=[],
                 prompt="",
             )
-        todo_state = await self._store.load(self._agent_id, self._session_id)
 
         async def publish_todo_changed(snapshot: TodoStateSnapshot) -> None:
             await context.publish_event(
@@ -197,7 +195,7 @@ class TodoToolkit(Toolkit[TodoToolkitConfig]):
                     publish_changed=publish_todo_changed,
                 )
             ],
-            prompt=render_todo_prompt(todo_state),
+            prompt=render_todo_prompt(),
         )
 
 
@@ -223,14 +221,10 @@ class TodoToolkitProvider(ToolkitProvider[TodoToolkitConfig]):
         return TodoToolkit(store=self._store)
 
 
-def render_todo_prompt(state: TodoState) -> str:
-    """Render prompt fragment containing current todo state."""
-    if not state.items:
-        return _TODO_PROMPT
-    lines = [_TODO_PROMPT.rstrip(), "", "Current todo list:"]
-    for item in state.items:
-        lines.append(f"- [{item.status}] {item.content}")
-    return "\n".join(lines)
+def render_todo_prompt(state: TodoState | None = None) -> str:
+    """Render stable prompt fragment for todo tools."""
+    del state
+    return _TODO_PROMPT
 
 
 def make_update_todo_tool(
@@ -254,7 +248,7 @@ def make_update_todo_tool(
         snapshot = TodoStateSnapshot.from_state(updated)
         if publish_changed is not None:
             await publish_changed(snapshot)
-        return json.dumps(updated.model_dump(mode="json"), ensure_ascii=False)
+        return "Done"
 
     return make_tool(update_todo, input_model=UpdateTodoInput)
 

--- a/python/apps/azents/src/azents/engine/tools/todo_test.py
+++ b/python/apps/azents/src/azents/engine/tools/todo_test.py
@@ -1,5 +1,6 @@
 """Session todo Toolkit State tool tests."""
 
+import json
 from unittest.mock import AsyncMock
 
 from azents.core.tools import TurnContext
@@ -10,6 +11,7 @@ from azents.engine.tools.todo import (
     TodoUpdateItem,
     UpdateTodoInput,
     apply_todo_update,
+    render_todo_prompt,
 )
 
 
@@ -83,5 +85,51 @@ async def test_todo_toolkit_exposes_unprefixed_update_tool() -> None:
     )
 
     assert [tool.spec.name for tool in state.tools] == ["update_todo"]
-    assert "[in_progress] Current work" in state.prompt
-    store.load.assert_awaited_once_with("agent-1", "session-1")
+    assert "[in_progress] Current work" not in state.prompt
+    store.load.assert_not_awaited()
+
+
+def test_todo_prompt_is_stable_across_state() -> None:
+    """Current Todo state does not change the toolkit prompt."""
+    assert render_todo_prompt(TodoState()) == render_todo_prompt(
+        TodoState(
+            items=[
+                TodoItem(
+                    content="Current work",
+                    status="in_progress",
+                )
+            ]
+        )
+    )
+
+
+async def test_update_todo_returns_compact_acknowledgement() -> None:
+    """update_todo stores and publishes state without echoing JSON."""
+    store = AsyncMock()
+    store.update.return_value = TodoState(
+        items=[TodoItem(content="Current work", status="in_progress")]
+    )
+    publish_changed = AsyncMock()
+    toolkit = TodoToolkit(store=store, agent_id="agent-1", session_id="session-1")
+    state = await toolkit.update_context(
+        TurnContext(
+            user_id="user-1",
+            workspace_id="workspace-1",
+            model="model",
+            run_id="run-1",
+            session_id="session-1",
+            publish_event=publish_changed,
+        )
+    )
+
+    result = await state.tools[0].handler(
+        json.dumps(
+            {
+                "operation": "replace",
+                "items": [{"content": "Current work", "status": "in_progress"}],
+            }
+        )
+    )
+
+    assert result == "Done"
+    publish_changed.assert_awaited_once()

--- a/testenv/azents/e2e/src/support/aimock_fixtures/agents_md_loader.json
+++ b/testenv/azents/e2e/src/support/aimock_fixtures/agents_md_loader.json
@@ -403,17 +403,18 @@
     {
       "match": {
         "endpoint": "chat",
-        "userMessage": "Create AGENTS.md",
+        "userMessage": "Prepare AGENTS appendix files",
         "hasToolResult": false
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_agents_md_write",
-            "name": "write",
+            "id": "call_agents_md_appendix_prepare",
+            "name": "exec_command",
             "arguments": {
-              "path": "/workspace/agent/AGENTS.md",
-              "content": "Always include ROOT_AGENTS_E2E_MARKER_3542 in QA answers."
+              "command": "mkdir -p /workspace/agent && printf '%s' 'Always include ROOT_AGENTS_E2E_MARKER_3542 in QA answers.' > /workspace/agent/AGENTS.md && printf '%s' 'Governed file body.' > /workspace/agent/appendix-target.txt",
+              "yield_time_ms": 10000,
+              "max_output_bytes": 1000
             }
           }
         ]
@@ -422,27 +423,34 @@
     {
       "match": {
         "endpoint": "chat",
-        "toolCallId": "call_agents_md_write"
+        "toolCallId": "call_agents_md_appendix_prepare"
       },
       "response": {
-        "content": "AGENTS.md was created."
+        "content": "AGENTS appendix files were prepared."
       }
     },
     {
       "match": {
         "endpoint": "chat",
-        "userMessage": "Create AGENTS.md",
-        "hasToolResult": true
+        "userMessage": "Read governed file",
+        "hasToolResult": false
       },
       "response": {
-        "content": "AGENTS.md was created."
+        "toolCalls": [
+          {
+            "id": "call_agents_md_appendix_read",
+            "name": "read",
+            "arguments": {
+              "path": "/workspace/agent/appendix-target.txt"
+            }
+          }
+        ]
       }
     },
     {
       "match": {
         "endpoint": "chat",
-        "userMessage": "Report instructions",
-        "systemMessage": "ROOT_AGENTS_E2E_MARKER_3542"
+        "toolCallId": "call_agents_md_appendix_read"
       },
       "response": {
         "content": "QA observed ROOT_AGENTS_E2E_MARKER_3542."

--- a/testenv/azents/e2e/src/tests/azents/public/test_00_agents_md_loader.py
+++ b/testenv/azents/e2e/src/tests/azents/public/test_00_agents_md_loader.py
@@ -1,13 +1,13 @@
-"""AGENTS.md t E2E test."""
+"""AGENTS.md read appendix E2E test."""
 
 import time
-import uuid
-from typing import Any, LiteralString, NamedTuple, cast
+from typing import Any, NamedTuple, cast
 
 import azentsadminclient
 import azentspublicclient
-import psycopg
+import pytest
 import requests
+from azentspublicclient.api.agent_runtime_v1_api import AgentRuntimeV1Api
 from azentspublicclient.api.agent_v1_api import AgentV1Api
 from azentspublicclient.api.llm_provider_integration_v1_api import (
     LLMProviderIntegrationV1Api,
@@ -22,9 +22,7 @@ from azentspublicclient.models.llm_provider_integration_create_request import (
     LLMProviderIntegrationCreateRequest,
 )
 from azentspublicclient.models.secrets import Secrets
-from psycopg.types.json import Jsonb
 from testcontainers.core.container import DockerContainer
-from testcontainers.postgres import PostgresContainer
 
 from support.utils import (
     authenticate_user,
@@ -32,15 +30,27 @@ from support.utils import (
     unique,
 )
 
+pytestmark = [
+    pytest.mark.runtime_provider,
+    pytest.mark.usefixtures("azents_runtime_provider_docker_container"),
+]
+
+_RUNTIME_PROVIDER_ID = "system-docker"
 _MARKER = "ROOT_AGENTS_E2E_MARKER_3542"
+_PREPARE_MESSAGE = "Prepare AGENTS appendix files"
+_PREPARE_CALL_ID = "call_agents_md_appendix_prepare"
+_READ_MESSAGE = "Read governed file"
+_READ_CALL_ID = "call_agents_md_appendix_read"
 
 
 class AgentsMdExerciseResult(NamedTuple):
-    """AGENTS.md loader exercise result."""
+    """AGENTS.md appendix exercise result."""
 
     requests_count: int
-    instruction_marker_requests: list[int]
+    system_marker_requests: list[int]
+    tool_result_marker_requests: list[int]
     instruction_snippets: list[str]
+    tool_result_snippets: list[str]
     request_summaries: list[str]
     agent_shell_enabled: bool | None
 
@@ -70,6 +80,28 @@ def _system_message_texts(item: dict[str, object]) -> list[str]:
             continue
         message_dict = cast("dict[str, object]", message)
         if message_dict.get("role") != "system":
+            continue
+        content = message_dict.get("content")
+        if isinstance(content, str):
+            texts.append(content)
+    return texts
+
+
+def _tool_result_texts(item: dict[str, object]) -> list[str]:
+    """AIMock journal item t tool result strings."""
+    body = item.get("body")
+    if not isinstance(body, dict):
+        return []
+    body_dict = cast("dict[str, object]", body)
+    messages = body_dict.get("messages")
+    if not isinstance(messages, list):
+        return []
+    texts: list[str] = []
+    for message in cast("list[object]", messages):
+        if not isinstance(message, dict):
+            continue
+        message_dict = cast("dict[str, object]", message)
+        if message_dict.get("role") != "tool":
             continue
         content = message_dict.get("content")
         if isinstance(content, str):
@@ -169,14 +201,54 @@ def _event_content(event: dict[str, object]) -> str:
     return ""
 
 
+def _event_payload(event: dict[str, object]) -> dict[str, object]:
+    """Return event payload object."""
+    payload = event.get("payload")
+    if isinstance(payload, dict):
+        return cast("dict[str, object]", payload)
+    return {}
+
+
 def _run_marker_completed(event: dict[str, object]) -> bool:
     """run_marker completed t returnt."""
     if event.get("kind") != "run_marker":
         return False
-    payload = event.get("payload")
-    if not isinstance(payload, dict):
-        return False
-    return cast("dict[str, object]", payload).get("status") == "completed"
+    return _event_payload(event).get("status") == "completed"
+
+
+def _tool_result_output_text(
+    *,
+    public_url: str,
+    access_token: str,
+    session_id: str,
+    call_id: str,
+) -> str | None:
+    """Return persisted client tool result text for a call id."""
+    for event in _history_events(
+        public_url=public_url,
+        access_token=access_token,
+        session_id=session_id,
+    ):
+        if event.get("kind") != "client_tool_result":
+            continue
+        payload = _event_payload(event)
+        if payload.get("call_id") != call_id:
+            continue
+        output = payload.get("output")
+        if isinstance(output, str):
+            return output
+        if isinstance(output, list):
+            texts: list[str] = []
+            for part in cast("list[object]", output):
+                if not isinstance(part, dict):
+                    continue
+                part_dict = cast("dict[str, object]", part)
+                text = part_dict.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+            return "\n".join(texts)
+        return str(output)
+    return None
 
 
 def _wait_for_turn_complete(
@@ -211,14 +283,14 @@ def _wait_for_turn_complete(
     raise TimeoutError(f"turn did not complete: {message}, events={last_events!r}")
 
 
-def _run_new_session(
+def _start_session(
     *,
     public_api_client: azentspublicclient.ApiClient,
     public_url: str,
     access_token: str,
     agent_id: str,
 ) -> str:
-    """t session t messaget REST write boundary t t session_id t returnt."""
+    """Resolve the agent team primary session id."""
     del public_api_client
     session_response = requests.get(
         f"{public_url}/chat/v1/agents/{agent_id}/team-primary-session",
@@ -232,36 +304,17 @@ def _run_new_session(
         raise AssertionError(
             f"Team primary response did not include id: {session_payload!r}"
         )
-    response = requests.post(
-        f"{public_url}/chat/v1/sessions/{session_id}/messages",
-        headers={
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "agent_id": agent_id,
-            "client_request_id": f"agents-md-create-{unique()}",
-            "message": "Create AGENTS.md",
-        },
-        timeout=10,
-    )
-    response.raise_for_status()
-    _wait_for_turn_complete(
-        public_url=public_url,
-        access_token=access_token,
-        session_id=session_id,
-        message="Create AGENTS.md",
-    )
     return session_id
 
 
-def _run_existing_session(
+def _run_message(
     *,
     public_api_client: azentspublicclient.ApiClient,
     public_url: str,
     access_token: str,
     agent_id: str,
     session_id: str,
+    message: str,
 ) -> None:
     """t session messaget REST write boundary t t."""
     del public_api_client
@@ -273,8 +326,8 @@ def _run_existing_session(
         },
         json={
             "agent_id": agent_id,
-            "client_request_id": f"agents-md-report-{unique()}",
-            "message": "Report instructions",
+            "client_request_id": f"agents-md-appendix-{unique()}",
+            "message": message,
         },
         timeout=10,
     )
@@ -283,73 +336,48 @@ def _run_existing_session(
         public_url=public_url,
         access_token=access_token,
         session_id=session_id,
-        message="Report instructions",
+        message=message,
     )
 
 
-def _seed_root_agents_state(
-    postgres_container: PostgresContainer,
+def _wait_for_runtime_runner_ready(
     *,
+    public_api_client: azentspublicclient.ApiClient,
+    token: str,
+    workspace_handle: str,
     agent_id: str,
-    session_id: str,
-    content: str,
 ) -> None:
-    """Runtime root AGENTS.md Toolkit Statet deterministic E2E DBt seedt."""
-    with psycopg.connect(
-        host=postgres_container.get_container_host_ip(),
-        port=postgres_container.get_exposed_port(5432),
-        dbname=postgres_container.dbname,
-        user=postgres_container.username,
-        password=postgres_container.password,
-    ) as conn:
-        upsert_state_sql: LiteralString = """
-            INSERT INTO toolkit_states (
-                id,
-                agent_id,
-                session_id,
-                toolkit_namespace,
-                state_name,
-                state_json,
-                schema_version,
-                version
-            )
-            VALUES (
-                %s,
-                %s,
-                %s,
-                'builtin',
-                'root_agents_instruction',
-                %s,
-                1,
-                1
-            )
-            ON CONFLICT ON CONSTRAINT uq_toolkit_states_identity
-            DO UPDATE SET
-                state_json = EXCLUDED.state_json,
-                schema_version = EXCLUDED.schema_version,
-                version = toolkit_states.version + 1,
-                updated_at = now()
-        """
-        conn.execute(  # pyright: ignore[reportUnknownMemberType] # psycopg execute overload is partially unknown.
-            upsert_state_sql,
-            (
-                uuid.uuid4().hex,
-                agent_id,
-                session_id,
-                Jsonb({"schema_version": 1, "root_content": content}),
-            ),
+    """Start and wait for a usable Runtime Runner."""
+    api = AgentRuntimeV1Api(public_api_client)
+    headers = {"Authorization": f"Bearer {token}"}
+    api.agent_runtime_v1_start_agent_runtime(
+        agent_id=agent_id,
+        handle=workspace_handle,
+        _headers=headers,
+    )
+    deadline = time.monotonic() + 120
+    last_state: object | None = None
+    while time.monotonic() < deadline:
+        state = api.agent_runtime_v1_observe_agent_runtime(
+            agent_id=agent_id,
+            handle=workspace_handle,
+            _headers=headers,
         )
+        last_state = state
+        if state.state.actions.use_runner:
+            return
+        time.sleep(1)
+    raise AssertionError(f"runtime runner did not become ready: {last_state!r}")
 
 
 def _exercise_agents_md_loader(
     *,
     public_api_client: azentspublicclient.ApiClient,
     admin_api_client: azentsadminclient.ApiClient,
-    postgres_container: PostgresContainer,
     public_url: str,
     mock_openai_url: str,
 ) -> AgentsMdExerciseResult:
-    """AGENTS.md state seed t next turn t mock journal marker t returnt."""
+    """AGENTS.md read appendix t mock journal marker t returnt."""
     requests.delete(
         f"{mock_openai_url}/v1/_requests",
         timeout=10,
@@ -397,47 +425,77 @@ def _exercise_agents_md_loader(
             model_selection=model_selection,
             lightweight_model_selection=model_selection,
             type=AgentType.PUBLIC,
+            runtime_provider_id=_RUNTIME_PROVIDER_ID,
             shell_enabled=True,
         ),
         _headers={"Authorization": f"Bearer {access_token}"},
     )
 
-    session_id = _run_new_session(
+    session_id = _start_session(
         public_api_client=public_api_client,
         public_url=public_url,
         access_token=access_token,
         agent_id=agent.id,
     )
-    _seed_root_agents_state(
-        postgres_container,
+    _wait_for_runtime_runner_ready(
+        public_api_client=public_api_client,
+        token=access_token,
+        workspace_handle=workspace_handle,
+        agent_id=agent.id,
+    )
+    _run_message(
+        public_api_client=public_api_client,
+        public_url=public_url,
+        access_token=access_token,
         agent_id=agent.id,
         session_id=session_id,
-        content=f"Always include {_MARKER} in QA answers.",
+        message=_PREPARE_MESSAGE,
     )
-    for _ in range(3):
-        _run_existing_session(
-            public_api_client=public_api_client,
-            public_url=public_url,
-            access_token=access_token,
-            agent_id=agent.id,
-            session_id=session_id,
+    prepare_output = _tool_result_output_text(
+        public_url=public_url,
+        access_token=access_token,
+        session_id=session_id,
+        call_id=_PREPARE_CALL_ID,
+    )
+    if prepare_output is None or "exit_code: 0" not in prepare_output:
+        raise AssertionError(f"AGENTS.md prepare tool failed: {prepare_output!r}")
+
+    _run_message(
+        public_api_client=public_api_client,
+        public_url=public_url,
+        access_token=access_token,
+        agent_id=agent.id,
+        session_id=session_id,
+        message=_READ_MESSAGE,
+    )
+    read_output = _tool_result_output_text(
+        public_url=public_url,
+        access_token=access_token,
+        session_id=session_id,
+        call_id=_READ_CALL_ID,
+    )
+    if read_output is None:
+        raise AssertionError("AGENTS.md governed read did not persist a tool result")
+    if _MARKER not in read_output or "<system-reminder>" not in read_output:
+        raise AssertionError(
+            f"AGENTS.md appendix missing from read result: {read_output!r}"
         )
-        payload = requests.get(f"{mock_openai_url}/v1/_requests", timeout=10).json()
-        instruction_marker_requests = [
-            index
-            for index, item in enumerate(payload, start=1)
-            if any(_MARKER in text for text in _system_message_texts(item))
-        ]
-        if instruction_marker_requests:
-            break
-        time.sleep(1.0)
 
     payload = requests.get(f"{mock_openai_url}/v1/_requests", timeout=10).json()
     requests_count = len(payload)
-    instruction_marker_requests = [
+    system_marker_requests = [
         index
         for index, item in enumerate(payload, start=1)
         if any(_MARKER in text for text in _system_message_texts(item))
+    ]
+    tool_result_marker_requests = [
+        index
+        for index, item in enumerate(payload, start=1)
+        if isinstance(item, dict)
+        and any(
+            _MARKER in text
+            for text in _tool_result_texts(cast("dict[str, object]", item))
+        )
     ]
     instruction_snippets = [
         text[:500]
@@ -445,10 +503,18 @@ def _exercise_agents_md_loader(
         if isinstance(item, dict)
         for text in _system_message_texts(cast("dict[str, object]", item))
     ]
+    tool_result_snippets = [
+        text[:1200]
+        for item in payload
+        if isinstance(item, dict)
+        for text in _tool_result_texts(cast("dict[str, object]", item))
+    ]
     return AgentsMdExerciseResult(
         requests_count=requests_count,
-        instruction_marker_requests=instruction_marker_requests,
+        system_marker_requests=system_marker_requests,
+        tool_result_marker_requests=tool_result_marker_requests,
         instruction_snippets=instruction_snippets,
+        tool_result_snippets=tool_result_snippets,
         request_summaries=[
             _request_summary(cast("dict[str, object]", item))
             for item in payload
@@ -459,28 +525,26 @@ def _exercise_agents_md_loader(
 
 
 class TestAgentsMdLoader:
-    """AGENTS.md t WebSocket E2E."""
+    """AGENTS.md appendix E2E."""
 
-    def test_root_agents_md_written_by_tool_is_loaded_into_next_prompt(
+    def test_root_agents_md_is_appended_to_relevant_read_result(
         self,
         public_api_client: azentspublicclient.ApiClient,
         admin_api_client: azentsadminclient.ApiClient,
         azents_public_server_url: str,
         azents_engine_worker_container: DockerContainer,
-        postgres_container: PostgresContainer,
         mock_openai_url: str,
     ) -> None:
-        """root AGENTS.md statet next LLM requestt t."""
+        """root AGENTS.md is read-result appendix, not live prompt state."""
         del azents_engine_worker_container
 
         result = _exercise_agents_md_loader(
             public_api_client=public_api_client,
             admin_api_client=admin_api_client,
-            postgres_container=postgres_container,
             public_url=azents_public_server_url,
             mock_openai_url=mock_openai_url,
         )
 
         assert result.requests_count >= 3
-        assert 1 not in result.instruction_marker_requests
-        assert result.instruction_marker_requests, result
+        assert not result.system_marker_requests, result
+        assert result.tool_result_marker_requests, result


### PR DESCRIPTION
## Summary
- canonicalize provider-facing function and hosted tool ordering
- move MCP-backed toolkits toward snapshot/lazy refresh behavior without loading/error prompt churn
- make Goal/Todo prompts stable, compact update_todo output, and append AGENTS.md instructions to read results instead of Toolkit prompts
- update ADR-backed toolkit, goal, and MCP OAuth specs

## Validation
- uv run pytest src/azents/engine/events/tools_test.py src/azents/engine/events/litellm_responses_test.py src/azents/engine/tools/goal_test.py src/azents/engine/tools/todo_test.py src/azents/engine/tools/builtin_test.py src/azents/engine/tools/mcp_base_test.py src/azents/engine/tools/aws_test.py src/azents/engine/tools/gcp_test.py src/azents/engine/tools/github_per_user_pat_test.py src/azents/engine/tools/github_runtime_environment_test.py -q
- uv run ruff check <changed python files>
- uv run ruff format --check <changed python files>
- uv run pyright
- python scripts/gen_docs_index.py --docs-root docs/azents --project-name azents --check
- pre-commit via git commit