### PR TITLE
Shorten architecture carousel titles on mobile

### DIFF
--- a/typescript/apps/azents-site/messages/en-US.json
+++ b/typescript/apps/azents-site/messages/en-US.json
@@ -94,6 +94,7 @@
         "imageAlt": "Abstract architecture diagram showing a durable session loop separated from runtime execution.",
         "eyebrow": "01 / session loop",
         "title": "An independent session loop, decoupled from runtime execution.",
+        "mobileTitle": "An independent session loop.",
         "body": "Engine owns the agent loop and durable events. Runtime is called only when work needs files, tools, shell, or compute.",
         "diagram": {
           "sessionLabel": "durable session",
@@ -113,6 +114,7 @@
         "imageAlt": "Abstract architecture diagram showing a runtime adapter branching into multiple provider backends.",
         "eyebrow": "02 / runtime adapter",
         "title": "Providers sit behind one runtime adapter.",
+        "mobileTitle": "One adapter, many providers.",
         "body": "Kubernetes is first. The same adapter shape can map to local machines, E2B, or custom execution backends as the project grows.",
         "diagram": {
           "adapterLabel": "stable interface",
@@ -132,6 +134,7 @@
         "imageAlt": "Abstract architecture diagram showing a long-running agent timeline with durable state and handoff.",
         "eyebrow": "03 / long-running agent",
         "title": "Long-running agents need durable state.",
+        "mobileTitle": "Durable state for long runs.",
         "body": "Runs should keep their history, progress, and handoff point even when a tab closes, a worker moves, or execution is reprovisioned.",
         "diagram": {
           "railLabel": "run timeline",

--- a/typescript/apps/azents-site/messages/fr-FR.json
+++ b/typescript/apps/azents-site/messages/fr-FR.json
@@ -94,6 +94,7 @@
         "imageAlt": "Diagramme d'architecture abstrait montrant une session loop durable séparée de l'exécution Runtime.",
         "eyebrow": "01 / session loop",
         "title": "Une session loop indépendante, découplée du Runtime.",
+        "mobileTitle": "Une session loop indépendante.",
         "body": "L'Engine possède la boucle agent et les événements durables. Le Runtime est appelé seulement pour les files, tools, shell ou compute.",
         "diagram": {
           "sessionLabel": "durable session",
@@ -113,6 +114,7 @@
         "imageAlt": "Diagramme d'architecture abstrait montrant un runtime adapter connecté à plusieurs providers.",
         "eyebrow": "02 / runtime adapter",
         "title": "Les providers restent derrière un seul Runtime adapter.",
+        "mobileTitle": "Un adapter, plusieurs providers.",
         "body": "Kubernetes arrive en premier. La même forme d'adapter peut ensuite viser une machine locale, E2B ou des backends custom.",
         "diagram": {
           "adapterLabel": "stable interface",
@@ -132,6 +134,7 @@
         "imageAlt": "Diagramme d'architecture abstrait montrant une timeline de long-running agent avec état durable et handoff.",
         "eyebrow": "03 / long-running agent",
         "title": "Un long-running agent a besoin d'un état durable.",
+        "mobileTitle": "État durable pour les longs runs.",
         "body": "Un run doit garder son historique, sa progression et son point de reprise même si l'onglet se ferme, qu'un worker bouge ou que l'exécution est reprovisionnée.",
         "diagram": {
           "railLabel": "run timeline",

--- a/typescript/apps/azents-site/messages/ja-JP.json
+++ b/typescript/apps/azents-site/messages/ja-JP.json
@@ -94,6 +94,7 @@
         "imageAlt": "Durable session loop と Runtime 実行境界の分離を示す抽象 architecture diagram。",
         "eyebrow": "01 / session loop",
         "title": "Runtime execution から decouple された独立 session loop。",
+        "mobileTitle": "独立した session loop。",
         "body": "Engine が agent loop と durable events を扱い、Runtime は files、tools、shell、compute が必要なときだけ呼び出されます。",
         "diagram": {
           "sessionLabel": "durable session",
@@ -113,6 +114,7 @@
         "imageAlt": "Runtime adapter が複数の provider backend へ分岐する様子を示す抽象 architecture diagram。",
         "eyebrow": "02 / runtime adapter",
         "title": "Provider はひとつの Runtime adapter の後ろに置きます。",
+        "mobileTitle": "ひとつの adapter、複数の provider。",
         "body": "まずは Kubernetes からです。同じ adapter 形状で local machine、E2B、custom backend へ広げられるようにします。",
         "diagram": {
           "adapterLabel": "stable interface",
@@ -132,6 +134,7 @@
         "imageAlt": "Long-running agent の timeline、durable state、handoff を示す抽象 architecture diagram。",
         "eyebrow": "03 / long-running agent",
         "title": "Long-running agent には durable state が必要です。",
+        "mobileTitle": "長い run に durable state を。",
         "body": "Tab が閉じても、worker が移っても、実行環境が再作成されても、history、progress、handoff point は残るべきです。",
         "diagram": {
           "railLabel": "run timeline",

--- a/typescript/apps/azents-site/messages/ko-KR.json
+++ b/typescript/apps/azents-site/messages/ko-KR.json
@@ -94,6 +94,7 @@
         "imageAlt": "Durable session loop와 Runtime 실행 경계가 분리된 구조를 보여주는 추상 architecture diagram.",
         "eyebrow": "01 / session loop",
         "title": "Runtime 실행과 분리된 독립 session loop.",
+        "mobileTitle": "독립적인 session loop.",
         "body": "Engine이 agent loop와 durable event를 맡고, Runtime은 파일, 도구, shell, compute가 필요할 때 호출됩니다.",
         "diagram": {
           "sessionLabel": "durable session",
@@ -113,6 +114,7 @@
         "imageAlt": "Runtime adapter가 여러 provider backend로 연결되는 구조를 보여주는 추상 architecture diagram.",
         "eyebrow": "02 / runtime adapter",
         "title": "Provider는 하나의 Runtime adapter 뒤에 둡니다.",
+        "mobileTitle": "하나의 adapter, 여러 provider.",
         "body": "지금은 Kubernetes가 먼저입니다. 같은 adapter 형태로 local machine, E2B, custom backend까지 확장할 수 있게 가져갑니다.",
         "diagram": {
           "adapterLabel": "stable interface",
@@ -132,6 +134,7 @@
         "imageAlt": "Long-running agent의 timeline, durable state, handoff를 보여주는 추상 architecture diagram.",
         "eyebrow": "03 / long-running agent",
         "title": "Long-running agent에는 durable state가 필요합니다.",
+        "mobileTitle": "긴 run을 위한 durable state.",
         "body": "탭이 닫히거나, worker가 바뀌거나, 실행 환경이 다시 잡혀도 history, progress, handoff point는 남아야 합니다.",
         "diagram": {
           "railLabel": "run timeline",

--- a/typescript/apps/azents-site/src/features/home/components/ArchitectureDeepDiveSection.module.css
+++ b/typescript/apps/azents-site/src/features/home/components/ArchitectureDeepDiveSection.module.css
@@ -4,8 +4,20 @@
   color: var(--mantine-color-dark-0);
 }
 
+.mobileTitle {
+  display: none;
+}
+
 @media (max-width: 48em) {
   .controls {
     display: none;
+  }
+
+  .desktopTitle {
+    display: none;
+  }
+
+  .mobileTitle {
+    display: inline;
   }
 }

--- a/typescript/apps/azents-site/src/features/home/components/ArchitectureDeepDiveSection.tsx
+++ b/typescript/apps/azents-site/src/features/home/components/ArchitectureDeepDiveSection.tsx
@@ -100,7 +100,12 @@ function ArchitectureSlide({
               {t(`slides.${slideId}.eyebrow`)}
             </Text>
             <Title fz={{ base: rem(28), md: rem(40) }} lh={1.1} order={3}>
-              {t(`slides.${slideId}.title`)}
+              <span className={classes.desktopTitle}>
+                {t(`slides.${slideId}.title`)}
+              </span>
+              <span className={classes.mobileTitle}>
+                {t(`slides.${slideId}.mobileTitle`)}
+              </span>
             </Title>
             <Text c="dimmed" lh={1.65} size="lg">
               {t(`slides.${slideId}.body`)}


### PR DESCRIPTION
## Summary
- Add mobile-only short titles for architecture carousel slides across locales
- Keep the fuller desktop titles unchanged
- Swap title text by breakpoint in the carousel component

## Validation
- pnpm --filter @azents/site format
- pnpm --filter @azents/site typecheck
- pnpm --filter @azents/site lint
- git diff --check

Note: local `pnpm --filter @azents/site build` was started but cancelled after the Next build phase stayed silent for several minutes; GitHub CI will be the build gate.