### PR TITLE
fix(engine): shorten database session scopes

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -30,7 +30,7 @@ _8 documents_
 
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
-| [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-14 | 81 |
+| [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 82 |
 | [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-12 | 17 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-14 | 29 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -25,7 +25,7 @@ Details of all living specs. Synchronized from frontmatter.
 
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
-| [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-14 | 81 |
+| [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 82 |
 | [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-12 | 17 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-14 | 29 |

--- a/docs/azents/spec/flow/agent-execution-loop.md
+++ b/docs/azents/spec/flow/agent-execution-loop.md
@@ -16,6 +16,7 @@ code_paths:
   - python/apps/azents/src/azents/engine/events/**
   - python/apps/azents/src/azents/engine/hooks/**
   - python/apps/azents/src/azents/engine/run/deps.py
+  - python/apps/azents/src/azents/engine/run/resolve.py
   - python/apps/azents/src/azents/api/public/chat/v1/**
   - python/apps/azents/src/azents/core/config.py
   - python/apps/azents/src/azents/core/inference_profile.py
@@ -40,8 +41,8 @@ code_paths:
   - python/apps/azents/src/azents/worker/session/**
   - typescript/apps/azents-web/src/features/chat/components/ChatView.tsx
   - typescript/apps/azents-web/src/features/chat/containers/useChatSessionContainer.ts
-last_verified_at: 2026-07-14
-spec_version: 81
+last_verified_at: 2026-07-15
+spec_version: 82
 ---
 
 # Agent Execution Loop
@@ -576,6 +577,21 @@ Primary checks:
 - **2026-07-06** — v59. Removed the session-initialization run gate and documented terminal `action_execution_result` history events.
 - **2026-07-05** — v56. Reflected operation TurnAction processing before model dispatch and Project context invalidation after worktree setup.
 
+## Database session boundaries
+
+Run execution uses short database sessions around one durable read or state transition. Model
+preparation callbacks, model streaming, runtime hooks, foreground tools, Toolkit provider resolution,
+OAuth token HTTP requests, broker calls, and live event publication run only after the preceding
+database session has closed. Boundary input polling also completes its external queue read before it
+opens the short session that appends promoted messages.
+
+Row locks remain limited to persistence invariants. Tool-result finalization locks its `AgentRun`
+while appending the deterministic result and removing that call from `active_tool_calls`, so parallel
+tool completions cannot overwrite each other. MCP OAuth refresh reads a credential snapshot, closes
+the session, performs the provider request, then briefly locks and re-reads the row before applying
+the result. If another refresh committed first, the newer credentials win; a stale success or failure
+must not overwrite them. No database row lock or transaction spans external I/O.
+
 ## Idle continuation
 
 Idle transition is allowed only at a terminal run boundary. `AgentSession.run_state` may become `idle` only
@@ -642,6 +658,8 @@ updated by the user.
 
 ## Changelog
 
+- **2026-07-15** (spec_version 82) — Required short run-owned database sessions, external-I/O
+  separation, and lock/revalidation boundaries for tool finalization and MCP OAuth refresh.
 - **2026-07-14** (spec_version 81) — Added durable per-model-call start time to live Run projections and a once-per-second duration beside the LLM indicator after ten elapsed seconds.
 - **2026-07-14** (spec_version 80) — Restored incremental native-stream normalization and bounded live partial batching: text and reasoning are projected before provider completion, durable output remains completion-based, and user stop preserves valid partial assistant text without admitting incomplete tools.
 - **2026-07-14** (spec_version 79) — Defined operation TurnActions as owner-generation-fenced live execution state with atomic terminal snapshot/delete handover, 30-second shutdown completion, preemptive user-stop cancellation, and no stale-owner re-execution.

--- a/python/apps/azents/src/azents/core/tools.py
+++ b/python/apps/azents/src/azents/core/tools.py
@@ -177,7 +177,8 @@ class ResolveContext:
     :param agent_id: Agent ID owning the current AgentSession
     :param session_id: Current AgentSession ID
     :param user_id: User ID; None for system context
-    :param session: DB session
+    :param session: Optional caller-owned DB session. Run-time Toolkit resolution
+        passes None so providers cannot retain a snapshot transaction across I/O.
     :param web_url: Frontend URL for building OAuth redirect_uri
     :param oauth_secret_key: OAuth HMAC signing key
     :param workspace_id: Workspace ID
@@ -191,7 +192,7 @@ class ResolveContext:
     agent_id: str
     session_id: str
     user_id: str | None
-    session: AsyncSession
+    session: AsyncSession | None
     web_url: str
     oauth_secret_key: str
     workspace_id: str

--- a/python/apps/azents/src/azents/engine/events/engine_adapter.py
+++ b/python/apps/azents/src/azents/engine/events/engine_adapter.py
@@ -133,7 +133,6 @@ class RunExecution(Protocol):
 
     async def run(
         self,
-        session: AsyncSession,
         request: AgentRunExecutionRequest,
         *,
         check_stop: CheckStop | None = None,
@@ -438,29 +437,28 @@ class AgentEngineAdapter:
             [
                 EventAttachmentAvailabilityFilter(),
                 EventFilePartPlaceholderFilter(session_id=request.session_id),
-                EventAutoCompactionFilter(
-                    session_id=request.session_id,
-                    compactor=self.compactor,
-                    summarize=_event_summary_generator(
-                        request,
-                        summarize=self.summary_model_call,
-                    ),
-                    max_input_tokens=request.effective_max_input_tokens,
-                    auto_compaction_threshold_tokens=(
-                        request.auto_compaction_threshold_tokens
-                    ),
-                    compaction_id_factory=lambda: uuid7().hex,
-                    on_compaction_started=on_auto_compaction_started,
-                    summary_enricher=_compaction_summary_enricher(
-                        request,
-                        dispatcher=hook_dispatcher,
-                        providers=run_hook_providers,
-                        run_id=context.run_id,
-                    ),
-                ),
             ]
         )
+        auto_compaction_filter = EventAutoCompactionFilter(
+            session_id=request.session_id,
+            compactor=self.compactor,
+            summarize=_event_summary_generator(
+                request,
+                summarize=self.summary_model_call,
+            ),
+            max_input_tokens=request.effective_max_input_tokens,
+            auto_compaction_threshold_tokens=request.auto_compaction_threshold_tokens,
+            compaction_id_factory=lambda: uuid7().hex,
+            on_compaction_started=on_auto_compaction_started,
+            summary_enricher=_compaction_summary_enricher(
+                request,
+                dispatcher=hook_dispatcher,
+                providers=run_hook_providers,
+                run_id=context.run_id,
+            ),
+        )
         execution = self.execution_factory(
+            session_manager=self.session_manager,
             post_lower_filter=PostLowerFilterPipeline(
                 [
                     NativeRequestSizeGuard(
@@ -474,6 +472,7 @@ class AgentEngineAdapter:
                 model=request.model,
             ),
             pre_lower_filter=pre_lower_filter,
+            auto_compaction_filter=auto_compaction_filter,
             model_call_preparer=prepare_model_call,
             output_sink=emit_queue.extend_from_output,
             phase_sink=lambda phase, model_call_started_at: _emit_phase_change(
@@ -481,7 +480,7 @@ class AgentEngineAdapter:
                 run_id=context.run_id,
                 phase=phase,
                 model_call_started_at=model_call_started_at,
-                pre_lower_filter=pre_lower_filter,
+                pre_lower_filter=auto_compaction_filter,
             ),
             pre_model_lower_hook=model_file_materializer.materialize,
             model_file_pin_repo=self.model_file_pin_repo,
@@ -491,24 +490,23 @@ class AgentEngineAdapter:
         )
 
         async def execute_run() -> AgentRunStatus:
-            async with self.session_manager() as session:
-                return await execution.run(
-                    session,
-                    AgentRunExecutionRequest(
-                        run_id=context.run_id,
-                        session_id=request.session_id,
-                        owner_generation=context.owner_generation,
-                        tool_admission_barrier=context.tool_admission_barrier,
-                        run_index=run_state.run_index,
-                        model=request.model,
-                        max_turns=request.max_turns,
-                    ),
-                    check_stop=check_stop,
-                    poll_input_events=_make_input_poller(
-                        poll_messages,
-                        transcript_repo=self.transcript_repo,
-                    ),
-                )
+            return await execution.run(
+                AgentRunExecutionRequest(
+                    run_id=context.run_id,
+                    session_id=request.session_id,
+                    owner_generation=context.owner_generation,
+                    tool_admission_barrier=context.tool_admission_barrier,
+                    run_index=run_state.run_index,
+                    model=request.model,
+                    max_turns=request.max_turns,
+                ),
+                check_stop=check_stop,
+                poll_input_events=_make_input_poller(
+                    poll_messages,
+                    session_manager=self.session_manager,
+                    transcript_repo=self.transcript_repo,
+                ),
+            )
 
         run_task = asyncio.create_task(execute_run())
         cancel_args: tuple[object, ...] | None = None
@@ -584,7 +582,7 @@ async def _emit_phase_change(
     run_id: str,
     phase: AgentRunPhase,
     model_call_started_at: datetime.datetime | None,
-    pre_lower_filter: EventPreLowerFilterPipeline,
+    pre_lower_filter: EventAutoCompactionFilter,
 ) -> None:
     """Reflect run phase and auto compaction lifecycle in legacy stream."""
     if phase == AgentRunPhase.PREPARING_INPUT:
@@ -715,14 +713,14 @@ def _provider_name(provider: LLMProvider) -> str:
 def _make_input_poller(
     poll_messages: PollMessages | None,
     *,
+    session_manager: SessionManager[AsyncSession],
     transcript_repo: TranscriptRepository,
-) -> Callable[[AsyncSession, str], Awaitable[InputPollResult]] | None:
+) -> Callable[[str], Awaitable[InputPollResult]] | None:
     """Convert boundary poll to event transcript append callback."""
     if poll_messages is None:
         return None
 
     async def poll(
-        session: AsyncSession,
         session_id: str,
     ) -> InputPollResult:
         result = await poll_messages()
@@ -732,12 +730,13 @@ def _make_input_poller(
                 context_invalidated=result.context_invalidated,
                 complete_run=result.complete_run,
             )
-        events = await _append_run_user_messages(
-            session,
-            session_id,
-            result.user_messages,
-            transcript_repo=transcript_repo,
-        )
+        async with session_manager() as session:
+            events = await _append_run_user_messages(
+                session,
+                session_id,
+                result.user_messages,
+                transcript_repo=transcript_repo,
+            )
         return InputPollResult(
             events=events,
             context_invalidated=result.context_invalidated,

--- a/python/apps/azents/src/azents/engine/events/engine_adapter_test.py
+++ b/python/apps/azents/src/azents/engine/events/engine_adapter_test.py
@@ -37,6 +37,7 @@ from azents.engine.events.execution import (
     PreparedModelCall,
 )
 from azents.engine.events.filters import (
+    EventAutoCompactionFilter,
     EventPreLowerFilterPipeline,
     PostLowerFilterPipeline,
 )
@@ -415,14 +416,13 @@ class _Execution:
 
     async def run(
         self,
-        session: AsyncSession,
         request: AgentRunExecutionRequest,
         *,
         check_stop: CheckStop | None = None,
         poll_input_events: object = None,
     ) -> AgentRunStatus:
         """Record run request and prepare a model call when wired."""
-        del session, check_stop, poll_input_events
+        del check_stop, poll_input_events
         self.request = request
         if self.model_call_preparer is not None:
             self.prepared_model_call = await self.model_call_preparer(
@@ -437,14 +437,13 @@ class _FailingExecution:
 
     async def run(
         self,
-        session: AsyncSession,
         request: AgentRunExecutionRequest,
         *,
         check_stop: CheckStop | None = None,
         poll_input_events: object = None,
     ) -> AgentRunStatus:
         """Propagate ModelCallError."""
-        del session, request, check_stop, poll_input_events
+        del request, check_stop, poll_input_events
         raise ModelCallError("Model call failed (401): Missing scopes")
 
 
@@ -459,14 +458,13 @@ class _StreamingExecution:
 
     async def run(
         self,
-        session: AsyncSession,
         request: AgentRunExecutionRequest,
         *,
         check_stop: CheckStop | None = None,
         poll_input_events: object = None,
     ) -> AgentRunStatus:
         """Send tool call output to sink first, then wait for completion signal."""
-        del session, request, check_stop, poll_input_events
+        del request, check_stop, poll_input_events
         event = Event(
             id="1" * 32,
             session_id="session-1",
@@ -1006,13 +1004,14 @@ async def test_adapter_wires_event_filters_and_session_head_repo() -> None:
     ]
 
     pre_lower_filter = captured["pre_lower_filter"]
+    auto_compaction_filter = captured["auto_compaction_filter"]
     post_lower_filter = captured["post_lower_filter"]
     assert isinstance(pre_lower_filter, EventPreLowerFilterPipeline)
+    assert isinstance(auto_compaction_filter, EventAutoCompactionFilter)
     assert isinstance(post_lower_filter, PostLowerFilterPipeline)
     assert [item.__class__.__name__ for item in pre_lower_filter.filters] == [
         "EventAttachmentAvailabilityFilter",
         "EventFilePartPlaceholderFilter",
-        "EventAutoCompactionFilter",
     ]
     assert [item.__class__.__name__ for item in post_lower_filter.filters] == [
         "NativeRequestSizeGuard",

--- a/python/apps/azents/src/azents/engine/events/execution.py
+++ b/python/apps/azents/src/azents/engine/events/execution.py
@@ -53,6 +53,7 @@ from azents.engine.run.errors import (
     UserVisibleRuntimeError,
 )
 from azents.engine.run.types import USER_STOP_CANCEL_MESSAGE
+from azents.rdb.session import SessionManager
 from azents.repos.agent_execution import (
     AgentRunRepository,
     EventTranscriptRepository,
@@ -75,7 +76,7 @@ class InputPollResult:
     complete_run: bool
 
 
-InputPoller = Callable[[AsyncSession, str], Awaitable[InputPollResult]]
+InputPoller = Callable[[str], Awaitable[InputPollResult]]
 TurnEndReason = Literal["completed", "error", "cancelled", "unknown"]
 TurnEndCallback = Callable[[TurnEndReason], Awaitable[None]]
 
@@ -113,6 +114,16 @@ class ModelCallPreparer(Protocol):
         model: str,
     ) -> PreparedModelCall:
         """Prepare one model-call turn."""
+        ...
+
+
+class AutoCompactionFilter(Protocol):
+    """Model-input compaction that owns its persistence sessions."""
+
+    was_compacted: bool
+
+    async def compact(self, transcript: Sequence[Event]) -> list[Event]:
+        """Compact model input outside a caller-owned DB session."""
         ...
 
 
@@ -174,11 +185,13 @@ class AgentRunExecution:
     def __init__(
         self,
         *,
+        session_manager: SessionManager[AsyncSession],
         post_lower_filter: PostLowerFilter,
         model_adapter: ModelAdapter,
         output_normalizer: AdapterOutputNormalizer,
         model_call_preparer: ModelCallPreparer,
         pre_lower_filter: PreLowerFilter | None = None,
+        auto_compaction_filter: AutoCompactionFilter | None = None,
         output_sink: OutputSink | None = None,
         phase_sink: PhaseSink | None = None,
         pre_model_lower_hook: PreModelLowerHook | None = None,
@@ -188,10 +201,12 @@ class AgentRunExecution:
         session_repo: SessionHeadRepository | None = None,
     ) -> None:
         """Inject loop dependencies."""
+        self._session_manager = session_manager
         self._post_lower_filter = post_lower_filter
         self._model_adapter = model_adapter
         self._output_normalizer = output_normalizer
         self._pre_lower_filter = pre_lower_filter
+        self._auto_compaction_filter = auto_compaction_filter
         self._model_call_preparer = model_call_preparer
         self._output_sink = output_sink
         self._phase_sink = phase_sink
@@ -203,7 +218,6 @@ class AgentRunExecution:
 
     async def run(
         self,
-        session: AsyncSession,
         request: AgentRunExecutionRequest,
         *,
         check_stop: CheckStop | None = None,
@@ -214,75 +228,85 @@ class AgentRunExecution:
             for _model_call_index in _turn_range(request.max_turns):
                 if await _stopped(check_stop):
                     if request.tool_admission_barrier.closed:
-                        await session.rollback()
                         return AgentRunStatus.RUNNING
-                    await self._mark_terminal(
-                        session,
-                        request.run_id,
-                        AgentRunStatus.INTERRUPTED,
-                    )
-                    await session.commit()
-                    return AgentRunStatus.INTERRUPTED
-
-                if poll_input_events is not None:
-                    poll_result = await poll_input_events(
-                        session,
-                        request.session_id,
-                    )
-                    if poll_result.complete_run:
+                    async with self._session_manager() as session:
                         await self._mark_terminal(
                             session,
                             request.run_id,
-                            AgentRunStatus.COMPLETED,
+                            AgentRunStatus.INTERRUPTED,
                         )
-                        await session.commit()
+                    return AgentRunStatus.INTERRUPTED
+
+                if poll_input_events is not None:
+                    poll_result = await poll_input_events(request.session_id)
+                    if poll_result.complete_run:
+                        async with self._session_manager() as session:
+                            await self._mark_terminal(
+                                session,
+                                request.run_id,
+                                AgentRunStatus.COMPLETED,
+                            )
                         return AgentRunStatus.COMPLETED
                     if poll_result.context_invalidated:
-                        await session.commit()
                         return AgentRunStatus.RUNNING
-                    if poll_result.events:
-                        await session.commit()
 
-                head_event_id = await self._model_input_head_event_id(
-                    session,
-                    request.session_id,
-                )
-                transcript = await self._transcript_repo.list_for_model_input(
-                    session,
-                    request.session_id,
-                    head_event_id=head_event_id,
-                )
-                repaired_events = await self._append_missing_tool_results(
-                    session,
-                    request,
-                    transcript,
-                )
-                if repaired_events:
-                    await session.commit()
+                async with self._session_manager() as session:
+                    head_event_id = await self._model_input_head_event_id(
+                        session,
+                        request.session_id,
+                    )
                     transcript = await self._transcript_repo.list_for_model_input(
                         session,
                         request.session_id,
                         head_event_id=head_event_id,
                     )
-                await self._update_phase(
-                    session,
-                    request.run_id,
-                    AgentRunPhase.PREPARING_INPUT,
-                )
-                compacted = False
-                if self._pre_lower_filter is not None:
-                    transcript = await self._pre_lower_filter.apply(session, transcript)
-                    compacted = self._pre_lower_filter.was_compacted
-                if compacted:
-                    await session.commit()
-                if self._model_file_pin_repo is not None:
-                    await self._model_file_pin_repo.pin_many(
+                    repaired_events = await self._append_missing_tool_results(
                         session,
-                        session_id=request.session_id,
-                        run_id=request.run_id,
-                        model_file_ids=unique_model_file_ids(transcript),
+                        request,
+                        transcript,
                     )
-                    await session.commit()
+                    if repaired_events:
+                        transcript = await self._transcript_repo.list_for_model_input(
+                            session,
+                            request.session_id,
+                            head_event_id=head_event_id,
+                        )
+                    model_call_started_at = await self._update_phase_in_session(
+                        session,
+                        request.run_id,
+                        AgentRunPhase.PREPARING_INPUT,
+                    )
+                    if self._pre_lower_filter is not None:
+                        transcript = await self._pre_lower_filter.apply(
+                            session, transcript
+                        )
+                if self._output_sink is not None:
+                    for repaired_event in repaired_events:
+                        await self._output_sink(
+                            NormalizedAdapterOutput(events=[]),
+                            [repaired_event],
+                        )
+                await self._publish_phase(
+                    AgentRunPhase.PREPARING_INPUT,
+                    model_call_started_at,
+                )
+
+                compacted = (
+                    self._pre_lower_filter.was_compacted
+                    if self._pre_lower_filter is not None
+                    else False
+                )
+                if self._auto_compaction_filter is not None:
+                    transcript = await self._auto_compaction_filter.compact(transcript)
+                    compacted = compacted or self._auto_compaction_filter.was_compacted
+                if self._model_file_pin_repo is not None:
+                    async with self._session_manager() as session:
+                        await self._model_file_pin_repo.pin_many(
+                            session,
+                            session_id=request.session_id,
+                            run_id=request.run_id,
+                            model_file_ids=unique_model_file_ids(transcript),
+                        )
                 if self._pre_model_lower_hook is not None:
                     await self._pre_model_lower_hook(transcript=transcript)
                 model_input_transcript = (
@@ -314,14 +338,11 @@ class AgentRunExecution:
                     )
 
                     await self._update_phase(
-                        session,
                         request.run_id,
                         AgentRunPhase.WAITING_FOR_MODEL,
                     )
-                    await session.commit()
                     try:
                         output_stream = await self._stream_model(
-                            session,
                             request.run_id,
                             request.session_id,
                             native_request,
@@ -329,13 +350,11 @@ class AgentRunExecution:
                     except _ModelStreamUserInterrupted as exc:
                         await finish_turn("cancelled")
                         return await self._complete_user_interrupted_model_stream(
-                            session,
                             request,
                             exc.normalized,
                         )
 
                     await self._update_phase(
-                        session,
                         request.run_id,
                         AgentRunPhase.NORMALIZING_OUTPUT,
                     )
@@ -346,7 +365,6 @@ class AgentRunExecution:
                     )
 
                     await self._update_phase(
-                        session,
                         request.run_id,
                         AgentRunPhase.APPENDING_EVENTS,
                     )
@@ -369,40 +387,49 @@ class AgentRunExecution:
                     ) -> None:
                         """Append output and admit its complete foreground call set."""
                         nonlocal appended, turn_marker
-                        appended = await self._append_events(
-                            session,
-                            normalized_output.events,
-                            tool_call_run_id=request.run_id,
-                        )
-                        turn_marker = await self._append_turn_marker(
-                            session,
-                            request.session_id,
-                            request.run_id,
-                            normalized_output.usage,
-                            inference_state=prepared_call.inference_state,
-                            system_prompt=prepared_call.system_prompt_analysis,
-                        )
-                        if tool_calls:
-                            await self._update_phase(
+                        model_call_started_at: datetime.datetime | None = None
+                        async with self._session_manager() as session:
+                            appended = await self._append_events(
                                 session,
-                                request.run_id,
-                                AgentRunPhase.EXECUTING_TOOLS,
-                                active_tool_calls=[
-                                    _active_tool_call(
-                                        call,
-                                        owner_generation=request.owner_generation,
-                                    )
-                                    for call in tool_calls
-                                ],
+                                normalized_output.events,
+                                tool_call_run_id=request.run_id,
                             )
-                        await session.commit()
+                            turn_marker = await self._append_turn_marker(
+                                session,
+                                request.session_id,
+                                request.run_id,
+                                normalized_output.usage,
+                                inference_state=prepared_call.inference_state,
+                                system_prompt=prepared_call.system_prompt_analysis,
+                            )
+                            if tool_calls:
+                                model_call_started_at = (
+                                    await self._update_phase_in_session(
+                                        session,
+                                        request.run_id,
+                                        AgentRunPhase.EXECUTING_TOOLS,
+                                        active_tool_calls=[
+                                            _active_tool_call(
+                                                call,
+                                                owner_generation=(
+                                                    request.owner_generation
+                                                ),
+                                            )
+                                            for call in tool_calls
+                                        ],
+                                    )
+                                )
+                        if tool_calls:
+                            await self._publish_phase(
+                                AgentRunPhase.EXECUTING_TOOLS,
+                                model_call_started_at,
+                            )
 
                     if normalized_tool_calls:
                         admitted = await request.tool_admission_barrier.run_if_open(
                             append_model_output
                         )
                         if not admitted:
-                            await session.rollback()
                             await finish_turn("cancelled")
                             return AgentRunStatus.RUNNING
                     else:
@@ -415,23 +442,23 @@ class AgentRunExecution:
                         if isinstance(event.payload, ClientToolCallPayload)
                     ]
                     if not client_tool_calls:
-                        run_marker = await self._append_run_marker(
-                            session,
-                            request.session_id,
-                            request.run_id,
-                            "completed",
-                        )
-                        terminal_event_id, terminal_message = (
-                            _terminal_result_from_events(appended)
-                        )
-                        await self._mark_terminal(
-                            session,
-                            request.run_id,
-                            AgentRunStatus.COMPLETED,
-                            terminal_result_event_id=terminal_event_id,
-                            terminal_result_message=terminal_message,
-                        )
-                        await session.commit()
+                        async with self._session_manager() as session:
+                            run_marker = await self._append_run_marker(
+                                session,
+                                request.session_id,
+                                request.run_id,
+                                "completed",
+                            )
+                            terminal_event_id, terminal_message = (
+                                _terminal_result_from_events(appended)
+                            )
+                            await self._mark_terminal(
+                                session,
+                                request.run_id,
+                                AgentRunStatus.COMPLETED,
+                                terminal_result_event_id=terminal_event_id,
+                                terminal_result_message=terminal_message,
+                            )
                         if self._output_sink is not None:
                             await self._output_sink(
                                 normalized,
@@ -444,38 +471,38 @@ class AgentRunExecution:
                         await self._output_sink(normalized, [*appended, *turn_events])
                     try:
                         await self._execute_tools(
-                            session,
                             request.run_id,
                             request.session_id,
                             client_tool_calls,
                             tool_executor=prepared.tool_executor,
                         )
                     except _ToolExecutionUserInterrupted:
-                        current_run = await self._run_repo.get_by_id(
-                            session,
-                            request.run_id,
-                        )
-                        if (
-                            current_run is not None
-                            and current_run.status == AgentRunStatus.RUNNING
-                        ):
-                            run_marker = await self._append_run_marker(
-                                session,
-                                request.session_id,
-                                request.run_id,
-                                "interrupted",
-                            )
-                            await self._mark_terminal(
+                        run_marker: Event | None = None
+                        async with self._session_manager() as session:
+                            current_run = await self._run_repo.get_by_id(
                                 session,
                                 request.run_id,
-                                AgentRunStatus.INTERRUPTED,
                             )
-                            await session.commit()
-                            if self._output_sink is not None:
-                                await self._output_sink(
-                                    NormalizedAdapterOutput(events=[]),
-                                    [run_marker],
+                            if (
+                                current_run is not None
+                                and current_run.status == AgentRunStatus.RUNNING
+                            ):
+                                run_marker = await self._append_run_marker(
+                                    session,
+                                    request.session_id,
+                                    request.run_id,
+                                    "interrupted",
                                 )
+                                await self._mark_terminal(
+                                    session,
+                                    request.run_id,
+                                    AgentRunStatus.INTERRUPTED,
+                                )
+                        if run_marker is not None and self._output_sink is not None:
+                            await self._output_sink(
+                                NormalizedAdapterOutput(events=[]),
+                                [run_marker],
+                            )
                         await finish_turn("cancelled")
                         return AgentRunStatus.INTERRUPTED
                     await finish_turn("completed")
@@ -487,14 +514,16 @@ class AgentRunExecution:
         except UserVisibleRuntimeError:
             raise
 
-        await self._append_run_marker(
-            session,
-            request.session_id,
-            request.run_id,
-            "interrupted",
-        )
-        await self._mark_terminal(session, request.run_id, AgentRunStatus.INTERRUPTED)
-        await session.commit()
+        async with self._session_manager() as session:
+            await self._append_run_marker(
+                session,
+                request.session_id,
+                request.run_id,
+                "interrupted",
+            )
+            await self._mark_terminal(
+                session, request.run_id, AgentRunStatus.INTERRUPTED
+            )
         return AgentRunStatus.INTERRUPTED
 
     async def _prepare_model_call(
@@ -511,18 +540,15 @@ class AgentRunExecution:
 
     async def _stream_model(
         self,
-        session: AsyncSession,
         run_id: str,
         session_id: str,
         native_request: NativeModelRequest,
     ) -> AdapterOutputStream:
         """Normalize and project model stream events as they arrive."""
         await self._update_phase(
-            session,
             run_id,
             AgentRunPhase.STREAMING_MODEL,
         )
-        await session.commit()
         output_stream = self._output_normalizer.start(session_id)
         try:
             async for event in self._model_adapter.stream(native_request):
@@ -537,13 +563,11 @@ class AgentRunExecution:
 
     async def _complete_user_interrupted_model_stream(
         self,
-        session: AsyncSession,
         request: AgentRunExecutionRequest,
         normalized: NormalizedAdapterOutput,
     ) -> AgentRunStatus:
         """Durabilize partial text from model stream interrupted by user stop."""
         await self._update_phase(
-            session,
             request.run_id,
             AgentRunPhase.APPENDING_EVENTS,
         )
@@ -554,22 +578,22 @@ class AgentRunExecution:
             and isinstance(event.payload, AssistantMessagePayload)
             and _assistant_content_is_non_empty(event.payload.content)
         ]
-        appended = await self._append_events(session, assistant_events)
-        run_marker = await self._append_run_marker(
-            session,
-            request.session_id,
-            request.run_id,
-            "interrupted",
-        )
-        terminal_event_id, terminal_message = _terminal_result_from_events(appended)
-        await self._mark_terminal(
-            session,
-            request.run_id,
-            AgentRunStatus.INTERRUPTED,
-            terminal_result_event_id=terminal_event_id,
-            terminal_result_message=terminal_message,
-        )
-        await session.commit()
+        async with self._session_manager() as session:
+            appended = await self._append_events(session, assistant_events)
+            run_marker = await self._append_run_marker(
+                session,
+                request.session_id,
+                request.run_id,
+                "interrupted",
+            )
+            terminal_event_id, terminal_message = _terminal_result_from_events(appended)
+            await self._mark_terminal(
+                session,
+                request.run_id,
+                AgentRunStatus.INTERRUPTED,
+                terminal_result_event_id=terminal_event_id,
+                terminal_result_message=terminal_message,
+            )
         if self._output_sink is not None:
             await self._output_sink(
                 NormalizedAdapterOutput(events=assistant_events),
@@ -618,7 +642,6 @@ class AgentRunExecution:
 
     async def _execute_tools(
         self,
-        session: AsyncSession,
         run_id: str,
         session_id: str,
         tool_calls: Sequence[ClientToolCallPayload],
@@ -637,7 +660,6 @@ class AgentRunExecution:
             for completed in asyncio.as_completed(tasks):
                 outcome = await completed
                 await self._finalize_tool_result(
-                    session,
                     run_id=run_id,
                     session_id=session_id,
                     call=outcome.call,
@@ -655,21 +677,31 @@ class AgentRunExecution:
                     task.cancel()
             await asyncio.gather(*tasks, return_exceptions=True)
             await self._append_cancelled_tool_results(
-                session,
                 session_id,
                 unresolved,
                 run_id=run_id,
             )
             if _is_user_stop_cancellation(exc):
-                run_state = await self._run_repo.get_by_id(session, run_id)
-                if run_state is not None and run_state.status == AgentRunStatus.RUNNING:
-                    await self._update_phase(
-                        session,
-                        run_id,
+                stopping_updated = False
+                stopping_started_at: datetime.datetime | None = None
+                async with self._session_manager() as session:
+                    run_state = await self._run_repo.get_by_id(session, run_id)
+                    if (
+                        run_state is not None
+                        and run_state.status == AgentRunStatus.RUNNING
+                    ):
+                        stopping_started_at = await self._update_phase_in_session(
+                            session,
+                            run_id,
+                            AgentRunPhase.STOPPING,
+                            active_tool_calls=[],
+                        )
+                        stopping_updated = True
+                if stopping_updated:
+                    await self._publish_phase(
                         AgentRunPhase.STOPPING,
-                        active_tool_calls=[],
+                        stopping_started_at,
                     )
-                    await session.commit()
                 raise _ToolExecutionUserInterrupted from exc
             raise
 
@@ -685,7 +717,6 @@ class AgentRunExecution:
 
     async def _finalize_tool_result(
         self,
-        session: AsyncSession,
         *,
         run_id: str,
         session_id: str,
@@ -693,7 +724,29 @@ class AgentRunExecution:
         result: ClientToolResultPayload,
     ) -> Event:
         """Append one terminal result and remove only its active ownership entry."""
-        event = await finalize_tool_result(
+        async with self._session_manager() as session:
+            event = await self._finalize_tool_result_in_session(
+                session,
+                run_id=run_id,
+                session_id=session_id,
+                call=call,
+                result=result,
+            )
+        if self._output_sink is not None:
+            await self._output_sink(NormalizedAdapterOutput(events=[]), [event])
+        return event
+
+    async def _finalize_tool_result_in_session(
+        self,
+        session: AsyncSession,
+        *,
+        run_id: str,
+        session_id: str,
+        call: ClientToolCallPayload,
+        result: ClientToolResultPayload,
+    ) -> Event:
+        """Finalize one tool result in the caller's DB transaction."""
+        return await finalize_tool_result(
             session,
             run_repo=self._run_repo,
             transcript_repo=self._transcript_repo,
@@ -702,10 +755,6 @@ class AgentRunExecution:
             call=call,
             result=result,
         )
-        await session.commit()
-        if self._output_sink is not None:
-            await self._output_sink(NormalizedAdapterOutput(events=[]), [event])
-        return event
 
     async def _append_missing_tool_results(
         self,
@@ -739,7 +788,7 @@ class AgentRunExecution:
             for call_id, call in calls_by_id.items()
             if call_id not in result_call_ids
         ]
-        appended = await self._append_cancelled_tool_results(
+        appended = await self._append_cancelled_tool_results_in_session(
             session,
             request.session_id,
             unresolved_calls,
@@ -760,7 +809,7 @@ class AgentRunExecution:
                 for active in refreshed.active_tool_calls
                 if active.call_id not in stale_resolved_ids
             ]
-            await self._update_phase(
+            await self._update_phase_in_session(
                 session,
                 request.run_id,
                 AgentRunPhase.EXECUTING_TOOLS
@@ -768,12 +817,10 @@ class AgentRunExecution:
                 else AgentRunPhase.APPENDING_EVENTS,
                 active_tool_calls=remaining,
             )
-            await session.commit()
         return appended
 
     async def _append_cancelled_tool_results(
         self,
-        session: AsyncSession,
         session_id: str,
         tool_calls: Sequence[ClientToolCallPayload],
         *,
@@ -796,6 +843,39 @@ class AgentRunExecution:
             )
             appended.append(
                 await self._finalize_tool_result(
+                    run_id=run_id,
+                    session_id=session_id,
+                    call=call,
+                    result=payload,
+                )
+            )
+        return appended
+
+    async def _append_cancelled_tool_results_in_session(
+        self,
+        session: AsyncSession,
+        session_id: str,
+        tool_calls: Sequence[ClientToolCallPayload],
+        *,
+        run_id: str,
+    ) -> list[Event]:
+        """Cancel calls atomically inside the caller's DB transaction."""
+        appended: list[Event] = []
+        for call in tool_calls:
+            payload = ClientToolResultPayload(
+                call_id=call.call_id,
+                name=call.name,
+                status="cancelled",
+                output=[
+                    OutputTextPart(
+                        text=(
+                            "Tool execution was cancelled before a result was recorded."
+                        ),
+                    )
+                ],
+            )
+            appended.append(
+                await self._finalize_tool_result_in_session(
                     session,
                     run_id=run_id,
                     session_id=session_id,
@@ -946,21 +1026,46 @@ class AgentRunExecution:
 
     async def _update_phase(
         self,
-        session: AsyncSession,
         run_id: str,
         phase: AgentRunPhase,
         *,
         active_tool_calls: list[ActiveToolCall] | None = None,
     ) -> None:
         """Reflect run phase in durable state and UI projection."""
+        async with self._session_manager() as session:
+            model_call_started_at = await self._update_phase_in_session(
+                session,
+                run_id,
+                phase,
+                active_tool_calls=active_tool_calls,
+            )
+        await self._publish_phase(phase, model_call_started_at)
+
+    async def _update_phase_in_session(
+        self,
+        session: AsyncSession,
+        run_id: str,
+        phase: AgentRunPhase,
+        *,
+        active_tool_calls: list[ActiveToolCall] | None = None,
+    ) -> datetime.datetime | None:
+        """Update the durable phase inside the caller's DB transaction."""
         run = await self._run_repo.update_phase(
             session,
             run_id,
             phase,
             active_tool_calls=active_tool_calls,
         )
+        return run.model_call_started_at
+
+    async def _publish_phase(
+        self,
+        phase: AgentRunPhase,
+        model_call_started_at: datetime.datetime | None,
+    ) -> None:
+        """Publish a committed phase after its DB session has closed."""
         if self._phase_sink is not None:
-            await self._phase_sink(phase, run.model_call_started_at)
+            await self._phase_sink(phase, model_call_started_at)
 
 
 async def _finish_turn(

--- a/python/apps/azents/src/azents/engine/events/execution_test.py
+++ b/python/apps/azents/src/azents/engine/events/execution_test.py
@@ -4,6 +4,8 @@ import asyncio
 import datetime
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from contextlib import asynccontextmanager
+from typing import AsyncContextManager
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -67,6 +69,37 @@ class _Session(AsyncSession):
 
     async def rollback(self) -> None:
         """Accept rollback calls from rejected admission tests."""
+
+
+@asynccontextmanager
+async def _session_context() -> AsyncIterator[AsyncSession]:
+    """Create a recording session for each production-style DB scope."""
+    session = _Session()
+    try:
+        yield session
+    except Exception:
+        await session.rollback()
+        raise
+    else:
+        await session.commit()
+
+
+def _session_manager_for(
+    session: _Session,
+) -> Callable[[], AsyncContextManager[AsyncSession]]:
+    """Return a session manager that reuses one assertion-visible session."""
+
+    @asynccontextmanager
+    async def manager() -> AsyncIterator[AsyncSession]:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise
+        else:
+            await session.commit()
+
+    return manager
 
 
 class _OpenToolAdmissionBarrier:
@@ -748,6 +781,7 @@ async def test_text_run_completes() -> None:
         emitted_phases.append((phase, model_call_started_at))
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -760,7 +794,6 @@ async def test_text_run_completes() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -790,6 +823,95 @@ async def test_text_run_completes() -> None:
     assert streaming_started_at == waiting_started_at
 
 
+async def test_external_run_callbacks_observe_no_open_db_session() -> None:
+    """Model, hook, tool, and publish callbacks run after DB scopes close."""
+    open_sessions = 0
+
+    @asynccontextmanager
+    async def session_manager() -> AsyncIterator[AsyncSession]:
+        nonlocal open_sessions
+        open_sessions += 1
+        session = _Session()
+        try:
+            yield session
+        finally:
+            await session.commit()
+            open_sessions -= 1
+
+    class AssertingModelAdapter(_ModelAdapter):
+        async def stream(
+            self, request: NativeModelRequest
+        ) -> AsyncIterator[NativeEvent]:
+            assert open_sessions == 0
+            async for event in super().stream(request):
+                yield event
+
+    class AssertingToolExecutor(_ToolExecutor):
+        async def execute(self, call: ClientToolCallPayload) -> ClientToolResultPayload:
+            assert open_sessions == 0
+            return await super().execute(call)
+
+    tool_executor = AssertingToolExecutor()
+
+    async def prepare_model_call(
+        *, transcript: Sequence[Event], model: str
+    ) -> PreparedModelCall:
+        del transcript
+        assert open_sessions == 0
+
+        async def on_turn_end(reason: TurnEndReason) -> None:
+            del reason
+            assert open_sessions == 0
+
+        return PreparedModelCall(
+            native_request=NativeModelRequest(model=model, input=[]),
+            inference_state=None,
+            system_prompt_analysis=None,
+            tool_executor=tool_executor,
+            on_turn_end=on_turn_end,
+        )
+
+    async def output_sink(
+        normalized: NormalizedAdapterOutput, appended: Sequence[Event]
+    ) -> None:
+        del normalized, appended
+        assert open_sessions == 0
+
+    async def phase_sink(
+        phase: AgentRunPhase,
+        model_call_started_at: datetime.datetime | None,
+    ) -> None:
+        del phase, model_call_started_at
+        assert open_sessions == 0
+
+    execution = AgentRunExecution(
+        session_manager=session_manager,
+        post_lower_filter=_PostFilter(),
+        model_adapter=AssertingModelAdapter(),
+        output_normalizer=_SequenceNormalizer(
+            [[_tool_call_event()], [_assistant_event()]]
+        ),
+        model_call_preparer=prepare_model_call,
+        output_sink=output_sink,
+        phase_sink=phase_sink,
+        run_repo=_RunRepo(),
+        transcript_repo=_TranscriptRepo(),
+    )
+
+    status = await execution.run(
+        AgentRunExecutionRequest(
+            owner_generation=1,
+            tool_admission_barrier=_OpenToolAdmissionBarrier(),
+            run_id="run-1",
+            session_id="session-1",
+            model="gpt-5.1",
+        )
+    )
+
+    assert status == AgentRunStatus.COMPLETED
+    assert open_sessions == 0
+
+
 async def test_model_delta_reaches_output_sink_before_stream_completion() -> None:
     """Project native text while the provider stream remains open."""
     run_repo = _RunRepo()
@@ -806,6 +928,7 @@ async def test_model_delta_reaches_output_sink_before_stream_completion() -> Non
         sink_outputs.append(normalized)
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=model_adapter,
         output_normalizer=_ProjectingNormalizer([_assistant_event()]),
@@ -816,7 +939,6 @@ async def test_model_delta_reaches_output_sink_before_stream_completion() -> Non
     )
     run_task = asyncio.create_task(
         execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -861,6 +983,7 @@ async def test_text_run_commits_durable_events_before_output_sink() -> None:
         committed_event_counts_at_sink.append(session.commits[-1])
 
     execution = AgentRunExecution(
+        session_manager=_session_manager_for(session),
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -873,7 +996,6 @@ async def test_text_run_commits_durable_events_before_output_sink() -> None:
     )
 
     status = await execution.run(
-        session,
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -902,6 +1024,7 @@ async def test_text_run_output_sink_receives_run_marker() -> None:
         sink_kinds.append([event.kind for event in appended])
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -914,7 +1037,6 @@ async def test_text_run_output_sink_receives_run_marker() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -970,6 +1092,7 @@ async def test_model_usage_is_appended_as_turn_marker(
         ),
     )
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()], usage=usage),
@@ -985,7 +1108,6 @@ async def test_model_usage_is_appended_as_turn_marker(
 
     with caplog.at_level(logging.INFO, logger="azents.engine.events.execution"):
         status = await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1036,6 +1158,7 @@ async def test_model_input_uses_session_head_event_id() -> None:
     """After compaction, model input is fetched from session head."""
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1048,7 +1171,6 @@ async def test_model_input_uses_session_head_event_id() -> None:
     )
 
     await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1067,6 +1189,7 @@ async def test_closed_admission_barrier_prevents_call_and_handler_start() -> Non
     transcript_repo = _TranscriptRepo()
     tool_executor = _ToolExecutor()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event()]),
@@ -1079,7 +1202,6 @@ async def test_closed_admission_barrier_prevents_call_and_handler_start() -> Non
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=2,
             tool_admission_barrier=_ClosedToolAdmissionBarrier(),
@@ -1100,6 +1222,7 @@ async def test_tool_run_with_turn_limit_interrupts_after_tool_result() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event(), _assistant_event()]),
@@ -1111,7 +1234,6 @@ async def test_tool_run_with_turn_limit_interrupts_after_tool_result() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1141,6 +1263,7 @@ async def test_parallel_calls_finalize_independently() -> None:
     transcript_repo = _TranscriptRepo()
     tool_executor = _OrderedToolExecutor()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer(
@@ -1155,7 +1278,6 @@ async def test_parallel_calls_finalize_independently() -> None:
     )
     run_task = asyncio.create_task(
         execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=3,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1201,6 +1323,7 @@ async def test_term_after_admission_keeps_normal_result_and_run_recoverable() ->
     tool_executor = _OrderedToolExecutor()
     barrier = _MutableToolAdmissionBarrier()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event("call-2")]),
@@ -1217,7 +1340,6 @@ async def test_term_after_admission_keeps_normal_result_and_run_recoverable() ->
 
     run_task = asyncio.create_task(
         execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=4,
                 tool_admission_barrier=barrier,
@@ -1251,6 +1373,7 @@ async def test_unlimited_tool_run_executes_tool_then_completes() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_SequenceNormalizer(
@@ -1267,7 +1390,6 @@ async def test_unlimited_tool_run_executes_tool_then_completes() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1312,6 +1434,7 @@ async def test_model_call_preparer_runs_for_each_model_turn() -> None:
         )
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_SequenceNormalizer(
@@ -1326,7 +1449,6 @@ async def test_model_call_preparer_runs_for_each_model_turn() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1374,6 +1496,7 @@ async def test_model_call_preparer_turn_end_receives_error_reason() -> None:
         )
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_FailingModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1384,7 +1507,6 @@ async def test_model_call_preparer_turn_end_receives_error_reason() -> None:
 
     with pytest.raises(ModelCallError, match="Missing scopes"):
         await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1402,6 +1524,7 @@ async def test_provider_tool_call_completes_without_next_model_turn() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_SequenceNormalizer(
@@ -1417,7 +1540,6 @@ async def test_provider_tool_call_completes_without_next_model_turn() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1442,6 +1564,7 @@ async def test_provider_tool_call_with_message_completes_one_turn() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_SequenceNormalizer(
@@ -1457,7 +1580,6 @@ async def test_provider_tool_call_with_message_completes_one_turn() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1503,6 +1625,7 @@ async def test_compacted_run_continues_with_summary_without_terminal_marker() ->
     )
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1515,7 +1638,6 @@ async def test_compacted_run_continues_with_summary_without_terminal_marker() ->
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1538,7 +1660,6 @@ async def test_tool_turn_polls_input_before_next_model_call() -> None:
     poll_count = 0
 
     async def poll_input_events(
-        session: AsyncSession,
         session_id: str,
     ) -> InputPollResult:
         """Append queued user input at second turn boundary."""
@@ -1550,24 +1671,25 @@ async def test_tool_turn_polls_input_before_next_model_call() -> None:
                 context_invalidated=False,
                 complete_run=False,
             )
+        async with _session_context() as session:
+            event = await transcript_repo.append(
+                session,
+                EventCreate(
+                    session_id=session_id,
+                    kind=EventKind.USER_MESSAGE,
+                    payload=UserMessagePayload(
+                        content="Is something odd with the grep tool?",
+                    ).model_dump(mode="json", exclude_none=True),
+                ),
+            )
         return InputPollResult(
             context_invalidated=False,
             complete_run=False,
-            events=[
-                await transcript_repo.append(
-                    session,
-                    EventCreate(
-                        session_id=session_id,
-                        kind=EventKind.USER_MESSAGE,
-                        payload=UserMessagePayload(
-                            content="Is something odd with the grep tool?",
-                        ).model_dump(mode="json", exclude_none=True),
-                    ),
-                )
-            ],
+            events=[event],
         )
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_SequenceNormalizer(
@@ -1584,7 +1706,6 @@ async def test_tool_turn_polls_input_before_next_model_call() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1617,11 +1738,10 @@ async def test_context_invalidation_yields_for_request_refresh() -> None:
     poll_count = 0
 
     async def poll_input_events(
-        session: AsyncSession,
         session_id: str,
     ) -> InputPollResult:
         """Request a handoff at the second turn boundary."""
-        del session, session_id
+        del session_id
         nonlocal poll_count
         poll_count += 1
         return InputPollResult(
@@ -1631,6 +1751,7 @@ async def test_context_invalidation_yields_for_request_refresh() -> None:
         )
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_SequenceNormalizer(
@@ -1648,7 +1769,6 @@ async def test_context_invalidation_yields_for_request_refresh() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1676,6 +1796,7 @@ async def test_orphan_tool_call_without_state_is_cancelled_before_lowering() -> 
     transcript_repo.events.append(_tool_call_event())
     lowerer = _RecordingLowerer()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1687,7 +1808,6 @@ async def test_orphan_tool_call_without_state_is_cancelled_before_lowering() -> 
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1727,6 +1847,7 @@ async def test_active_unresolved_tool_call_is_cancelled_before_lowering() -> Non
     transcript_repo.events.append(_tool_call_event())
     lowerer = _RecordingLowerer()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1738,7 +1859,6 @@ async def test_active_unresolved_tool_call_is_cancelled_before_lowering() -> Non
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1776,6 +1896,7 @@ async def test_stale_active_entry_with_result_is_removed_without_replacement() -
     transcript_repo = _TranscriptRepo()
     transcript_repo.events.extend([_tool_call_event(), _tool_result_event()])
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1785,7 +1906,6 @@ async def test_stale_active_entry_with_result_is_removed_without_replacement() -
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=2,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1821,6 +1941,7 @@ async def test_active_entry_without_call_event_fails_invariant() -> None:
         )
     ]
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -1831,7 +1952,6 @@ async def test_active_entry_without_call_event_fails_invariant() -> None:
 
     with pytest.raises(RuntimeError, match="no durable call event"):
         await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=2,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1857,6 +1977,7 @@ async def test_model_stream_user_stop_appends_only_assistant_text() -> None:
         ReasoningPayload(text="hidden", native_artifact=_artifact()),
     )
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_CancellingModelAdapter(),
         output_normalizer=_Normalizer([assistant, reasoning, _tool_call_event()]),
@@ -1868,7 +1989,6 @@ async def test_model_stream_user_stop_appends_only_assistant_text() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1894,6 +2014,7 @@ async def test_model_stream_user_stop_without_text_appends_only_marker() -> None
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_CancellingModelAdapter(),
         output_normalizer=_Normalizer([]),
@@ -1905,7 +2026,6 @@ async def test_model_stream_user_stop_without_text_appends_only_marker() -> None
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1927,6 +2047,7 @@ async def test_shutdown_tool_cancellation_repairs_before_reraising() -> None:
     transcript_repo = _TranscriptRepo()
     tool_executor = _CancellingToolExecutor()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event()]),
@@ -1939,7 +2060,6 @@ async def test_shutdown_tool_cancellation_repairs_before_reraising() -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -1968,6 +2088,7 @@ async def test_tool_user_stop_appends_cancelled_result_and_interrupts() -> None:
     transcript_repo = _TranscriptRepo()
     tool_executor = _CancellingToolExecutor(user_stop=True)
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event()]),
@@ -1979,7 +2100,6 @@ async def test_tool_user_stop_appends_cancelled_result_and_interrupts() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2021,6 +2141,7 @@ async def test_tool_result_output_sink_receives_tool_result() -> None:
         sink_kinds.append([event.kind for event in appended])
 
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event()]),
@@ -2033,7 +2154,6 @@ async def test_tool_result_output_sink_receives_tool_result() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2053,6 +2173,7 @@ async def test_tool_failure_appends_failed_tool_result() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_tool_call_event()]),
@@ -2064,7 +2185,6 @@ async def test_tool_failure_appends_failed_tool_result() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2093,6 +2213,7 @@ async def test_tool_failure_appends_failed_tool_result() -> None:
 async def test_run_input_preparation_does_not_run_lifecycle_cleanup() -> None:
     """File lifecycle cleanup is scheduler-owned, not run-loop-owned."""
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -2105,7 +2226,6 @@ async def test_run_input_preparation_does_not_run_lifecycle_cleanup() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2135,6 +2255,7 @@ async def test_pre_model_lower_hook_runs_before_lowerer() -> None:
     lowerer = _RecordingLowerer()
     hook = _PreModelLowerHook()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([_assistant_event()]),
@@ -2148,7 +2269,6 @@ async def test_pre_model_lower_hook_runs_before_lowerer() -> None:
     )
 
     status = await execution.run(
-        _Session(),
         AgentRunExecutionRequest(
             owner_generation=1,
             tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2169,6 +2289,7 @@ async def test_empty_model_output_propagates_for_retry() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([]),
@@ -2181,7 +2302,6 @@ async def test_empty_model_output_propagates_for_retry() -> None:
 
     with pytest.raises(ModelCallError, match="without assistant output"):
         await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2205,6 +2325,7 @@ async def test_blank_assistant_message_propagates_for_retry() -> None:
         AssistantMessagePayload(content=" ", native_artifact=_artifact()),
     )
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_ModelAdapter(),
         output_normalizer=_Normalizer([blank_message]),
@@ -2217,7 +2338,6 @@ async def test_blank_assistant_message_propagates_for_retry() -> None:
 
     with pytest.raises(ModelCallError, match="without assistant output"):
         await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),
@@ -2236,6 +2356,7 @@ async def test_model_call_error_propagates_for_retry() -> None:
     run_repo = _RunRepo()
     transcript_repo = _TranscriptRepo()
     execution = AgentRunExecution(
+        session_manager=_session_context,
         post_lower_filter=_PostFilter(),
         model_adapter=_FailingModelAdapter(),
         output_normalizer=_Normalizer([]),
@@ -2248,7 +2369,6 @@ async def test_model_call_error_propagates_for_retry() -> None:
 
     with pytest.raises(ModelCallError, match="Missing scopes"):
         await execution.run(
-            _Session(),
             AgentRunExecutionRequest(
                 owner_generation=1,
                 tool_admission_barrier=_OpenToolAdmissionBarrier(),

--- a/python/apps/azents/src/azents/engine/events/filters.py
+++ b/python/apps/azents/src/azents/engine/events/filters.py
@@ -261,21 +261,12 @@ class EventAutoCompactionFilter:
         self._summary_enricher = summary_enricher
         self.was_compacted = False
 
-    async def apply(
-        self,
-        session: AsyncSession,
-        transcript: Sequence[Event],
-    ) -> list[Event]:
-        """Replace old input with append-only summary when threshold is exceeded."""
+    async def compact(self, transcript: Sequence[Event]) -> list[Event]:
+        """Compact model input without keeping a caller-owned DB session open."""
         self.was_compacted = False
         events = list(transcript)
         if _compaction_input_tokens(events) <= self._threshold_tokens:
             return events
-
-        # End the input-preparation transaction before lifecycle hooks and the
-        # external summary call. Both can take tens of seconds, and keeping the
-        # transaction open would block Stop finalization and concurrent input.
-        await session.commit()
 
         summary = await self._compactor.compact(
             session_id=self._session_id,
@@ -289,9 +280,6 @@ class EventAutoCompactionFilter:
         )
         if summary is None:
             return events
-        # The compactor advances the head through an independent short session.
-        # Expire the caller identity map so the next turn reloads that new head.
-        session.expire_all()
         self.was_compacted = True
         return [summary]
 

--- a/python/apps/azents/src/azents/engine/events/filters_test.py
+++ b/python/apps/azents/src/azents/engine/events/filters_test.py
@@ -1278,7 +1278,7 @@ async def test_auto_compaction_runs_when_threshold_is_exceeded() -> None:
         max_input_tokens=10,
         auto_compaction_threshold_tokens=None,
         compaction_id_factory=lambda: "compact-1",
-    ).apply(_Session(), events)
+    ).compact(events)
 
     assert session_repo.head_event_id is not None
     assert len(result) == 1
@@ -1311,11 +1311,9 @@ async def test_auto_compaction_emits_started_before_summary_call() -> None:
     transcript_repo = _TranscriptRepo(events)
     session_repo = _SessionRepo()
     session_manager = _SessionManager()
-    session = _Session()
     calls: list[str] = []
 
     async def on_compaction_started() -> None:
-        assert session.commit_count == 1
         assert session_manager.active_scopes == 0
         assert session_manager.sessions[0].commit_count == 1
         marker = transcript_repo.events[-1].payload
@@ -1344,10 +1342,9 @@ async def test_auto_compaction_emits_started_before_summary_call() -> None:
         auto_compaction_threshold_tokens=None,
         compaction_id_factory=lambda: "compact-1",
         on_compaction_started=on_compaction_started,
-    ).apply(session, events)
+    ).compact(events)
 
     assert calls == ["started", "summarize"]
-    assert session.expire_all_count == 1
 
 
 async def test_auto_compaction_marks_compacted_only_when_summary_is_created() -> None:
@@ -1387,7 +1384,7 @@ async def test_auto_compaction_marks_compacted_only_when_summary_is_created() ->
         compaction_id_factory=lambda: "compact-1",
     )
 
-    await filter_.apply(_Session(), events)
+    await filter_.compact(events)
 
     assert filter_.was_compacted is True
 
@@ -1421,7 +1418,7 @@ async def test_auto_compaction_skips_when_threshold_is_not_exceeded() -> None:
         max_input_tokens=1000,
         auto_compaction_threshold_tokens=None,
         compaction_id_factory=lambda: "compact-1",
-    ).apply(_Session(), events)
+    ).compact(events)
 
     assert result == events
 
@@ -1455,7 +1452,7 @@ async def test_auto_compaction_uses_explicit_threshold_override() -> None:
         max_input_tokens=1000,
         auto_compaction_threshold_tokens=1,
         compaction_id_factory=lambda: "compact-1",
-    ).apply(_Session(), events)
+    ).compact(events)
 
     assert [event.kind for event in result] == [EventKind.COMPACTION_SUMMARY]
 
@@ -1499,7 +1496,7 @@ async def test_auto_compaction_uses_latest_turn_marker_usage() -> None:
         max_input_tokens=1000,
         auto_compaction_threshold_tokens=None,
         compaction_id_factory=lambda: "compact-1",
-    ).apply(_Session(), events)
+    ).compact(events)
 
     assert result == events
 
@@ -1539,7 +1536,7 @@ async def test_auto_compaction_counts_events_after_latest_turn_marker() -> None:
         max_input_tokens=100,
         auto_compaction_threshold_tokens=None,
         compaction_id_factory=lambda: "compact-1",
-    ).apply(_Session(), events)
+    ).compact(events)
 
     assert session_repo.head_event_id is not None
     assert result[0].kind == EventKind.COMPACTION_SUMMARY

--- a/python/apps/azents/src/azents/engine/run/resolve.py
+++ b/python/apps/azents/src/azents/engine/run/resolve.py
@@ -490,22 +490,8 @@ async def resolve_invoke_input_with_model_source(
                     integration_id=main_selection.llm_provider_integration_id,
                 )
             )
-        refreshed_integration = await _ensure_provider_runtime_tokens(
-            integration=integration,
-            integration_repository=integration_repository,
-            session_manager=session_manager,
-        )
-        match refreshed_integration:
-            case Success(value):
-                integration = value
-            case Failure():
-                return Failure(
-                    IntegrationDisabled(
-                        integration_id=main_selection.llm_provider_integration_id,
-                    )
-                )
 
-        lightweight_integration = integration
+        loaded_lightweight_integration = integration
         if lightweight_selection.llm_provider_integration_id != integration.id:
             loaded_lightweight_integration = (
                 await integration_repository.get_by_id_with_secrets(
@@ -525,22 +511,40 @@ async def resolve_invoke_input_with_model_source(
                         integration_id=lightweight_selection.llm_provider_integration_id,
                     )
                 )
-            refreshed_lightweight_integration = await _ensure_provider_runtime_tokens(
-                integration=loaded_lightweight_integration,
-                integration_repository=integration_repository,
-                session_manager=session_manager,
+
+    refreshed_integration = await _ensure_provider_runtime_tokens(
+        integration=integration,
+        integration_repository=integration_repository,
+        session_manager=session_manager,
+    )
+    match refreshed_integration:
+        case Success(value):
+            integration = value
+        case Failure():
+            return Failure(
+                IntegrationDisabled(
+                    integration_id=main_selection.llm_provider_integration_id,
+                )
             )
-            match refreshed_lightweight_integration:
-                case Success(value):
-                    lightweight_integration = value
-                case Failure():
-                    return Failure(
-                        IntegrationDisabled(
-                            integration_id=(
-                                lightweight_selection.llm_provider_integration_id
-                            ),
-                        )
+
+    lightweight_integration = integration
+    if loaded_lightweight_integration.id != integration.id:
+        refreshed_lightweight_integration = await _ensure_provider_runtime_tokens(
+            integration=loaded_lightweight_integration,
+            integration_repository=integration_repository,
+            session_manager=session_manager,
+        )
+        match refreshed_lightweight_integration:
+            case Success(value):
+                lightweight_integration = value
+            case Failure():
+                return Failure(
+                    IntegrationDisabled(
+                        integration_id=(
+                            lightweight_selection.llm_provider_integration_id
+                        ),
                     )
+                )
 
     model = to_runtime_model(
         main_selection.provider,
@@ -875,7 +879,7 @@ async def resolve_agent_tools(
     toolkit_registry: dict[str, ToolkitProvider[Any]],
     agent_toolkit_repository: AgentToolkitRepository,
     toolkit_repository: ToolkitRepository,
-    session: AsyncSession,
+    session_manager: SessionManager[AsyncSession],
     web_url: str,
     oauth_secret_key: str,
     mcp_proxy_url: str | None,
@@ -898,7 +902,7 @@ async def resolve_agent_tools(
     :param toolkit_registry: toolkit_type to ToolkitProvider instance mapping
     :param agent_toolkit_repository: AgentToolkit repository
     :param toolkit_repository: Toolkit repository
-    :param session: DB session
+    :param session_manager: DB session factory used only for Toolkit snapshot reads
     :param web_url: Frontend URL for OAuth redirect_uri construction
     :param oauth_secret_key: OAuth HMAC signing key
     :param runtime_domain_config: Runtime domain allow/deny policy. Parent
@@ -915,7 +919,14 @@ async def resolve_agent_tools(
         Memory tools can be exposed without runtime.
     :return: List of (Toolkit, slug) tuples
     """
-    agent_toolkits = await agent_toolkit_repository.list_by_agent(session, agent_id)
+    async with session_manager() as session:
+        agent_toolkits = await agent_toolkit_repository.list_by_agent(session, agent_id)
+        registered_toolkits = []
+        for agent_toolkit in agent_toolkits:
+            toolkit = await toolkit_repository.get_by_id(
+                session, agent_toolkit.toolkit_id
+            )
+            registered_toolkits.append((agent_toolkit, toolkit))
     # (provider, resolved, config, slug, prompt, use_prefix, toolkit_type, modes)
     # toolkit_type is populated only for DB-registered toolkits; auto-binding is None
     pending: list[
@@ -932,7 +943,7 @@ async def resolve_agent_tools(
     ] = []
 
     # DB-registered toolkit (registry-based, prefix applied)
-    for at in agent_toolkits:
+    for at, toolkit in registered_toolkits:
         provider = toolkit_registry.get(at.toolkit_type)
         if provider is None:
             logger.warning(
@@ -944,7 +955,6 @@ async def resolve_agent_tools(
             )
             continue
 
-        toolkit = await toolkit_repository.get_by_id(session, at.toolkit_id)
         if toolkit is None or not toolkit.enabled:
             continue
 
@@ -956,7 +966,7 @@ async def resolve_agent_tools(
             agent_id=context.agent_id,
             session_id=context.session_id,
             user_id=context.user_id,
-            session=session,
+            session=None,
             web_url=web_url,
             oauth_secret_key=oauth_secret_key,
             workspace_id=context.workspace_id,
@@ -1014,7 +1024,7 @@ async def resolve_agent_tools(
                     agent_id=context.agent_id,
                     session_id=context.session_id,
                     user_id=context.user_id,
-                    session=session,
+                    session=None,
                     web_url=web_url,
                     oauth_secret_key=oauth_secret_key,
                     workspace_id=context.workspace_id,
@@ -1057,7 +1067,7 @@ async def resolve_agent_tools(
                     agent_id=context.agent_id,
                     session_id=context.session_id,
                     user_id=context.user_id,
-                    session=session,
+                    session=None,
                     web_url=web_url,
                     oauth_secret_key=oauth_secret_key,
                     workspace_id=context.workspace_id,
@@ -1102,7 +1112,7 @@ async def resolve_agent_tools(
                     agent_id=context.agent_id,
                     session_id=context.session_id,
                     user_id=context.user_id,
-                    session=session,
+                    session=None,
                     web_url=web_url,
                     oauth_secret_key=oauth_secret_key,
                     workspace_id=context.workspace_id,
@@ -1161,7 +1171,7 @@ async def resolve_agent_tools(
                         agent_id=context.agent_id,
                         session_id=context.session_id,
                         user_id=context.user_id,
-                        session=session,
+                        session=None,
                         web_url=web_url,
                         oauth_secret_key=oauth_secret_key,
                         workspace_id=context.workspace_id,
@@ -1212,7 +1222,7 @@ async def resolve_agent_tools(
             agent_id=context.agent_id,
             session_id=context.session_id,
             user_id=context.user_id,
-            session=session,
+            session=None,
             web_url=web_url,
             oauth_secret_key=oauth_secret_key,
             workspace_id=context.workspace_id,
@@ -1257,7 +1267,7 @@ async def resolve_agent_tools(
             agent_id=context.agent_id,
             session_id=context.session_id,
             user_id=context.user_id,
-            session=session,
+            session=None,
             web_url=web_url,
             oauth_secret_key=oauth_secret_key,
             workspace_id=context.workspace_id,
@@ -1305,7 +1315,7 @@ async def resolve_agent_tools(
             agent_id=context.agent_id,
             session_id=context.session_id,
             user_id=context.user_id,
-            session=session,
+            session=None,
             web_url=web_url,
             oauth_secret_key=oauth_secret_key,
             workspace_id=context.workspace_id,
@@ -1353,7 +1363,7 @@ async def resolve_agent_tools(
             agent_id=context.agent_id,
             session_id=context.session_id,
             user_id=context.user_id,
-            session=session,
+            session=None,
             web_url=web_url,
             oauth_secret_key=oauth_secret_key,
             workspace_id=context.workspace_id,

--- a/python/apps/azents/src/azents/engine/run/resolve_test.py
+++ b/python/apps/azents/src/azents/engine/run/resolve_test.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
 
+import pytest
 from azcommon.result import Failure, Success
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +28,7 @@ from azents.engine.tools.claude_rules import (
 )
 from azents.engine.tools.goal import GoalStateStore, GoalToolkitProvider
 from azents.engine.tools.subagent import SubagentToolkitProvider
+from azents.rdb.session import SessionManager
 from azents.repos.agent.data import Agent
 from azents.repos.llm_provider_integration.data import LLMProviderIntegrationWithSecrets
 from azents.runtime.types import RuntimeDomainConfig
@@ -35,6 +37,7 @@ from azents.testing.model_selection import (
     make_test_selectable_model_options,
 )
 
+from . import resolve as resolve_module
 from .resolve import (
     ModelTargetNotFound,
     ReasoningEffortUnsupported,
@@ -44,6 +47,18 @@ from .resolve import (
 )
 
 _NOW = datetime.datetime.now(datetime.timezone.utc)
+
+
+def _session_manager_for(
+    session: AsyncSession,
+) -> SessionManager[AsyncSession]:
+    """Return a session manager yielding one test session."""
+
+    @asynccontextmanager
+    async def manager() -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    return manager
 
 
 def _make_agent(
@@ -185,7 +200,7 @@ def _make_subagent_provider() -> SubagentToolkitProvider:
     agent_repository = AsyncMock()
     agent_repository.get_by_id.return_value = _make_agent()
     return SubagentToolkitProvider(
-        session_manager=AsyncMock(),
+        session_manager=_session_manager_for(AsyncMock(spec=AsyncSession)),
         broker=AsyncMock(),
         input_buffer_service=AsyncMock(),
         agent_repository=agent_repository,
@@ -230,8 +245,74 @@ class TestResolveInvokeInput:
         assert isinstance(result, Success)
         run_request = result.value
         assert run_request.model == "gpt-4o"
-        assert run_request.provider == LLMProvider.OPENAI
-        assert run_request.agent_id == "agent-1"
+
+    async def test_closes_snapshot_session_before_provider_refresh(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Provider token I/O starts only after Agent/Integration reads close."""
+        active_sessions = 0
+        agent_repository = AsyncMock()
+        integration_repository = AsyncMock()
+
+        async def get_agent(session: AsyncSession, agent_id: str) -> Agent:
+            del session, agent_id
+            assert active_sessions == 1
+            return _make_agent()
+
+        async def get_integration(
+            session: AsyncSession, integration_id: str
+        ) -> LLMProviderIntegrationWithSecrets:
+            del session, integration_id
+            assert active_sessions == 1
+            return _make_integration()
+
+        agent_repository.get_by_id.side_effect = get_agent
+        integration_repository.get_by_id_with_secrets.side_effect = get_integration
+
+        @asynccontextmanager
+        async def session_manager() -> AsyncGenerator[AsyncSession, None]:
+            nonlocal active_sessions
+            active_sessions += 1
+            try:
+                yield AsyncMock(spec=AsyncSession)
+            finally:
+                active_sessions -= 1
+
+        async def ensure_tokens(
+            *,
+            integration: LLMProviderIntegrationWithSecrets,
+            integration_repository: object,
+            session_manager: object,
+        ) -> Success[LLMProviderIntegrationWithSecrets]:
+            del integration_repository, session_manager
+            assert active_sessions == 0
+            return Success(integration)
+
+        monkeypatch.setattr(
+            resolve_module,
+            "_ensure_provider_runtime_tokens",
+            ensure_tokens,
+        )
+
+        result = await resolve_invoke_input(
+            InvokeInput(
+                agent_id="agent-1",
+                session_id="session-1",
+                messages=[],
+                user_id="user-1",
+            ),
+            agent_repository=agent_repository,
+            integration_repository=integration_repository,
+            session_manager=session_manager,
+            exchange_file_service=AsyncMock(),
+            model_file_service=AsyncMock(),
+        )
+
+        assert isinstance(result, Success)
+        assert active_sessions == 0
+        assert result.value.provider == LLMProvider.OPENAI
+        assert result.value.agent_id == "agent-1"
 
     async def test_profile_resolution_preserves_explicit_default_effort(self) -> None:
         """Null effort remains visible model Default for the selected target."""
@@ -423,7 +504,7 @@ class TestResolveAgentTools:
             toolkit_registry={},
             agent_toolkit_repository=agent_toolkit_repository,
             toolkit_repository=AsyncMock(),
-            session=session,
+            session_manager=_session_manager_for(session),
             web_url="https://example.test",
             oauth_secret_key="secret",
             mcp_proxy_url=None,
@@ -476,7 +557,7 @@ class TestResolveAgentTools:
             toolkit_registry={},
             agent_toolkit_repository=agent_toolkit_repository,
             toolkit_repository=AsyncMock(),
-            session=session,
+            session_manager=_session_manager_for(session),
             web_url="https://example.test",
             oauth_secret_key="secret",
             mcp_proxy_url=None,
@@ -508,7 +589,7 @@ class TestResolveAgentTools:
             toolkit_registry={},
             agent_toolkit_repository=agent_toolkit_repository,
             toolkit_repository=AsyncMock(),
-            session=session,
+            session_manager=_session_manager_for(session),
             web_url="https://example.test",
             oauth_secret_key="secret",
             mcp_proxy_url=None,
@@ -550,7 +631,7 @@ class TestResolveAgentTools:
             toolkit_registry={},
             agent_toolkit_repository=agent_toolkit_repository,
             toolkit_repository=AsyncMock(),
-            session=session,
+            session_manager=_session_manager_for(session),
             web_url="https://example.test",
             oauth_secret_key="secret",
             mcp_proxy_url=None,

--- a/python/apps/azents/src/azents/engine/tools/mcp.py
+++ b/python/apps/azents/src/azents/engine/tools/mcp.py
@@ -173,9 +173,11 @@ class McpToolkitProvider(ToolkitProvider[McpToolkitConfig]):
         on_auth_failure: Callable[[], Awaitable[str | None]] | None = None
 
         if config.auth_type == "oauth2" and self._connection_repo is not None:
+            if self._session_manager is None:
+                raise RuntimeError("MCP OAuth requires a DB session manager")
             connection = await _ensure_oauth_connection_token(
                 connection_repo=self._connection_repo,
-                session=context.session,
+                session_manager=self._session_manager,
                 toolkit_id=context.toolkit_id,
                 proxy_url=context.mcp_proxy_url,
             )
@@ -184,13 +186,12 @@ class McpToolkitProvider(ToolkitProvider[McpToolkitConfig]):
                 and connection.status == MCPOAuthConnectionStatus.CONNECTED
             ):
                 secret = connection.access_token
-            if self._session_manager is not None:
-                on_auth_failure = _make_oauth_refresh_callback(
-                    toolkit_id=context.toolkit_id,
-                    connection_repo=self._connection_repo,
-                    session_manager=self._session_manager,
-                    proxy_url=context.mcp_proxy_url,
-                )
+            on_auth_failure = _make_oauth_refresh_callback(
+                toolkit_id=context.toolkit_id,
+                connection_repo=self._connection_repo,
+                session_manager=self._session_manager,
+                proxy_url=context.mcp_proxy_url,
+            )
         else:
             secret = _extract_static_secret(config, context.credentials_json)
 
@@ -235,20 +236,19 @@ def _make_oauth_refresh_callback(
     """
 
     async def _refresh() -> str | None:
-        async with session_manager() as session:
-            connection = await _refresh_oauth_connection_under_lock(
-                connection_repo=connection_repo,
-                session=session,
-                toolkit_id=toolkit_id,
-                proxy_url=proxy_url,
-                force=True,
-            )
-            if (
-                connection is None
-                or connection.status != MCPOAuthConnectionStatus.CONNECTED
-            ):
-                return None
-            return connection.access_token
+        connection = await _refresh_oauth_connection(
+            connection_repo=connection_repo,
+            session_manager=session_manager,
+            toolkit_id=toolkit_id,
+            proxy_url=proxy_url,
+            force=True,
+        )
+        if (
+            connection is None
+            or connection.status != MCPOAuthConnectionStatus.CONNECTED
+        ):
+            return None
+        return connection.access_token
 
     return _refresh
 
@@ -298,57 +298,67 @@ def _token_needs_refresh(connection: MCPOAuthConnection) -> bool:
 async def _ensure_oauth_connection_token(
     *,
     connection_repo: MCPOAuthConnectionRepository,
-    session: AsyncSession,
+    session_manager: SessionManager[AsyncSession],
     toolkit_id: str,
     proxy_url: str | None,
 ) -> MCPOAuthConnection | None:
     """Load OAuth connection and refresh it when needed.
 
     :param connection_repo: OAuth connection repository
-    :param session: Database session
+    :param session_manager: Database session factory
     :param toolkit_id: Toolkit ID
     :param proxy_url: egress proxy URL
     :return: OAuth connection or None
     """
-    connection = await connection_repo.get_by_toolkit_id(session, toolkit_id)
+    async with session_manager() as session:
+        connection = await connection_repo.get_by_toolkit_id(session, toolkit_id)
     if connection is None or connection.status != MCPOAuthConnectionStatus.CONNECTED:
         return connection
     if not _token_needs_refresh(connection):
         return connection
-    return await _refresh_oauth_connection_under_lock(
+    return await _refresh_oauth_connection(
         connection_repo=connection_repo,
-        session=session,
+        session_manager=session_manager,
         toolkit_id=toolkit_id,
         proxy_url=proxy_url,
         force=False,
+        connection=connection,
     )
 
 
-async def _refresh_oauth_connection_under_lock(
+async def _refresh_oauth_connection(
     *,
     connection_repo: MCPOAuthConnectionRepository,
-    session: AsyncSession,
+    session_manager: SessionManager[AsyncSession],
     toolkit_id: str,
     proxy_url: str | None,
     force: bool,
+    connection: MCPOAuthConnection | None = None,
 ) -> MCPOAuthConnection | None:
-    """Refresh OAuth connection while holding the row lock.
+    """Refresh OAuth outside DB and conditionally persist the result.
 
     :param connection_repo: OAuth connection repository
-    :param session: Database session
+    :param session_manager: Database session factory
     :param toolkit_id: Toolkit ID
     :param proxy_url: egress proxy URL
     :param force: Refresh even when token is not near expiry
     :return: Refreshed or existing OAuth connection
     """
-    connection = await connection_repo.get_by_toolkit_id_for_update(session, toolkit_id)
+    if connection is None:
+        async with session_manager() as session:
+            connection = await connection_repo.get_by_toolkit_id(session, toolkit_id)
     if connection is None or connection.status != MCPOAuthConnectionStatus.CONNECTED:
         return connection
     if not force and not _token_needs_refresh(connection):
         return connection
     if connection.refresh_token is None:
-        await connection_repo.mark_reconnect_required(session, toolkit_id=toolkit_id)
-        return await connection_repo.get_by_toolkit_id(session, toolkit_id)
+        return await _persist_refresh_failure(
+            connection_repo=connection_repo,
+            session_manager=session_manager,
+            connection=connection,
+            toolkit_id=toolkit_id,
+            reconnect_required=True,
+        )
 
     try:
         refreshed = await refresh_access_token(
@@ -359,50 +369,108 @@ async def _refresh_oauth_connection_under_lock(
             proxy_url=proxy_url,
         )
     except httpx.HTTPStatusError as exc:
-        await _handle_refresh_failure(
-            exc,
-            connection_repo=connection_repo,
-            session=session,
-            toolkit_id=toolkit_id,
-        )
-        return await connection_repo.get_by_toolkit_id(session, toolkit_id)
-    except OAuthTokenError as exc:
-        if "invalid_grant" in str(exc):
-            await connection_repo.mark_reconnect_required(
-                session, toolkit_id=toolkit_id
+        reconnect_required = _refresh_failure_requires_reconnect(exc)
+        if not reconnect_required:
+            logger.warning(
+                "Failed to refresh MCP OAuth connection",
+                extra={
+                    "toolkit_id": toolkit_id,
+                    "status_code": exc.response.status_code,
+                },
+                exc_info=True,
             )
-        else:
+        return await _persist_refresh_failure(
+            connection_repo=connection_repo,
+            session_manager=session_manager,
+            connection=connection,
+            toolkit_id=toolkit_id,
+            reconnect_required=reconnect_required,
+        )
+    except OAuthTokenError as exc:
+        reconnect_required = "invalid_grant" in str(exc)
+        if not reconnect_required:
             logger.warning(
                 "Failed to refresh MCP OAuth connection",
                 extra={"toolkit_id": toolkit_id},
                 exc_info=True,
             )
-        return await connection_repo.get_by_toolkit_id(session, toolkit_id)
+        return await _persist_refresh_failure(
+            connection_repo=connection_repo,
+            session_manager=session_manager,
+            connection=connection,
+            toolkit_id=toolkit_id,
+            reconnect_required=reconnect_required,
+        )
     except httpx.HTTPError, KeyError, ValidationError:
         logger.warning(
             "Failed to refresh MCP OAuth connection",
             extra={"toolkit_id": toolkit_id},
             exc_info=True,
         )
+        return await _persist_refresh_failure(
+            connection_repo=connection_repo,
+            session_manager=session_manager,
+            connection=connection,
+            toolkit_id=toolkit_id,
+            reconnect_required=False,
+        )
+
+    async with session_manager() as session:
+        current = await connection_repo.get_by_toolkit_id_for_update(
+            session, toolkit_id
+        )
+        if current is None:
+            return None
+        if _connection_changed(connection, current):
+            return current
+        return await connection_repo.update_tokens(
+            session,
+            toolkit_id=toolkit_id,
+            access_token=refreshed.access_token,
+            refresh_token=refreshed.refresh_token,
+            expires_at=refreshed.expires_at,
+        )
+
+
+async def _persist_refresh_failure(
+    *,
+    connection_repo: MCPOAuthConnectionRepository,
+    session_manager: SessionManager[AsyncSession],
+    connection: MCPOAuthConnection,
+    toolkit_id: str,
+    reconnect_required: bool,
+) -> MCPOAuthConnection | None:
+    """Keep a concurrent refresh or persist this refresh failure."""
+    async with session_manager() as session:
+        current = await connection_repo.get_by_toolkit_id_for_update(
+            session, toolkit_id
+        )
+        if current is None:
+            return None
+        if _connection_changed(connection, current):
+            return current
+        if reconnect_required:
+            await connection_repo.mark_reconnect_required(
+                session, toolkit_id=toolkit_id
+            )
         return await connection_repo.get_by_toolkit_id(session, toolkit_id)
 
-    return await connection_repo.update_tokens(
-        session,
-        toolkit_id=toolkit_id,
-        access_token=refreshed.access_token,
-        refresh_token=refreshed.refresh_token,
-        expires_at=refreshed.expires_at,
+
+def _connection_changed(
+    before: MCPOAuthConnection,
+    current: MCPOAuthConnection,
+) -> bool:
+    """Return whether another transaction changed the credential snapshot."""
+    return (
+        current.updated_at != before.updated_at
+        or current.refresh_token != before.refresh_token
+        or current.access_token != before.access_token
+        or current.status != before.status
     )
 
 
-async def _handle_refresh_failure(
-    exc: httpx.HTTPStatusError,
-    *,
-    connection_repo: MCPOAuthConnectionRepository,
-    session: AsyncSession,
-    toolkit_id: str,
-) -> None:
-    """Handle HTTP refresh failure and mark terminal revocation."""
+def _refresh_failure_requires_reconnect(exc: httpx.HTTPStatusError) -> bool:
+    """Return whether an HTTP refresh failure requires reconnect."""
     should_reconnect = exc.response.status_code in {400, 401}
     if should_reconnect:
         try:
@@ -411,14 +479,7 @@ async def _handle_refresh_failure(
                 should_reconnect = payload.get("error") == "invalid_grant"
         except ValueError:
             pass
-    if should_reconnect:
-        await connection_repo.mark_reconnect_required(session, toolkit_id=toolkit_id)
-        return
-    logger.warning(
-        "Failed to refresh MCP OAuth connection",
-        extra={"toolkit_id": toolkit_id, "status_code": exc.response.status_code},
-        exc_info=True,
-    )
+    return should_reconnect
 
 
 async def _test_oauth2_discovery(

--- a/python/apps/azents/src/azents/engine/tools/mcp_test.py
+++ b/python/apps/azents/src/azents/engine/tools/mcp_test.py
@@ -1,0 +1,195 @@
+"""MCP Toolkit OAuth refresh transaction tests."""
+
+import datetime
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from azents.core.enums import MCPOAuthConnectionStatus
+from azents.core.oauth2 import OAuthTokenResponse
+from azents.repos.mcp_oauth_connection.data import MCPOAuthConnection
+
+from . import mcp as mcp_module
+
+
+def _connection(*, access_token: str, updated_second: int = 0) -> MCPOAuthConnection:
+    """Build one refreshable OAuth connection snapshot."""
+    now = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+    return MCPOAuthConnection(
+        id="1" * 32,
+        toolkit_id="toolkit-1",
+        issuer=None,
+        resource=None,
+        server_url="https://mcp.example.test",
+        authorization_endpoint="https://auth.example.test/authorize",
+        token_endpoint="https://auth.example.test/token",
+        registration_endpoint=None,
+        client_id="client-1",
+        client_secret="secret-1",
+        token_endpoint_auth_method="client_secret_post",
+        scope=None,
+        access_token=access_token,
+        refresh_token="refresh-1",
+        expires_at=now,
+        status=MCPOAuthConnectionStatus.CONNECTED,
+        created_at=now,
+        updated_at=now + datetime.timedelta(seconds=updated_second),
+    )
+
+
+class _ConnectionRepository:
+    """In-memory repository that verifies every DB call has an open session."""
+
+    def __init__(self, connection: MCPOAuthConnection, active: list[int]) -> None:
+        self.connection = connection
+        self.active = active
+        self.update_calls = 0
+
+    def _assert_session(self) -> None:
+        assert self.active[0] == 1
+
+    async def get_by_toolkit_id(
+        self, session: AsyncSession, toolkit_id: str
+    ) -> MCPOAuthConnection:
+        del session, toolkit_id
+        self._assert_session()
+        return self.connection.model_copy(deep=True)
+
+    async def get_by_toolkit_id_for_update(
+        self, session: AsyncSession, toolkit_id: str
+    ) -> MCPOAuthConnection:
+        return await self.get_by_toolkit_id(session, toolkit_id)
+
+    async def update_tokens(
+        self,
+        session: AsyncSession,
+        *,
+        toolkit_id: str,
+        access_token: str,
+        refresh_token: str | None,
+        expires_at: datetime.datetime | None,
+    ) -> MCPOAuthConnection:
+        del session, toolkit_id
+        self._assert_session()
+        self.update_calls += 1
+        self.connection = self.connection.model_copy(
+            update={
+                "access_token": access_token,
+                "refresh_token": refresh_token or self.connection.refresh_token,
+                "expires_at": expires_at,
+                "updated_at": self.connection.updated_at
+                + datetime.timedelta(seconds=1),
+            }
+        )
+        return self.connection.model_copy(deep=True)
+
+    async def mark_reconnect_required(
+        self, session: AsyncSession, *, toolkit_id: str
+    ) -> None:
+        del session, toolkit_id
+        self._assert_session()
+        self.connection = self.connection.model_copy(
+            update={"status": MCPOAuthConnectionStatus.RECONNECT_REQUIRED}
+        )
+
+
+@pytest.mark.asyncio
+async def test_oauth_refresh_closes_db_session_during_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token HTTP I/O runs between the read and conditional-write sessions."""
+    active = [0]
+
+    @asynccontextmanager
+    async def session_manager() -> AsyncIterator[AsyncSession]:
+        active[0] += 1
+        try:
+            yield cast(AsyncSession, object())
+        finally:
+            active[0] -= 1
+
+    async def refresh_access_token(
+        token_url: str,
+        client_id: str,
+        client_secret: str | None,
+        refresh_token: str,
+        *,
+        proxy_url: str | None,
+    ) -> OAuthTokenResponse:
+        del token_url, client_id, client_secret, refresh_token, proxy_url
+        assert active[0] == 0
+        return OAuthTokenResponse(
+            access_token="access-2",
+            refresh_token="refresh-2",
+            expires_in=3600,
+        )
+
+    monkeypatch.setattr(mcp_module, "refresh_access_token", refresh_access_token)
+    repository = _ConnectionRepository(_connection(access_token="access-1"), active)
+
+    refreshed = await mcp_module._ensure_oauth_connection_token(  # pyright: ignore[reportPrivateUsage]
+        connection_repo=cast(Any, repository),
+        session_manager=session_manager,
+        toolkit_id="toolkit-1",
+        proxy_url=None,
+    )
+
+    assert refreshed is not None
+    assert refreshed.access_token == "access-2"
+    assert repository.update_calls == 1
+    assert active[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_oauth_refresh_keeps_concurrent_newer_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale refresh result cannot overwrite another committed refresh."""
+    active = [0]
+
+    @asynccontextmanager
+    async def session_manager() -> AsyncIterator[AsyncSession]:
+        active[0] += 1
+        try:
+            yield cast(AsyncSession, object())
+        finally:
+            active[0] -= 1
+
+    repository = _ConnectionRepository(_connection(access_token="access-1"), active)
+
+    async def refresh_access_token(
+        token_url: str,
+        client_id: str,
+        client_secret: str | None,
+        refresh_token: str,
+        *,
+        proxy_url: str | None,
+    ) -> OAuthTokenResponse:
+        del token_url, client_id, client_secret, refresh_token, proxy_url
+        assert active[0] == 0
+        repository.connection = _connection(
+            access_token="access-from-peer",
+            updated_second=1,
+        )
+        return OAuthTokenResponse(
+            access_token="stale-local-access",
+            refresh_token="stale-local-refresh",
+            expires_in=3600,
+        )
+
+    monkeypatch.setattr(mcp_module, "refresh_access_token", refresh_access_token)
+
+    refreshed = await mcp_module._ensure_oauth_connection_token(  # pyright: ignore[reportPrivateUsage]
+        connection_repo=cast(Any, repository),
+        session_manager=session_manager,
+        toolkit_id="toolkit-1",
+        proxy_url=None,
+    )
+
+    assert refreshed is not None
+    assert refreshed.access_token == "access-from-peer"
+    assert repository.update_calls == 0
+    assert active[0] == 0

--- a/python/apps/azents/src/azents/engine/tools/subagent.py
+++ b/python/apps/azents/src/azents/engine/tools/subagent.py
@@ -1091,7 +1091,8 @@ class SubagentToolkitProvider(ToolkitProvider[SubagentToolkitConfig]):
     ) -> SubagentToolkit:
         """Resolve per-session subagent collaboration tools."""
         del config
-        agent = await self.agent_repository.get_by_id(context.session, context.agent_id)
+        async with self.session_manager() as session:
+            agent = await self.agent_repository.get_by_id(session, context.agent_id)
         if agent is None:
             raise ValueError("Agent not found while resolving subagent Toolkit")
         subagent_settings = agent.subagent_settings

--- a/python/apps/azents/src/azents/worker/run/executor.py
+++ b/python/apps/azents/src/azents/worker/run/executor.py
@@ -937,41 +937,41 @@ class RunExecutor:
                 allowed_domains=(), denied_domains=()
             )
 
-            logger.info(
-                "Run agent tools resolve started",
-                extra={
-                    "session_id": message.session_id,
-                    "agent_id": invoke_input.agent_id,
-                    "run_id": run_id,
-                    "workspace_id": run_request.workspace_id,
-                    "model": run_request.model,
-                    "execution_mode": execution_mode.value,
-                    "memory_enabled": agent_memory_enabled,
-                    "runtime_tools_enabled": runtime_tools_enabled,
-                },
-            )
-            toolkits = await resolve_agent_tools(
-                invoke_input.agent_id,
-                context,
-                execution_mode=execution_mode,
-                toolkit_registry=self.toolkit_registry,
-                agent_toolkit_repository=self.agent_toolkit_repository,
-                toolkit_repository=self.toolkit_repository,
-                session=session,
-                web_url=self.worker_config.web_url,
-                oauth_secret_key=self.worker_config.oauth_secret_key,
-                mcp_proxy_url=self.worker_config.mcp_proxy_url,
-                runtime_domain_config=runtime_domain_config,
-                workspace_handle=message.workspace_handle or "",
-                builtin_toolkit_provider=self.builtin_toolkit_provider,
-                claude_rules_toolkit_provider=self.claude_rules_toolkit_provider,
-                todo_toolkit_provider=self.todo_toolkit_provider,
-                goal_toolkit_provider=self.goal_toolkit_provider,
-                skill_toolkit_provider=self.skill_toolkit_provider,
-                subagent_toolkit_provider=self.subagent_toolkit_provider,
-                memory_enabled=agent_memory_enabled,
-                runtime_tools_enabled=runtime_tools_enabled,
-            )
+        logger.info(
+            "Run agent tools resolve started",
+            extra={
+                "session_id": message.session_id,
+                "agent_id": invoke_input.agent_id,
+                "run_id": run_id,
+                "workspace_id": run_request.workspace_id,
+                "model": run_request.model,
+                "execution_mode": execution_mode.value,
+                "memory_enabled": agent_memory_enabled,
+                "runtime_tools_enabled": runtime_tools_enabled,
+            },
+        )
+        toolkits = await resolve_agent_tools(
+            invoke_input.agent_id,
+            context,
+            execution_mode=execution_mode,
+            toolkit_registry=self.toolkit_registry,
+            agent_toolkit_repository=self.agent_toolkit_repository,
+            toolkit_repository=self.toolkit_repository,
+            session_manager=self.session_manager,
+            web_url=self.worker_config.web_url,
+            oauth_secret_key=self.worker_config.oauth_secret_key,
+            mcp_proxy_url=self.worker_config.mcp_proxy_url,
+            runtime_domain_config=runtime_domain_config,
+            workspace_handle=message.workspace_handle or "",
+            builtin_toolkit_provider=self.builtin_toolkit_provider,
+            claude_rules_toolkit_provider=self.claude_rules_toolkit_provider,
+            todo_toolkit_provider=self.todo_toolkit_provider,
+            goal_toolkit_provider=self.goal_toolkit_provider,
+            skill_toolkit_provider=self.skill_toolkit_provider,
+            subagent_toolkit_provider=self.subagent_toolkit_provider,
+            memory_enabled=agent_memory_enabled,
+            runtime_tools_enabled=runtime_tools_enabled,
+        )
 
         now = loop.time()
         logger.info(


### PR DESCRIPTION
## Summary

- make `AgentRunExecution` own short database sessions for individual durable reads and writes instead of inheriting one session for the whole run
- close database sessions before boundary input polling, model/tool/hook execution, live event publication, attachment materialization, provider token refresh, and Toolkit provider resolution
- refresh MCP OAuth credentials with snapshot -> external HTTP -> row-locked revalidation/persist, preserving concurrency safety without Redis
- add regression coverage that asserts external run callbacks and OAuth HTTP refresh execute with zero open database sessions
- document the Engine database-session boundary convention

## Root cause

The Engine run adapter passed a single `AsyncSession` into the ReAct loop. That session remained open across model streaming, tool execution, hooks, live output publication, input polling, and auto-compaction. Toolkit resolution also reused a caller session while providers could perform OAuth HTTP requests. MCP OAuth refresh additionally held a `SELECT FOR UPDATE` row lock during the token endpoint call.

Those scopes kept transactions and pooled connections alive across unbounded external I/O, increasing lock contention and making stop/input processing susceptible to stalls.

## Lock semantics

- The `AgentRun` row lock used to append a tool result and remove only that call from `active_tool_calls` remains intact and is held only for the short atomic database update.
- The in-memory tool-admission barrier remains intact so shutdown cannot race with foreground tool admission.
- MCP refresh no longer holds a row lock during HTTP. It reads an immutable credential snapshot, closes the session, performs the HTTP request, then takes the row lock briefly and compares the current token/status/version fields before persisting. If another worker already refreshed or changed the connection, that newer state wins.
- No Redis lock was added.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright .` (0 errors)
- `uv run pytest -q` (1627 passed)
- `pre-commit run`
- OpenAPI and documentation index drift checks
