### PR TITLE
Fix Azents site snapshot lockfile

### DIFF
--- a/typescript/apps/azents-site/package.json
+++ b/typescript/apps/azents-site/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-perfectionist": "^5.0.0",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "postcss": "^8.5.4",
+    "postcss": "8.5.14",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",
     "typescript": "^6.0.0",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -215,14 +215,14 @@ importers:
         specifier: ^7.0.1
         version: 7.1.1(eslint@10.4.0(jiti@2.7.0))
       postcss:
-        specifier: ^8.5.4
-        version: 8.5.15
+        specifier: 8.5.14
+        version: 8.5.14
       postcss-preset-mantine:
         specifier: ^1.17.0
-        version: 1.18.0(postcss@8.5.15)
+        version: 1.18.0(postcss@8.5.14)
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.5.15)
+        version: 7.0.1(postcss@8.5.14)
       typescript:
         specifier: ^6.0.0
         version: 6.0.3


### PR DESCRIPTION
## Summary
- pin the Azents site PostCSS dependency to the existing workspace-resolved 8.5.14
- align the site importer lockfile entries so turbo prune includes the matching postcss package snapshot

## Verification
- Generated pruned tree with `turbo prune @azents/site --docker` and confirmed pruned lockfile includes `postcss@8.5.14`
- Ran `CI=true pnpm install --frozen-lockfile` in the pruned tree successfully
- Ran `CI=true pnpm --filter @azents/site typecheck`
- Ran `CI=true pnpm --filter @azents/site lint`