### PR TITLE
Fix runtime provider startup heartbeat expiry

### DIFF
--- a/python/libs/azents-runtime-control/src/azents_runtime_control/provider.py
+++ b/python/libs/azents-runtime-control/src/azents_runtime_control/provider.py
@@ -271,6 +271,11 @@ class ProviderRunLoop:
             registered_at=self._clock(),
         )
         self._accepted = accepted
+        # Refresh the connection before the potentially slow backend resync.
+        # The Control registration TTL starts when register_provider completes,
+        # so delaying the first heartbeat until after observe_known_runtimes can
+        # let a slow Kubernetes API scan expire an otherwise healthy Provider.
+        await self.heartbeat(force=True)
         reports = await self._lifecycle.observe_known_runtimes()
         _LOGGER.info(
             "Runtime Provider registered",
@@ -283,7 +288,6 @@ class ProviderRunLoop:
         )
         for report in reports:
             await self._client.report_provider_state(report)
-        await self.heartbeat(force=True)
         return accepted
 
     async def heartbeat(self, *, force: bool = False) -> bool:

--- a/python/libs/azents-runtime-control/tests/provider_test.py
+++ b/python/libs/azents-runtime-control/tests/provider_test.py
@@ -95,6 +95,7 @@ class FakeLifecycle(RuntimeProviderLifecycle):
 
     known_reports: Sequence[RuntimeProviderReport] = ()
     fail_with: Exception | None = None
+    fail_on_observe_known: Exception | None = None
     commands: list[RuntimeLifecycleCommand] = dataclasses.field(default_factory=list)
 
     async def start(self, command: RuntimeLifecycleCommand) -> RuntimeLifecycleResult:
@@ -120,6 +121,8 @@ class FakeLifecycle(RuntimeProviderLifecycle):
 
     async def observe_known_runtimes(self) -> Sequence[RuntimeProviderReport]:
         """Return known fake Runtime reports."""
+        if self.fail_on_observe_known is not None:
+            raise self.fail_on_observe_known
         return self.known_reports
 
     async def _result(
@@ -147,6 +150,19 @@ async def test_start_registers_heartbeats_and_reports_known_runtimes() -> None:
     assert accepted.generation == 11
     assert client.registrations[0].provider_id == "provider-1"
     assert client.reports == [known]
+    assert client.heartbeats == [("provider-1", 11)]
+
+
+@pytest.mark.asyncio
+async def test_start_heartbeats_before_observing_known_runtimes() -> None:
+    """Provider registration TTL is refreshed before backend resynchronization."""
+    client = FakeControlClient()
+    lifecycle = FakeLifecycle(fail_on_observe_known=RuntimeError("backend scan failed"))
+    loop = _loop(client, lifecycle)
+
+    with pytest.raises(RuntimeError, match="backend scan failed"):
+        await loop.start()
+
     assert client.heartbeats == [("provider-1", 11)]
 
 


### PR DESCRIPTION
## Summary

- send the Provider heartbeat immediately after Control registration
- keep the registration alive while the Provider resynchronizes existing Kubernetes Runtimes
- add a regression test covering a failed or delayed initial backend resync

## Root cause

Provider startup registered the connection, performed the potentially slow `observe_known_runtimes()` backend scan, reported all discovered Runtimes, and only then sent its first heartbeat. The Control connection TTL starts at registration, so a delayed Kubernetes API resync could expire the Provider connection before the first heartbeat and cause the Provider Control stream to be rejected.

## Validation

- `uv run pytest` in `python/libs/azents-runtime-control` — 15 passed
- Ruff and pre-commit checks passed
