### PR TITLE
[codex] Document GitHub MCP snapshot contract

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -20,7 +20,7 @@ Design documents are accumulated records and are not listed individually in this
 | [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-06-29 | 7 |
 | [Memory](spec/domain/memory.md) | memory | @Hardtack | 2026-05-10 | 1 |
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-06-21 | 1 |
-| [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-06-29 | 39 |
+| [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-06-29 | 40 |
 | [User & Authentication](spec/domain/user-auth.md) | user-auth | @Hardtack | 2026-06-29 | 5 |
 | [Workspace & Membership](spec/domain/workspace.md) | workspace | @Hardtack | 2026-06-27 | 21 |
 

--- a/docs/azents/adr/0085-deterministic-tool-catalog-and-mcp-snapshots.md
+++ b/docs/azents/adr/0085-deterministic-tool-catalog-and-mcp-snapshots.md
@@ -191,6 +191,16 @@ GitHub `per_user_pat` behavior is legacy and conflicts with the current toolkit-
 
 This cleanup is not part of the immediate tool-catalog optimization scope because the path is not expected to be used.
 
+### ADR-0085-D15. Expose GitHub installation snapshots before lazy MCP startup completes
+
+GitHub multi-installation toolkits must not require a concrete `McpToolkit` object before reading a previous successful installation snapshot.
+
+Each installation binding already has stable target metadata, `agent_id`, `session_id`, and an installation-specific MCP snapshot state name. During lazy startup, `update_context()` may run before installation token exchange and MCP client creation complete. In that state, the GitHub toolkit must read the session-bound installation snapshot directly from Toolkit State and rebuild provider-facing tool specs from it when the snapshot exists.
+
+Snapshot-backed GitHub handlers must defer installation token lookup until tool execution. `update_context()` may expose the cached tool schema without issuing a GitHub installation token. When the model later calls the tool, the handler obtains the current installation token and preserves the standard MCP auth-failure retry behavior.
+
+If no snapshot exists for an installation, the installation contributes no MCP tools until a complete background refresh saves one. The multi-installation `switch_installation` routing tool remains separate from MCP discovery; it does not satisfy the MCP snapshot contract by itself.
+
 ## Consequences
 
 ### Positive
@@ -226,6 +236,7 @@ Initial implementation should prioritize:
 9. Change `update_todo` to return a compact acknowledgement instead of the full Todo state JSON.
 10. Move AGENTS.md injection from Toolkit prompts to successful `read` tool result appendices with Toolkit State path dedupe reset on compaction.
 11. Add observability for `tool_count`, canonical `tool_names_hash`, full `tools_schema_hash`, `system_prompt_hash`, snapshot age, refresh outcome, and refresh duration.
+12. In GitHub multi-installation lazy bindings, read installation MCP snapshots before concrete `McpToolkit` creation and defer installation token lookup to tool-call execution.
 
 The immediate non-MCP tool scope is intentionally narrow: final tool ordering, hosted-tool ordering, and regression coverage for Goal/Todo fixed tool definitions. Background task and subagent tool injection are known future redesign areas and are not part of this optimization pass.
 

--- a/docs/azents/design/github-toolkit-multi-installation.md
+++ b/docs/azents/design/github-toolkit-multi-installation.md
@@ -1,7 +1,7 @@
 ---
 title: "GitHub Toolkit Multi-Installation Design"
 created: 2026-06-21
-updated: 2026-06-21
+updated: 2026-06-29
 tags: [backend, engine, frontend, security]
 ---
 
@@ -123,6 +123,12 @@ Example final tool names:
 
 - `github__azents__get_file_contents`
 - `github__hardtack__create_pull_request`
+
+Installation MCP tool exposure follows the same stale-while-revalidate snapshot lifecycle as generic MCP toolkits. `update_context()` must not await live GitHub MCP `list_tools`, but it must use the latest successful session-bound MCP snapshot for each installation when one exists.
+
+This matters for lazy multi-installation startup: a `GitHubInstallationBinding` can exist before its concrete `McpToolkit` instance has been created, because installation token exchange and MCP startup run in the background. That lazy preparation state must not prevent snapshot use. When `binding.mcp_toolkit` is still absent, the GitHub toolkit reads the installation's MCP snapshot directly from Toolkit State using the binding's `agent_id`, `session_id`, and installation-specific snapshot state name.
+
+Snapshot-backed installation tools are exposed with the same account-login prefix as live MCP-backed tools. Tool handlers acquire the current installation token at call time, not during `update_context()`, so listing cached tool schemas does not block on token exchange. If a cached snapshot is unavailable for an installation, that installation contributes no MCP tools until background refresh succeeds.
 
 ### Runtime env routing
 

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -17,7 +17,7 @@ Details of all living specs. Synchronized from frontmatter.
 | goal | [Goal Domain Spec](domain/goal.md) | - | 2026-06-29 | 7 |
 | memory | [Memory](domain/memory.md) | @Hardtack | 2026-05-10 | 1 |
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-06-21 | 1 |
-| toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-06-29 | 39 |
+| toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-06-29 | 40 |
 | user-auth | [User & Authentication](domain/user-auth.md) | @Hardtack | 2026-06-29 | 5 |
 | workspace | [Workspace & Membership](domain/workspace.md) | @Hardtack | 2026-06-27 | 21 |
 

--- a/docs/azents/spec/domain/toolkit.md
+++ b/docs/azents/spec/domain/toolkit.md
@@ -34,7 +34,7 @@ api_routes:
   - /toolkit/v1
   - /shell-environment/v1
 last_verified_at: 2026-06-29
-spec_version: 39
+spec_version: 40
 ---
 
 # Toolkit
@@ -188,6 +188,10 @@ MCP-backed toolkits must keep `list_tools` discovery off the normal run preparat
 - Generic MCP, Notion, and Sentry use the common MCP snapshot lifecycle. AWS, GCP, and GitHub MCP wrapper paths follow the same non-blocking/no-loading-prompt exposure contract and sort component/tool output deterministically.
 
 Snapshot payload stores only serializable tool metadata needed to rebuild model-visible wrappers, including raw MCP name, model-visible name, description, input schema, server URL, transport mode, loaded timestamp, and a stable tool hash. Runtime-only objects such as background tasks, auth callbacks, SigV4 auth, token providers, and artifact sinks stay in process memory.
+
+GitHub multi-installation bindings must expose cached installation MCP tools even before the lazy concrete `McpToolkit` for that installation has finished preparing. A binding that already has target metadata, `agent_id`, `session_id`, and an installation-specific MCP snapshot state name has enough information to read a previous successful snapshot from Toolkit State. Reconstructing model-visible specs from that snapshot must not require installation token exchange.
+
+Snapshot-backed GitHub tool handlers resolve installation authorization at execution time. They call the installation token provider only when the model calls a tool, and they preserve the same auth-failure retry path as live MCP-backed tools. This keeps first-turn provider-facing schemas stable when an installation snapshot exists, while avoiding token issuance work during normal run preparation.
 
 ### Credential Isolation
 


### PR DESCRIPTION
## Summary
- document that GitHub multi-installation bindings must read installation MCP snapshots before lazy MCP startup completes
- update the Toolkit domain spec with the call-time token resolution contract for snapshot-backed GitHub tools
- refresh generated Azents docs indexes

## Context
This follows PR #88, which implemented snapshot-backed GitHub multi-installation tool exposure while lazy MCP startup is still pending. The design/spec update makes that behavior an explicit contract so the provider-facing tool schema remains stable when a successful installation snapshot already exists.

## Validation
- pre-commit docs index hook passed during commit
- git diff --check