### PR TITLE
[codex] Add Azents site SEO metadata

### DIFF
--- a/typescript/apps/azents-site/src/app/layout.tsx
+++ b/typescript/apps/azents-site/src/app/layout.tsx
@@ -2,12 +2,19 @@ import { ColorSchemeScript } from "@mantine/core";
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { AZENTS_BRAND } from "@/shared/lib/brand";
-import { SITE_LINKS } from "@/shared/lib/links";
 import {
   DEFAULT_LOCALE,
   isSupportedLocale,
   type SupportedLocale,
 } from "@/shared/lib/locale";
+import {
+  LOCALE_TO_OG_LOCALE,
+  OG_IMAGE,
+  SEO_KEYWORDS,
+  SITE_NAME,
+  SITE_URL,
+  STRUCTURED_DATA,
+} from "@/shared/lib/seo";
 import { LocaleProvider } from "@/shared/providers/locale";
 import { AppMantineProvider } from "@/shared/providers/mantine";
 import type { Metadata } from "next";
@@ -18,29 +25,60 @@ import "@mantine/core/styles.css";
 import "./globals.css";
 
 export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const supportedLocale: SupportedLocale = isSupportedLocale(locale)
+    ? locale
+    : DEFAULT_LOCALE;
   const t = await getTranslations("metadata");
+  const title = t("title");
+  const description = t("description");
 
   return {
-    title: t("title"),
-    description: t("description"),
+    metadataBase: new URL(SITE_URL),
+    alternates: {
+      canonical: "/",
+    },
+    applicationName: SITE_NAME,
+    authors: [{ name: "Azents", url: SITE_URL }],
+    category: "developer tools",
+    creator: "Azents",
+    description,
     icons: {
+      apple: [{ url: AZENTS_BRAND.icon, sizes: "180x180" }],
       icon: [
         { url: "/brand/azents/favicon-32.png", sizes: "32x32" },
         { url: "/brand/azents/favicon-16.png", sizes: "16x16" },
       ],
     },
+    keywords: SEO_KEYWORDS,
+    manifest: "/manifest.webmanifest",
     openGraph: {
-      title: t("title"),
-      description: t("description"),
-      images: [{ url: AZENTS_BRAND.openGraphImage, width: 1200, height: 630 }],
+      description,
+      images: [OG_IMAGE],
+      locale: LOCALE_TO_OG_LOCALE[supportedLocale],
+      siteName: SITE_NAME,
+      title,
       type: "website",
-      url: SITE_LINKS.github,
+      url: SITE_URL,
     },
+    publisher: "Azents",
+    robots: {
+      follow: true,
+      googleBot: {
+        follow: true,
+        index: true,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+        "max-video-preview": -1,
+      },
+      index: true,
+    },
+    title,
     twitter: {
       card: "summary_large_image",
-      title: t("title"),
-      description: t("description"),
+      description,
       images: [AZENTS_BRAND.openGraphImage],
+      title,
     },
   };
 }
@@ -62,6 +100,10 @@ export default async function RootLayout({
     <html lang={htmlLang} suppressHydrationWarning>
       <head>
         <ColorSchemeScript forceColorScheme="dark" />
+        <script
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(STRUCTURED_DATA) }}
+          type="application/ld+json"
+        />
       </head>
       <body>
         <NextIntlClientProvider messages={messages}>

--- a/typescript/apps/azents-site/src/app/manifest.ts
+++ b/typescript/apps/azents-site/src/app/manifest.ts
@@ -1,0 +1,28 @@
+import { AZENTS_BRAND } from "@/shared/lib/brand";
+import { SITE_NAME } from "@/shared/lib/seo";
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    background_color: "#070a0f",
+    description:
+      "Open-source control plane for managed agent runtimes in your cloud.",
+    display: "standalone",
+    icons: [
+      {
+        sizes: "32x32",
+        src: "/brand/azents/favicon-32.png",
+        type: "image/png",
+      },
+      {
+        sizes: "4096x4096",
+        src: AZENTS_BRAND.icon,
+        type: "image/png",
+      },
+    ],
+    name: SITE_NAME,
+    short_name: SITE_NAME,
+    start_url: "/",
+    theme_color: "#070a0f",
+  };
+}

--- a/typescript/apps/azents-site/src/app/robots.ts
+++ b/typescript/apps/azents-site/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { SITE_URL } from "@/shared/lib/seo";
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    host: SITE_URL,
+    rules: {
+      allow: "/",
+      userAgent: "*",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/typescript/apps/azents-site/src/app/sitemap.ts
+++ b/typescript/apps/azents-site/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import { SITE_URL } from "@/shared/lib/seo";
+import type { MetadataRoute } from "next";
+
+const SITE_LAUNCH_DATE = new Date("2026-07-07");
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      changeFrequency: "weekly",
+      lastModified: SITE_LAUNCH_DATE,
+      priority: 1,
+      url: SITE_URL,
+    },
+  ];
+}

--- a/typescript/apps/azents-site/src/shared/lib/seo.ts
+++ b/typescript/apps/azents-site/src/shared/lib/seo.ts
@@ -1,0 +1,48 @@
+import { AZENTS_BRAND } from "./brand";
+import { SITE_LINKS } from "./links";
+import { type SupportedLocale } from "./locale";
+
+export const SITE_URL = "https://azents.io";
+export const SITE_NAME = "Azents";
+
+export const SEO_KEYWORDS = [
+  "Azents",
+  "managed agents",
+  "remote agents",
+  "agent runtime",
+  "agent control plane",
+  "self-hosted agents",
+  "open source agents",
+  "developer infrastructure",
+  "AI coding agents",
+];
+
+export const LOCALE_TO_OG_LOCALE: Record<SupportedLocale, string> = {
+  "en-US": "en_US",
+  "fr-FR": "fr_FR",
+  "ja-JP": "ja_JP",
+  "ko-KR": "ko_KR",
+};
+
+export const OG_IMAGE = {
+  alt: "Azents - managed agents inside your cloud",
+  height: 630,
+  url: AZENTS_BRAND.openGraphImage,
+  width: 1200,
+} as const;
+
+export const STRUCTURED_DATA = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  applicationCategory: "DeveloperApplication",
+  codeRepository: SITE_LINKS.github,
+  description:
+    "Azents is an open-source control plane for managed agent runtimes in your cloud.",
+  image: `${SITE_URL}${AZENTS_BRAND.openGraphImage}`,
+  isAccessibleForFree: true,
+  license: `${SITE_LINKS.github}/blob/main/LICENSE`,
+  name: SITE_NAME,
+  operatingSystem: "Cloud, Linux, macOS",
+  sameAs: [SITE_LINKS.github, SITE_LINKS.issues],
+  url: SITE_URL,
+} as const;


### PR DESCRIPTION
## Summary
- add canonical, Open Graph, Twitter card, robots, and indexing metadata for azents.io
- add JSON-LD SoftwareApplication structured data
- add manifest, robots.txt, and sitemap.xml app routes

## Verification
- pnpm --filter @azents/site format
- pnpm --filter @azents/site typecheck
- pnpm --filter @azents/site lint
- pnpm --filter @azents/site build