### PR TITLE
Fix runtime pod reuse after Kubernetes defaults

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -31,7 +31,7 @@ _8 documents_
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-09 | 65 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-10 | 12 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-10 | 13 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Background Tool Call](spec/flow/background-tool-call.md) | @Hardtack | 2026-06-13 | 3 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-09 | 19 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -26,7 +26,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-09 | 65 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-10 | 12 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-10 | 13 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Background Tool Call](flow/background-tool-call.md) | @Hardtack | 2026-06-13 | 3 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-09 | 19 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -23,7 +23,7 @@ code_paths:
   - infra/argocd/azents-runtime-provider-kubernetes/**
   - infra/argocd/azents-server/**
 last_verified_at: 2026-07-10
-spec_version: 12
+spec_version: 13
 ---
 
 # Agent Runtime Control
@@ -122,6 +122,8 @@ Provider is lifecycle-only. It implements:
 
 Provider reports backend observed state and metadata. The Agent Workspace absolute path is provider metadata and is stored on `agent_runtimes.workspace_path`. Runner registration can validate that it mounted the same path, but Runner is not the authority for choosing the Agent Workspace path.
 
+Kubernetes Runtime Pod reuse compares Provider-managed configuration while allowing additive fields injected by Kubernetes admission and defaulting. In particular, configured tolerations must remain present, but built-in `NoExecute` tolerations added by Kubernetes do not make an otherwise reusable Pod stale or trigger replacement during repeated start reconciliation.
+
 If Provider is disconnected or reports no workspace path for a Runtime that needs workspace access, Control records an explicit failure/unavailable state. It must not invent a fallback path. `PROVIDER_WORKSPACE_PATH_MISSING` is the explicit error for a missing provider path.
 
 Kubernetes and Docker Providers are external components. They must not import Azents server modules, DB sessions, repositories, or in-process managers. They communicate with Control only via the runtime-control protocol and their backend APIs.
@@ -198,6 +200,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-10** (spec_version 13) — Allowed Kubernetes admission-defaulted tolerations during Runtime Pod reuse so repeated start reconciliation does not delete a healthy Pod.
 - **2026-07-10** (spec_version 12) — Required Provider-side report generation rebasing after reconnect or leader failover so historical backend labels cannot close the current Control stream.
 - **2026-07-09** (spec_version 11) — Added generation-fenced connection heartbeat/revoke semantics and stale Runner stream-close handling.
 - **2026-07-09** (spec_version 10) — Added Provider/Runner request claim/ack/reclaim semantics, operation metadata deadline buffering, and background completion context propagation.

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -343,7 +343,7 @@ class KubernetesRuntimeProvider:
             return False
         if dict(pod.spec.node_selector) != dict(self._config.pod_node_selector):
             return False
-        if tuple(pod.spec.tolerations) != self._config.pod_tolerations:
+        if not set(self._config.pod_tolerations).issubset(set(pod.spec.tolerations)):
             return False
         env = {item.name: item.value for item in container.env}
         for key, value in self._stable_env(command).items():

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -312,6 +312,60 @@ async def test_start_preserves_generic_runner_resource_requirements() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_reuses_pod_with_kubernetes_default_tolerations() -> None:
+    """Admission-added tolerations do not make an existing Runtime Pod stale."""
+    api = FakeKubernetesApi()
+    configured_toleration = Toleration(
+        key="runtime",
+        operator="Equal",
+        value="azents",
+        effect="NoSchedule",
+    )
+    provider = KubernetesRuntimeProvider(
+        api,
+        KubernetesRuntimeProviderConfig(
+            provider_id="system-kubernetes",
+            namespace="azents-runtime",
+            storage_class_name="gp3",
+            pvc_storage_request="20Gi",
+            runner_resources=None,
+            pod_tolerations=(configured_toleration,),
+        ),
+    )
+    command = _command(RuntimeLifecycleCommandType.START)
+    await provider.start(command)
+    pod_key = ("azents-runtime", "azents-runtime-runtime-1")
+    pod = api.pods[pod_key]
+    default_tolerations = (
+        Toleration(
+            key="node.kubernetes.io/not-ready",
+            operator="Exists",
+            effect="NoExecute",
+        ),
+        Toleration(
+            key="node.kubernetes.io/unreachable",
+            operator="Exists",
+            effect="NoExecute",
+        ),
+    )
+    api.pods[pod_key] = dataclasses.replace(
+        pod,
+        spec=dataclasses.replace(
+            pod.spec,
+            tolerations=(configured_toleration, *default_tolerations),
+        ),
+    )
+
+    await provider.start(command)
+
+    assert api.deleted_pods == []
+    assert tuple(api.pods[pod_key].spec.tolerations) == (
+        configured_toleration,
+        *default_tolerations,
+    )
+
+
+@pytest.mark.asyncio
 async def test_runtime_control_adapter_reports_provider_workspace_path() -> None:
     api = FakeKubernetesApi()
     provider = _provider(api)


### PR DESCRIPTION
## Summary

- allow additive tolerations injected by Kubernetes when deciding whether a Runtime Pod is reusable
- continue requiring every Provider-configured toleration to remain present
- add a regression test covering the built-in `not-ready` and `unreachable` `NoExecute` tolerations

## Root cause

Kubernetes automatically adds `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` tolerations to Pods. The Provider compared the complete observed toleration tuple with its configured tuple, so every live Runtime Pod appeared stale after admission. Repeated start reconciliation deleted the Pod while its Runner image was still pulling, causing the Runner to register briefly and then disappear. Runtime tools then failed with `Runner operation route unavailable`.

## Validation

- `python/apps/azents-runtime-provider-kubernetes`: 39 tests passed
- Ruff and Pyright passed
- docs index and pre-commit checks passed
- reproduced in Home cluster: a generation-198 Pod was killed immediately after Runner generation 322 registered because the observed Pod contained the two Kubernetes default tolerations
