### PR TITLE
Fix provider resync generation fencing

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -31,7 +31,7 @@ _8 documents_
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-09 | 65 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-09 | 11 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-10 | 12 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Background Tool Call](spec/flow/background-tool-call.md) | @Hardtack | 2026-06-13 | 3 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-09 | 19 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -26,7 +26,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-09 | 65 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-09 | 11 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-10 | 12 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Background Tool Call](flow/background-tool-call.md) | @Hardtack | 2026-06-13 | 3 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-09 | 19 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -22,8 +22,8 @@ code_paths:
   - infra/charts/azents/**
   - infra/argocd/azents-runtime-provider-kubernetes/**
   - infra/argocd/azents-server/**
-last_verified_at: 2026-07-09
-spec_version: 11
+last_verified_at: 2026-07-10
+spec_version: 12
 ---
 
 # Agent Runtime Control
@@ -93,6 +93,8 @@ The store owns:
 - request claim cursors and stream metadata used to acknowledge delivered Provider/Runner requests
 
 Generation fencing is enforced before volatile stream messages mutate durable state. Control rejects or closes Provider/Runner streams whose inbound message generation differs from the accepted registration generation. Durable Provider reports are accepted only when both the Provider stream generation and observed desired generation are monotonic relative to the `agent_runtimes` row. Durable Runner state reports are accepted only when the Runner generation is not older than the row generation. Stale reports must not overwrite workspace path, observed state, runner availability, or current failure fields.
+
+Provider report framing always uses the generation accepted for the current Control stream. A Provider reconnect or leader failover may observe backend resources whose labels contain an older Provider generation; those labels are historical command metadata and must be replaced with the current connection generation before initial resync reports, watch reports, or command completion reports are sent to Control.
 
 Provider and Runner request streams use explicit claim/ack delivery. Control returns each claimed request with the stream cursor and consumer-group metadata needed to acknowledge the request only after it has been sent on the matching gRPC stream. Unacknowledged requests may be reclaimed after an idle interval so a Control replica crash or stream interruption does not strand in-flight Provider/Runner work.
 
@@ -196,6 +198,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-10** (spec_version 12) — Required Provider-side report generation rebasing after reconnect or leader failover so historical backend labels cannot close the current Control stream.
 - **2026-07-09** (spec_version 11) — Added generation-fenced connection heartbeat/revoke semantics and stale Runner stream-close handling.
 - **2026-07-09** (spec_version 10) — Added Provider/Runner request claim/ack/reclaim semantics, operation metadata deadline buffering, and background completion context propagation.
 - **2026-07-09** (spec_version 9) — Added monotonic Provider/Runner generation fencing for stream messages and durable Runtime state updates.

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
@@ -155,7 +155,7 @@ async def _run_control_loop(
             watch_task = asyncio.create_task(
                 _report_pod_watch_events(
                     lifecycle,
-                    control_client,
+                    run_loop,
                     stop=stop,
                 ),
                 name="runtime-provider-pod-watch",
@@ -201,7 +201,7 @@ async def _run_control_loop(
 
 async def _report_pod_watch_events(
     lifecycle: KubernetesRuntimeControlAdapter,
-    control_client: GrpcProviderControlClient,
+    run_loop: ProviderRunLoop,
     *,
     stop: asyncio.Event,
 ) -> None:
@@ -209,18 +209,18 @@ async def _report_pod_watch_events(
     while not stop.is_set():
         try:
             async for report in lifecycle.watch_known_runtimes():
-                await control_client.report_provider_state(report)
+                current_report = await run_loop.report_provider_state(report)
                 _LOGGER.info(
                     "Runtime Provider watch report sent",
                     extra={
-                        "provider_id": report.provider_id,
-                        "runtime_id": report.runtime_id,
-                        "provider_generation": report.provider_generation,
-                        "observed_state": report.observed_state.value,
+                        "provider_id": current_report.provider_id,
+                        "runtime_id": current_report.runtime_id,
+                        "provider_generation": current_report.provider_generation,
+                        "observed_state": current_report.observed_state.value,
                         "observed_desired_generation": (
-                            report.observed_desired_generation
+                            current_report.observed_desired_generation
                         ),
-                        "reason": report.reason,
+                        "reason": current_report.reason,
                     },
                 )
                 if stop.is_set():

--- a/python/libs/azents-runtime-control/src/azents_runtime_control/provider.py
+++ b/python/libs/azents-runtime-control/src/azents_runtime_control/provider.py
@@ -287,8 +287,21 @@ class ProviderRunLoop:
             },
         )
         for report in reports:
-            await self._client.report_provider_state(report)
+            await self.report_provider_state(report)
         return accepted
+
+    async def report_provider_state(
+        self,
+        report: RuntimeProviderReport,
+    ) -> RuntimeProviderReport:
+        """Send backend state under the current Provider connection generation."""
+        accepted = self._require_accepted()
+        current_report = dataclasses.replace(
+            report,
+            provider_generation=accepted.generation,
+        )
+        await self._client.report_provider_state(current_report)
+        return current_report
 
     async def heartbeat(self, *, force: bool = False) -> bool:
         """Send a heartbeat when due and reject stale generations explicitly."""
@@ -360,9 +373,17 @@ class ProviderRunLoop:
             )
             return completion
         completion = await self._execute_command(envelope, accepted.generation)
+        if completion.report is not None:
+            completion = dataclasses.replace(
+                completion,
+                report=dataclasses.replace(
+                    completion.report,
+                    provider_generation=accepted.generation,
+                ),
+            )
         await self._client.complete_provider_command(completion)
         if completion.report is not None:
-            await self._client.report_provider_state(completion.report)
+            await self.report_provider_state(completion.report)
         _LOGGER.info(
             "Runtime Provider command finished provider_id=%s provider_generation=%s "
             "request_id=%s command=%s resource=runtime/%s desired_generation=%s "

--- a/python/libs/azents-runtime-control/tests/provider_test.py
+++ b/python/libs/azents-runtime-control/tests/provider_test.py
@@ -141,7 +141,10 @@ class FakeLifecycle(RuntimeProviderLifecycle):
 @pytest.mark.asyncio
 async def test_start_registers_heartbeats_and_reports_known_runtimes() -> None:
     client = FakeControlClient()
-    known = _report(_command(RuntimeLifecycleCommandType.OBSERVE))
+    known = dataclasses.replace(
+        _report(_command(RuntimeLifecycleCommandType.OBSERVE)),
+        provider_generation=7,
+    )
     lifecycle = FakeLifecycle(known_reports=(known,))
     loop = _loop(client, lifecycle)
 
@@ -149,7 +152,7 @@ async def test_start_registers_heartbeats_and_reports_known_runtimes() -> None:
 
     assert accepted.generation == 11
     assert client.registrations[0].provider_id == "provider-1"
-    assert client.reports == [known]
+    assert client.reports == [dataclasses.replace(known, provider_generation=11)]
     assert client.heartbeats == [("provider-1", 11)]
 
 
@@ -167,10 +170,30 @@ async def test_start_heartbeats_before_observing_known_runtimes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_report_provider_state_uses_current_connection_generation() -> None:
+    """Backend resource labels cannot fence reports after Provider reconnect."""
+    client = FakeControlClient()
+    loop = _loop(client, FakeLifecycle())
+    await loop.start()
+    stale_report = dataclasses.replace(
+        _report(_command(RuntimeLifecycleCommandType.OBSERVE)),
+        provider_generation=7,
+    )
+
+    current_report = await loop.report_provider_state(stale_report)
+
+    assert current_report.provider_generation == 11
+    assert client.reports == [current_report]
+
+
+@pytest.mark.asyncio
 async def test_process_next_command_dispatches_and_completes_success() -> None:
     client = FakeControlClient()
     lifecycle = FakeLifecycle()
-    command = _command(RuntimeLifecycleCommandType.START)
+    command = dataclasses.replace(
+        _command(RuntimeLifecycleCommandType.START),
+        provider_generation=7,
+    )
     client.commands.append(ProviderCommandEnvelope(request_id="req-1", command=command))
     loop = _loop(client, lifecycle)
     await loop.start()
@@ -180,6 +203,7 @@ async def test_process_next_command_dispatches_and_completes_success() -> None:
     assert completion is not None
     assert completion.success
     assert completion.report is not None
+    assert completion.report.provider_generation == 11
     assert completion.report.workspace_path == "/workspace/agent"
     assert lifecycle.commands == [command]
     assert client.completions == [completion]


### PR DESCRIPTION
## Summary

- rebase Provider reports onto the generation accepted for the current Control stream
- apply the same rule to startup resync reports, watch reports, and command completions
- document the reconnect/failover generation contract

## Root cause

After a Provider reconnect or leader failover, Kubernetes backend resources still contain the Provider generation that created them. Startup resync and watch reports copied that historical label into the current gRPC stream. Control correctly rejected the report because its generation differed from the newly accepted stream generation, closed the Provider stream, and left lifecycle commands unconsumed. Existing Runtimes then remained without a Runner route, so stop requests appeared inert and runtime tools failed with `Runner operation route unavailable`.

## Validation

- `python/libs/azents-runtime-control`: 16 tests passed, Ruff and Pyright passed
- `python/apps/azents-runtime-provider-kubernetes`: 38 tests passed, Ruff and Pyright passed
- docs index and diff checks passed
- reproduced in Home cluster: historical PVC generation `5304` was sent on current Provider generation `10004`, immediately closing the stream
