### PR TITLE
[codex] Stabilize GitHub MCP snapshot tools

### DIFF
--- a/python/apps/azents/src/azents/engine/tools/github.py
+++ b/python/apps/azents/src/azents/engine/tools/github.py
@@ -11,9 +11,10 @@ import logging
 import re
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from textwrap import dedent
 
+from mcp.types import Tool as McpBaseTool
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,6 +48,7 @@ from azents.engine.tooling.toolkit_state import (
     ToolkitStateStore,
 )
 from azents.engine.tools.mcp import McpToolkit
+from azents.engine.tools.mcp_base import McpToolSnapshotState, wrap_mcp_tool
 from azents.rdb.session import SessionManager
 from azents.repos.github_user_installation import (
     GithubUserInstallationRepository,
@@ -628,23 +630,86 @@ class GitHubToolkit(Toolkit[GitHubToolkitConfig]):
                     self._prepare_installation_mcp(binding)
                 )
             if binding.lazy_mcp_task is not None and not binding.lazy_mcp_task.done():
-                return ToolkitState(
-                    status=ToolkitStatus.ENABLED,
-                    tools=[],
-                    prompt="",
+                return await self._installation_snapshot_update_context(
+                    binding,
+                    context,
                 )
             if binding.lazy_mcp_error is not None:
-                return ToolkitState(
-                    status=ToolkitStatus.ENABLED,
-                    tools=[],
-                    prompt="",
+                return await self._installation_snapshot_update_context(
+                    binding,
+                    context,
                 )
-            return ToolkitState(
-                status=ToolkitStatus.ENABLED,
-                tools=[],
-                prompt="",
+            return await self._installation_snapshot_update_context(
+                binding,
+                context,
             )
         return await binding.mcp_toolkit.update_context(context)
+
+    async def _installation_snapshot_update_context(
+        self,
+        binding: GitHubInstallationBinding,
+        context: TurnContext,
+    ) -> ToolkitState:
+        """Return tools from a previous installation MCP snapshot if available."""
+        del context
+        snapshot = await _load_installation_tool_snapshot(binding)
+        tools = (
+            self._tools_from_installation_snapshot(binding, snapshot)
+            if snapshot is not None
+            else []
+        )
+        return ToolkitState(status=ToolkitStatus.ENABLED, tools=tools, prompt="")
+
+    def _tools_from_installation_snapshot(
+        self,
+        binding: GitHubInstallationBinding,
+        snapshot: McpToolSnapshotState,
+    ) -> list[FunctionTool]:
+        """Rebuild installation MCP tools before the lazy McpToolkit exists."""
+        config = binding.lazy_mcp_config
+        if config is None:
+            return []
+
+        async def headers_provider() -> dict[str, str]:
+            return await self._installation_auth_headers(binding)
+
+        tools: list[FunctionTool] = []
+        for item in sorted(snapshot.tools, key=lambda tool: tool.model_name):
+            mcp_tool = McpBaseTool(
+                name=item.raw_name,
+                description=item.description,
+                inputSchema=item.input_schema,
+            )
+            tool = wrap_mcp_tool(
+                mcp_tool,
+                item.server_url,
+                {},
+                config.timeout,
+                use_streamable_http=item.use_streamable_http,
+                on_auth_failure=binding.lazy_mcp_secret_provider,
+                proxy_url=binding.lazy_mcp_proxy_url,
+                headers_provider=headers_provider,
+            )
+            if item.model_name != item.raw_name:
+                tool = replace(
+                    tool,
+                    spec=replace(tool.spec, name=item.model_name),
+                )
+            tools.append(tool)
+        return tools
+
+    async def _installation_auth_headers(
+        self,
+        binding: GitHubInstallationBinding,
+    ) -> dict[str, str]:
+        """Build auth headers for an installation MCP tool call."""
+        token = await self._get_cached_installation_token(
+            binding.target.installation_id,
+            binding.token_provider,
+        )
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}"}
 
     async def _prepare_lazy_mcp(self) -> None:
         """Issue GitHub token in background and start MCP lazy load."""
@@ -1208,6 +1273,37 @@ def _build_installation_bindings(
             )
         )
     return bindings
+
+
+async def _load_installation_tool_snapshot(
+    binding: GitHubInstallationBinding,
+) -> McpToolSnapshotState | None:
+    """Load a previous MCP tool snapshot before lazy GitHub MCP setup finishes."""
+    config = binding.lazy_mcp_config
+    if (
+        config is None
+        or binding.session_manager is None
+        or not binding.agent_id
+        or not binding.session_id
+    ):
+        return None
+    identity = ToolkitStateIdentity(
+        agent_id=binding.agent_id,
+        session_id=binding.session_id,
+        toolkit_namespace="mcp",
+        state_name=binding.state_name,
+    )
+    async with binding.session_manager() as session:
+        handle = ToolkitStateStore(session=session).handle(
+            identity,
+            McpToolSnapshotState,
+        )
+        snapshot = await handle.load(default_factory=McpToolSnapshotState)
+    if not snapshot.tools:
+        return None
+    if snapshot.server_url != config.server_url:
+        return None
+    return snapshot
 
 
 def _github_snapshot_state_name(*, toolkit_id: str, suffix: str) -> str:

--- a/python/apps/azents/src/azents/engine/tools/github_tool_snapshot_test.py
+++ b/python/apps/azents/src/azents/engine/tools/github_tool_snapshot_test.py
@@ -1,0 +1,358 @@
+"""GitHub Toolkit MCP snapshot fallback tests."""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import AsyncContextManager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from mcp.types import TextContent
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from azents.core.github_credentials import GitHubInstallationTarget
+from azents.core.tools import GitHubToolkitConfig, McpToolkitConfig, TurnContext
+from azents.engine.run.types import FunctionTool
+from azents.engine.tooling.toolkit_state import ToolkitStateIdentity
+from azents.engine.tools.github import GitHubInstallationBinding, GitHubToolkit
+from azents.engine.tools.mcp_base import McpToolSnapshotItem, McpToolSnapshotState
+
+_GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
+
+
+class _FakeToolkitStateHandle:
+    """In-memory Toolkit State handle for tests."""
+
+    _states: dict[tuple[str, str, str, str], object] = {}
+
+    def __init__(self, identity: ToolkitStateIdentity) -> None:
+        """Create fake handle."""
+        self.identity = identity
+
+    async def load(self, default_factory: object) -> object:
+        """Load state from in-memory store."""
+        key = self._key()
+        if key not in self._states:
+            return default_factory()  # type: ignore[operator]
+        return self._states[key]
+
+    async def save(self, state: object) -> object:
+        """Save state to in-memory store."""
+        self._states[self._key()] = state
+        return object()
+
+    @classmethod
+    def save_state(cls, identity: ToolkitStateIdentity, state: object) -> None:
+        """Seed state for identity."""
+        cls._states[
+            (
+                identity.agent_id,
+                identity.session_id,
+                identity.toolkit_namespace,
+                identity.state_name,
+            )
+        ] = state
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear stored Toolkit State."""
+        cls._states.clear()
+
+    def _key(self) -> tuple[str, str, str, str]:
+        return (
+            self.identity.agent_id,
+            self.identity.session_id,
+            self.identity.toolkit_namespace,
+            self.identity.state_name,
+        )
+
+
+class _FakeToolkitStateStore:
+    """In-memory Toolkit State store for tests."""
+
+    def __init__(self, *, session: object) -> None:
+        del session
+
+    def handle(
+        self, identity: ToolkitStateIdentity, _model_type: object
+    ) -> _FakeToolkitStateHandle:
+        """Return fake handle."""
+        return _FakeToolkitStateHandle(identity)
+
+
+class _FakeSessionContext:
+    """Minimal async session context manager."""
+
+    async def __aenter__(self) -> AsyncSession:
+        return AsyncSession()
+
+    async def __aexit__(self, *exc: object) -> None:
+        pass
+
+
+class _FakeSessionManager:
+    """Minimal async session manager."""
+
+    def __call__(self) -> AsyncContextManager[AsyncSession]:
+        return _FakeSessionContext()
+
+
+class _FakeSelectedInstallationStore:
+    """In-memory selected installation store for tests."""
+
+    async def load(self) -> str | None:
+        """Load selected installation ID."""
+        return None
+
+    async def save(self, installation_id: str) -> None:
+        """Save selected installation ID."""
+        del installation_id
+
+
+@pytest.fixture(autouse=True)
+def _toolkit_state_store(  # pyright: ignore[reportUnusedFunction] -- pytest fixture
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Patch Toolkit State to an in-memory store."""
+    _FakeToolkitStateHandle.clear()
+    monkeypatch.setattr(
+        "azents.engine.tools.github.ToolkitStateStore",
+        _FakeToolkitStateStore,
+    )
+
+
+def _make_config() -> GitHubToolkitConfig:
+    """Create GitHub App config."""
+    return GitHubToolkitConfig(
+        github_auth_type="github_app",
+        toolsets=["repos"],
+        timeout=30.0,
+    )
+
+
+def _make_context() -> TurnContext:
+    """Create TurnContext for tests."""
+    return TurnContext(
+        user_id="user-1",
+        workspace_id="workspace-1",
+        model="model",
+        run_id="run-1",
+        session_id="session-1",
+        publish_event=_publish,
+    )
+
+
+async def _publish(_event: object) -> None:
+    """No-op event publish."""
+
+
+def _target(installation_id: str, account_login: str) -> GitHubInstallationTarget:
+    """Create GitHub installation target."""
+    return GitHubInstallationTarget(
+        installation_id=installation_id,
+        account_login=account_login,
+        account_type="Organization",
+        account_avatar_url=None,
+    )
+
+
+def _snapshot(*tool_names: str) -> McpToolSnapshotState:
+    """Create MCP tool snapshot."""
+    return McpToolSnapshotState(
+        server_url=_GITHUB_MCP_URL,
+        tool_hash="test",
+        tools=[
+            McpToolSnapshotItem(
+                raw_name=name,
+                model_name=name,
+                description=f"{name} tool",
+                input_schema={"type": "object", "properties": {}},
+                server_url=_GITHUB_MCP_URL,
+                use_streamable_http=True,
+            )
+            for name in tool_names
+        ],
+    )
+
+
+def _identity(binding: GitHubInstallationBinding) -> ToolkitStateIdentity:
+    """Create Toolkit State identity for a binding."""
+    return ToolkitStateIdentity(
+        agent_id=binding.agent_id,
+        session_id=binding.session_id,
+        toolkit_namespace="mcp",
+        state_name=binding.state_name,
+    )
+
+
+def _binding(
+    *,
+    target: GitHubInstallationTarget,
+    state_name: str,
+    token_provider: Callable[[], Awaitable[str | None]],
+) -> GitHubInstallationBinding:
+    """Create installation binding fixture."""
+    return GitHubInstallationBinding(
+        target=target,
+        mcp_toolkit=None,
+        token_provider=token_provider,
+        lazy_mcp_config=McpToolkitConfig(
+            server_url=_GITHUB_MCP_URL,
+            auth_type="bearer",
+        ),
+        lazy_mcp_secret_provider=token_provider,
+        lazy_mcp_proxy_url=None,
+        session_manager=_FakeSessionManager(),
+        agent_id="agent-1",
+        session_id="session-1",
+        state_name=state_name,
+    )
+
+
+async def _never() -> None:
+    """Never-completing task fixture."""
+    await asyncio.Event().wait()
+
+
+def _find_tool(tools: list[FunctionTool], name: str) -> FunctionTool:
+    """Find tool by name."""
+    for tool in tools:
+        if tool.spec.name == name:
+            return tool
+    raise AssertionError(f"Tool not found: {name}")
+
+
+def _make_call_tool_result(text: str) -> MagicMock:
+    """Create MCP CallToolResult-like object."""
+    result = MagicMock()
+    result.content = [TextContent(type="text", text=text)]
+    result.isError = False
+    return result
+
+
+async def test_multi_installation_uses_snapshot_while_lazy_mcp_is_pending() -> None:
+    """Previous installation snapshots are exposed before lazy MCP setup finishes."""
+
+    async def provide_azents() -> str:
+        return "ghs_azents"
+
+    async def provide_hardtack() -> str:
+        return "ghs_hardtack"
+
+    azents = _binding(
+        target=_target("101", "azents"),
+        state_name="tool_snapshot:azents",
+        token_provider=provide_azents,
+    )
+    hardtack = _binding(
+        target=_target("202", "Hardtack"),
+        state_name="tool_snapshot:hardtack",
+        token_provider=provide_hardtack,
+    )
+    _FakeToolkitStateHandle.save_state(
+        _identity(azents),
+        _snapshot("create_or_update_file"),
+    )
+    _FakeToolkitStateHandle.save_state(
+        _identity(hardtack),
+        _snapshot("get_file_contents"),
+    )
+    azents.lazy_mcp_task = asyncio.create_task(_never())
+    hardtack.lazy_mcp_task = asyncio.create_task(_never())
+    toolkit = GitHubToolkit(
+        config=_make_config(),
+        installation_bindings=[hardtack, azents],
+        selected_installation_store=_FakeSelectedInstallationStore(),  # type: ignore[arg-type]
+    )
+
+    try:
+        state = await toolkit.update_context(_make_context())
+        names = [tool.spec.name for tool in state.tools]
+
+        assert names == [
+            "azents__create_or_update_file",
+            "hardtack__get_file_contents",
+            "switch_installation",
+        ]
+        assert "Current default installation" in state.prompt
+
+        second_state = await toolkit.update_context(_make_context())
+        assert [tool.spec.name for tool in second_state.tools] == names
+    finally:
+        for task in (azents.lazy_mcp_task, hardtack.lazy_mcp_task):
+            task.cancel()
+
+
+async def test_multi_installation_without_snapshot_keeps_switch_tool_only() -> None:
+    """No snapshot preserves existing switch-only behavior while MCP prepares."""
+
+    async def provide_token() -> str:
+        return "ghs_token"
+
+    azents = _binding(
+        target=_target("101", "azents"),
+        state_name="tool_snapshot:azents",
+        token_provider=provide_token,
+    )
+    hardtack = _binding(
+        target=_target("202", "Hardtack"),
+        state_name="tool_snapshot:hardtack",
+        token_provider=provide_token,
+    )
+    azents.lazy_mcp_task = asyncio.create_task(_never())
+    hardtack.lazy_mcp_task = asyncio.create_task(_never())
+    toolkit = GitHubToolkit(
+        config=_make_config(),
+        installation_bindings=[azents, hardtack],
+        selected_installation_store=_FakeSelectedInstallationStore(),  # type: ignore[arg-type]
+    )
+
+    try:
+        state = await toolkit.update_context(_make_context())
+
+        assert [tool.spec.name for tool in state.tools] == ["switch_installation"]
+    finally:
+        for task in (azents.lazy_mcp_task, hardtack.lazy_mcp_task):
+            task.cancel()
+
+
+async def test_snapshot_tool_handler_gets_installation_token_at_call_time() -> None:
+    """Snapshot tools defer token issuance until the tool is actually called."""
+    token_calls = 0
+
+    async def provide_token() -> str:
+        nonlocal token_calls
+        token_calls += 1
+        return "ghs_snapshot"
+
+    binding = _binding(
+        target=_target("101", "azents"),
+        state_name="tool_snapshot:azents",
+        token_provider=provide_token,
+    )
+    _FakeToolkitStateHandle.save_state(
+        _identity(binding),
+        _snapshot("create_or_update_file"),
+    )
+    binding.lazy_mcp_task = asyncio.create_task(_never())
+    toolkit = GitHubToolkit(
+        config=_make_config(),
+        installation_bindings=[binding],
+    )
+
+    try:
+        state = await toolkit.update_context(_make_context())
+        tool = _find_tool(state.tools, "azents__create_or_update_file")
+        assert token_calls == 0
+
+        with patch(
+            "azents.engine.tools.mcp_base.mcp_call_tool",
+            return_value=_make_call_tool_result("ok"),
+        ) as call_tool:
+            result = await tool.handler("{}")
+
+        assert result == "ok"
+        assert token_calls == 1
+        call_args = call_tool.call_args.args
+        assert call_args[1] == {"Authorization": "Bearer ghs_snapshot"}
+    finally:
+        binding.lazy_mcp_task.cancel()

--- a/python/apps/azents/src/azents/engine/tools/mcp_base.py
+++ b/python/apps/azents/src/azents/engine/tools/mcp_base.py
@@ -450,6 +450,7 @@ def wrap_mcp_tool(
     on_auth_failure: Callable[[], Awaitable[str | None]] | None = None,
     proxy_url: str | None = None,
     auth: httpx.Auth | None = None,
+    headers_provider: Callable[[], Awaitable[dict[str, str]]] | None = None,
     artifact_sink_getter: ArtifactSinkGetter | None = None,
 ) -> FunctionTool:
     """Wrap MCP tool as azents Tool.
@@ -465,6 +466,10 @@ def wrap_mcp_tool(
     :param on_auth_failure: Token reissue callback called on 401; no retry when None
     :param proxy_url: egress proxy URL; direct connection when None
     :param auth: httpx Auth handler for per-request signing such as SigV4
+    :param headers_provider:
+        Optional async header provider evaluated when the tool is called.
+        Useful when a cached tool snapshot can be exposed before credentials are
+        available during turn preparation.
     :return: azents Tool instance
     """
     spec = FunctionToolSpec(
@@ -481,10 +486,13 @@ def wrap_mcp_tool(
             )
         except json.JSONDecodeError as exc:
             raise FunctionToolError(f"Invalid JSON in tool arguments: {exc}") from None
+        call_headers = (
+            await headers_provider() if headers_provider is not None else headers
+        )
         try:
             result = await mcp_call_tool(
                 server_url,
-                headers,
+                call_headers,
                 timeout,
                 mcp_tool.name,
                 args,
@@ -496,7 +504,10 @@ def wrap_mcp_tool(
             if on_auth_failure is not None and _is_http_401(exc):
                 new_token = await on_auth_failure()
                 if new_token is not None:
-                    new_headers = {**headers, "Authorization": f"Bearer {new_token}"}
+                    new_headers = {
+                        **call_headers,
+                        "Authorization": f"Bearer {new_token}",
+                    }
                     try:
                         result = await mcp_call_tool(
                             server_url,


### PR DESCRIPTION
## Summary
- expose cached GitHub installation MCP snapshot tools while lazy MCP setup is still pending
- defer installation token issuance until snapshot-backed tool handlers are actually invoked
- add regression tests for multi-installation snapshot fallback, switch-only behavior without a snapshot, and call-time auth headers

## Root Cause
GitHub multi-installation bindings only delegated to McpToolkit after the lazy installation MCP object had been created. While token exchange/list_tools was still pending, update_context returned no MCP tools, so multi-installation GitHub exposed only switch_installation. Once background discovery completed, the provider-facing tool schema jumped from the pseudo-tool to the full installation tool list.

The underlying MCP snapshot state is session-bound by agent_id/session_id/state_name. Existing snapshots were therefore unavailable to GitHub bindings until McpToolkit existed, even when the binding already had enough identity information to load the snapshot directly.

## Validation
- uv run ruff check src/azents/engine/tools/mcp_base.py src/azents/engine/tools/github.py src/azents/engine/tools/github_tool_snapshot_test.py
- uv run ruff format --check src/azents/engine/tools/mcp_base.py src/azents/engine/tools/github.py src/azents/engine/tools/github_tool_snapshot_test.py
- uv run pytest src/azents/engine/tools/github_tool_snapshot_test.py src/azents/engine/tools/mcp_base_test.py src/azents/engine/tools/github_runtime_environment_test.py src/azents/engine/tools/aws_test.py src/azents/engine/tools/gcp_test.py -q
- uv run pyright
- pre-commit hooks during git commit