### PR TITLE
fix(engine): avoid input buffer attachment self-deadlock

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -16,7 +16,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Domain | Owner | Last Verified At | Spec Version |
 |---|---|---|---|---|
 | [Agent Domain Spec](spec/domain/agent.md) | agent | @Hardtack | 2026-07-12 | 46 |
-| [Conversation & Events](spec/domain/conversation.md) | conversation | @Hardtack | 2026-07-14 | 100 |
+| [Conversation & Events](spec/domain/conversation.md) | conversation | @Hardtack | 2026-07-15 | 101 |
 | [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-07-01 | 8 |
 | [Memory](spec/domain/memory.md) | memory | @Hardtack | 2026-07-09 | 4 |
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-07-14 | 7 |
@@ -30,13 +30,13 @@ _8 documents_
 
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
-| [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 83 |
+| [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 84 |
 | [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-12 | 17 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-14 | 29 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-14 | 8 |
 | [Context Compaction](spec/flow/context-compaction.md) | @Hardtack | 2026-07-14 | 21 |
-| [File Exchange Storage](spec/flow/file-exchange-storage.md) | @Hardtack | 2026-07-11 | 13 |
+| [File Exchange Storage](spec/flow/file-exchange-storage.md) | @Hardtack | 2026-07-15 | 14 |
 | [MCP OAuth Flow](spec/flow/mcp-oauth.md) | @Hardtack | 2026-06-29 | 4 |
 | [Periodic Execution Flow Spec](spec/flow/periodic-execution.md) | - | 2026-06-27 | 2 |
 | [Run Resume](spec/flow/run-resume.md) | @Hardtack | 2026-07-14 | 19 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -13,7 +13,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Domain | Title | Owner | Last Verified | Version |
 |---|---|---|---|---|
 | agent | [Agent Domain Spec](domain/agent.md) | @Hardtack | 2026-07-12 | 46 |
-| conversation | [Conversation & Events](domain/conversation.md) | @Hardtack | 2026-07-14 | 100 |
+| conversation | [Conversation & Events](domain/conversation.md) | @Hardtack | 2026-07-15 | 101 |
 | goal | [Goal Domain Spec](domain/goal.md) | - | 2026-07-01 | 8 |
 | memory | [Memory](domain/memory.md) | @Hardtack | 2026-07-09 | 4 |
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-07-14 | 7 |
@@ -25,13 +25,13 @@ Details of all living specs. Synchronized from frontmatter.
 
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
-| [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 83 |
+| [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 84 |
 | [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-12 | 17 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-14 | 29 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-14 | 8 |
 | [Context Compaction](flow/context-compaction.md) | @Hardtack | 2026-07-14 | 21 |
-| [File Exchange Storage](flow/file-exchange-storage.md) | @Hardtack | 2026-07-11 | 13 |
+| [File Exchange Storage](flow/file-exchange-storage.md) | @Hardtack | 2026-07-15 | 14 |
 | [MCP OAuth Flow](flow/mcp-oauth.md) | @Hardtack | 2026-06-29 | 4 |
 | [Periodic Execution Flow Spec](flow/periodic-execution.md) | - | 2026-06-27 | 2 |
 | [Run Resume](flow/run-resume.md) | @Hardtack | 2026-07-14 | 19 |

--- a/docs/azents/spec/domain/conversation.md
+++ b/docs/azents/spec/domain/conversation.md
@@ -91,8 +91,8 @@ api_routes:
   - /chat/v1/exchange-files/{file_id}/download
   - /internal/agent-home/v1/runtimes/{agent_runtime_id}/hibernate
   - /internal/agent-home/v1/runtimes/{agent_runtime_id}/projects
-last_verified_at: 2026-07-14
-spec_version: 100
+last_verified_at: 2026-07-15
+spec_version: 101
 ---
 
 # Conversation & Events
@@ -569,10 +569,13 @@ profile, then the Agent default when the Session has no snapshot.
 `InputBufferService` owns input-buffer reads and writes. Enqueue commits only the pending row;
 producers own wake-up and run-state transitions. Preparation handles exactly one FIFO head per
 transaction. The worker first reads the head's identity and inference requirement, resolves the
-profile outside the transaction when needed, then locks the Session and the same FIFO head. If the
-identity changed, it discards the stale preparation result and starts again. Successful preparation
-atomically updates the complete Session inference snapshot, applies Goal/Skill state changes, appends
-canonical events, associates input events with the active run, and deletes the source buffer.
+profile and attachment metadata outside any database session when needed, then locks the Session and
+the same FIFO head. Attachment resolution is metadata-only during promotion: it never downloads the
+Exchange file or creates a replacement ModelFile, and model rich input comes only from FileParts
+stored on the buffer at its creation boundary. If the identity changed while external preparation
+ran, the worker discards the stale result and starts again. Successful preparation atomically updates
+the complete Session inference snapshot, applies Goal/Skill state changes, appends canonical events,
+associates input events with the active run, and deletes the source buffer.
 
 Canonical outcomes are:
 
@@ -708,6 +711,8 @@ Current verification:
 
 ## 11. Changelog
 
+- **2026-07-15** — v101. Required input-buffer attachment metadata resolution outside the locking
+  transaction, FIFO head revalidation afterward, and creation-boundary-only FileParts.
 - **2026-07-14** — v100. Defined action execution tables as active operation state, with owner-generation admission, atomic durable terminal snapshot/delete handover, explicit live removal, and cancelled no-reexecution recovery.
 - **2026-07-13** — v99. Promoted raw-page cursor ownership, cross-page semantic projection identity, provider/internal-agent rendering, durable-over-live promotion, and explicit public WebSocket delivery boundaries.
 - **2026-07-12** — v98. Made PostgreSQL active tool ownership authoritative for execution and live reconstruction, and removed the Background flag from active calls.

--- a/docs/azents/spec/flow/agent-execution-loop.md
+++ b/docs/azents/spec/flow/agent-execution-loop.md
@@ -42,7 +42,7 @@ code_paths:
   - typescript/apps/azents-web/src/features/chat/components/ChatView.tsx
   - typescript/apps/azents-web/src/features/chat/containers/useChatSessionContainer.ts
 last_verified_at: 2026-07-15
-spec_version: 83
+spec_version: 84
 ---
 
 # Agent Execution Loop
@@ -59,7 +59,7 @@ worker/UI stream boundaries, but the DB source of truth is the event transcript 
 
 Main steps:
 
-1. Worker reads exactly one FIFO InputBuffer head, resolves the requested profile when that input requires inference, and then locks the same head for atomic preparation.
+1. Worker reads exactly one FIFO InputBuffer head, resolves the requested profile and attachment metadata outside a database session, and then locks the same head for atomic preparation.
 2. Preparation atomically updates the Session inference snapshot, applies Goal/Skill side effects, appends canonical events, associates run input, and deletes the source buffer. A changed FIFO head restarts preparation instead of applying a stale resolution.
 3. Worker executes buffer-keyed operation TurnActions such as `create_git_worktree` before the next model dispatch. The current Session owner generation admits the execution before buffer deletion; active state and progress remain in execution tables until one atomic terminal handover appends durable history and deletes live state.
 4. `AgentRunExecution` repeats model steps and tool steps while updating `agent_runs.phase`.
@@ -589,7 +589,10 @@ Run execution uses short database sessions around one durable read or state tran
 preparation callbacks, model streaming, runtime hooks, foreground tools, Toolkit provider resolution,
 OAuth token HTTP requests, broker calls, and live event publication run only after the preceding
 database session has closed. Boundary input polling also completes its external queue read before it
-opens the short session that appends promoted messages.
+opens the short session that appends promoted messages. Input-buffer attachment metadata resolution
+likewise runs after its snapshot session closes; promotion then locks and revalidates the FIFO head
+before applying any durable changes. Flush reuses only the FileParts stored at the input boundary and
+never downloads an attachment or creates a ModelFile while holding the Session/FIFO lock.
 
 Row locks remain limited to persistence invariants. Tool-result finalization locks its `AgentRun`
 while appending the deterministic result and removing that call from `active_tool_calls`, so parallel
@@ -664,6 +667,9 @@ updated by the user.
 
 ## Changelog
 
+- **2026-07-15** (spec_version 84) — Moved input-buffer attachment metadata resolution before the
+  locking transaction, required FIFO revalidation afterward, and prohibited execution-time
+  attachment-to-ModelFile rematerialization.
 - **2026-07-15** (spec_version 83) — Required unexpected Toolkit resolution and runtime instruction
   storage failures to propagate instead of being silently represented as missing optional context.
 - **2026-07-15** (spec_version 82) — Required short run-owned database sessions, external-I/O

--- a/docs/azents/spec/flow/file-exchange-storage.md
+++ b/docs/azents/spec/flow/file-exchange-storage.md
@@ -9,6 +9,7 @@ code_paths:
   - python/apps/azents/src/azents/services/exchange_file/**
   - python/apps/azents/src/azents/services/artifact.py
   - python/apps/azents/src/azents/services/model_file.py
+  - python/apps/azents/src/azents/services/input_buffer.py
   - python/apps/azents/src/azents/repos/artifact/**
   - python/apps/azents/src/azents/repos/model_file/**
   - python/apps/azents/src/azents/rdb/models/artifact.py
@@ -29,8 +30,8 @@ code_paths:
   - typescript/apps/azents-web/src/features/chat/components/AttachmentPreviewBar.tsx
   - typescript/apps/azents-web/src/features/chat/components/FileAttachmentList.tsx
   - typescript/apps/azents-web/src/features/chat/components/AttachmentPreviewViewer.tsx
-last_verified_at: 2026-07-11
-spec_version: 13
+last_verified_at: 2026-07-15
+spec_version: 14
 ---
 
 # File Exchange Storage
@@ -108,6 +109,9 @@ When `spawn_agent` forks parent model-visible context into a child session, File
 
 ## Changelog
 
+- **2026-07-15** — v14. Clarified that input-buffer promotion resolves only Exchange attachment
+  metadata outside its locking transaction and reuses creation-boundary FileParts without download
+  or rematerialization.
 - **2026-07-11** — v13. Added persisted previews for uploaded text files and delegated original-image zooming to the browser's native image viewer.
 - **2026-07-11** — v12. Clarified universal preview activation, isolated download actions, unsupported-file fallback, and original-only Agent image galleries.
 - **2026-07-11** — v11. Documented compact attachment strips, Agent image galleries and mixed groups, dynamic overflow masks, and the shared responsive preview viewer.

--- a/python/apps/azents/src/azents/services/agent_session_input_test.py
+++ b/python/apps/azents/src/azents/services/agent_session_input_test.py
@@ -43,7 +43,6 @@ from azents.repos.workspace.data import WorkspaceCreate
 from azents.repos.workspace_user import WorkspaceUserRepository
 from azents.repos.workspace_user.data import WorkspaceUserCreate
 from azents.services.exchange_file import ExchangeFileService
-from azents.services.model_file import ModelFileService
 from azents.testing.model_selection import make_test_model_selection_dict
 
 from .agent_session_input import (
@@ -200,13 +199,6 @@ class _ExchangeFileService(ExchangeFileService):
         """Bypass Base dataclass initialization."""
 
 
-class _ModelFileService(ModelFileService):
-    """ModelFileService for tests."""
-
-    def __init__(self) -> None:
-        """Bypass Base dataclass initialization."""
-
-
 def _input_buffer_service(
     rdb_session_manager: SessionManager[AsyncSession],
 ) -> InputBufferService:
@@ -215,7 +207,6 @@ def _input_buffer_service(
         session_manager=rdb_session_manager,
         input_buffer_repository=InputBufferRepository(),
         exchange_file_service=_ExchangeFileService(),
-        model_file_service=_ModelFileService(),
         agent_session_repository=AgentSessionRepository(),
         event_transcript_repository=EventTranscriptRepository(),
         agent_run_repository=AgentRunRepository(),

--- a/python/apps/azents/src/azents/services/chat/input_buffer_test.py
+++ b/python/apps/azents/src/azents/services/chat/input_buffer_test.py
@@ -46,7 +46,6 @@ from azents.repos.workspace_user import WorkspaceUserRepository
 from azents.repos.workspace_user.data import WorkspaceUserCreate
 from azents.services.exchange_file import ExchangeFileService
 from azents.services.input_buffer import InputBufferService
-from azents.services.model_file import ModelFileService
 from azents.testing.model_selection import (
     make_test_model_selection,
     make_test_model_selection_dict,
@@ -133,7 +132,6 @@ def _service(
         session_manager=rdb_session_manager,
         input_buffer_repository=InputBufferRepository(),
         exchange_file_service=_ExchangeFileService(),
-        model_file_service=_ModelFileService(),
         agent_session_repository=AgentSessionRepository(),
         event_transcript_repository=EventTranscriptRepository(),
         agent_run_repository=AgentRunRepository(),
@@ -158,13 +156,6 @@ def _service(
 
 class _ExchangeFileService(ExchangeFileService):
     """ExchangeFileService for tests."""
-
-    def __init__(self) -> None:
-        """Bypass Base dataclass initialization."""
-
-
-class _ModelFileService(ModelFileService):
-    """ModelFileService for tests."""
 
     def __init__(self) -> None:
         """Bypass Base dataclass initialization."""
@@ -373,7 +364,6 @@ class TestChatSessionInputBuffer:
             session_manager=rdb_session_manager,
             input_buffer_repository=InputBufferRepository(),
             exchange_file_service=_ExchangeFileService(),
-            model_file_service=_ModelFileService(),
             agent_session_repository=AgentSessionRepository(),
             event_transcript_repository=EventTranscriptRepository(),
             agent_run_repository=AgentRunRepository(),

--- a/python/apps/azents/src/azents/services/chat/team_session_test.py
+++ b/python/apps/azents/src/azents/services/chat/team_session_test.py
@@ -39,7 +39,6 @@ from azents.repos.workspace_user.data import WorkspaceUserCreate
 from azents.services.chat.data import InvalidSessionTitle
 from azents.services.exchange_file import ExchangeFileService
 from azents.services.input_buffer import InputBufferService
-from azents.services.model_file import ModelFileService
 from azents.testing.model_selection import make_test_model_selection_dict
 
 from . import ChatSessionService
@@ -135,7 +134,6 @@ def _service(
             session_manager=rdb_session_manager,
             input_buffer_repository=InputBufferRepository(),
             exchange_file_service=_ExchangeFileService(),
-            model_file_service=_ModelFileService(),
             agent_session_repository=AgentSessionRepository(),
             event_transcript_repository=EventTranscriptRepository(),
             agent_run_repository=AgentRunRepository(),
@@ -147,13 +145,6 @@ def _service(
 
 class _ExchangeFileService(ExchangeFileService):
     """ExchangeFileService for tests."""
-
-    def __init__(self) -> None:
-        """Bypass Base dataclass initialization."""
-
-
-class _ModelFileService(ModelFileService):
-    """ModelFileService for tests."""
 
     def __init__(self) -> None:
         """Bypass Base dataclass initialization."""

--- a/python/apps/azents/src/azents/services/chat_write_test.py
+++ b/python/apps/azents/src/azents/services/chat_write_test.py
@@ -56,7 +56,6 @@ from azents.repos.workspace.data import WorkspaceCreate
 from azents.services.chat_write import ChatWriteService
 from azents.services.exchange_file import ExchangeFileService
 from azents.services.input_buffer import InputBufferService
-from azents.services.model_file import ModelFileService
 from azents.testing.model_selection import (
     make_test_model_selection_dict,
 )
@@ -159,7 +158,6 @@ def _service(
         session_manager=rdb_session_manager,
         input_buffer_repository=InputBufferRepository(),
         exchange_file_service=_ExchangeFileService(),
-        model_file_service=_ModelFileService(),
         agent_session_repository=AgentSessionRepository(),
         event_transcript_repository=EventTranscriptRepository(),
         agent_run_repository=AgentRunRepository(),
@@ -177,13 +175,6 @@ def _service(
 
 class _ExchangeFileService(ExchangeFileService):
     """ExchangeFileService for tests."""
-
-    def __init__(self) -> None:
-        """Bypass Base dataclass initialization."""
-
-
-class _ModelFileService(ModelFileService):
-    """ModelFileService for tests."""
 
     def __init__(self) -> None:
         """Bypass Base dataclass initialization."""
@@ -296,7 +287,6 @@ class TestChatWriteService:
                 session_manager=rdb_session_manager,
                 input_buffer_repository=InputBufferRepository(),
                 exchange_file_service=_ExchangeFileService(),
-                model_file_service=_ModelFileService(),
                 agent_session_repository=AgentSessionRepository(),
                 event_transcript_repository=EventTranscriptRepository(),
                 agent_run_repository=AgentRunRepository(),

--- a/python/apps/azents/src/azents/services/input_buffer.py
+++ b/python/apps/azents/src/azents/services/input_buffer.py
@@ -32,6 +32,7 @@ from azents.engine.events.types import (
     SystemErrorPayload,
 )
 from azents.engine.events.user_messages import make_run_user_message
+from azents.engine.io.attachments import RuntimeAttachment
 from azents.engine.io.user_input import RunUserMessage
 from azents.engine.run.resolve import materialize_user_input_exchange_file_attachments
 from azents.engine.tools.goal import GoalState, GoalStateSnapshot, GoalStateStore
@@ -51,7 +52,6 @@ from azents.repos.agent_session import AgentSessionRepository
 from azents.repos.input_buffer import InputBufferRepository
 from azents.repos.input_buffer.data import InputBuffer, InputBufferCreate
 from azents.services.exchange_file import ExchangeFileService
-from azents.services.model_file import ModelFileService
 from azents.services.session_title import initial_title_from_event
 
 logger = logging.getLogger(__name__)
@@ -157,6 +157,14 @@ class _PromotedInputBuffer:
 
 
 @dataclasses.dataclass(frozen=True)
+class PreparedInputBufferFiles:
+    """Attachment metadata and creation-boundary FileParts prepared for promotion."""
+
+    attachments: list[RuntimeAttachment]
+    file_parts: list[FileOutputPart]
+
+
+@dataclasses.dataclass(frozen=True)
 class InputBufferPreparationContext:
     """Shared context passed to one closed input-buffer processor."""
 
@@ -164,6 +172,7 @@ class InputBufferPreparationContext:
     session_id: str
     required_inference_profile: RequestedInferenceProfile | None
     prepared_inference_state: SessionInferenceState | None
+    prepared_files: PreparedInputBufferFiles
 
 
 @dataclasses.dataclass(frozen=True)
@@ -198,7 +207,6 @@ class InputBufferService:
         InputBufferRepository, Depends(InputBufferRepository)
     ]
     exchange_file_service: Annotated[ExchangeFileService, Depends(ExchangeFileService)]
-    model_file_service: Annotated[ModelFileService, Depends(ModelFileService)]
     agent_session_repository: Annotated[
         AgentSessionRepository, Depends(AgentSessionRepository)
     ]
@@ -379,6 +387,10 @@ class InputBufferService:
         """Flush pending buffers of session in claim, append, delete order."""
         del model
         del limit
+        prepared_files = await self._prepare_input_buffer_attachments(
+            session_id=session_id,
+            expected_buffer_id=expected_buffer_id,
+        )
         async with self.session_manager() as session:
             agent_session = await self.agent_session_repository.lock_by_id(
                 session,
@@ -416,6 +428,7 @@ class InputBufferService:
                 claimed=claimed,
                 required_inference_profile=required_inference_profile,
                 prepared_inference_state=prepared_inference_state,
+                prepared_files=prepared_files,
                 profile_resolution_failure=profile_resolution_failure,
                 include_action_messages=include_action_messages,
             )
@@ -534,6 +547,52 @@ class InputBufferService:
             deduped_count=len(deduped),
         )
 
+    async def _prepare_input_buffer_attachments(
+        self,
+        *,
+        session_id: str,
+        expected_buffer_id: str | None,
+    ) -> PreparedInputBufferFiles:
+        """Resolve the FIFO head attachments without holding a database session."""
+        async with self.session_manager() as session:
+            agent_session = await self.agent_session_repository.get_by_id(
+                session,
+                session_id,
+            )
+            pending = await self.input_buffer_repository.list_for_flush(
+                session,
+                session_id,
+                limit=1,
+            )
+        if agent_session is None:
+            raise ValueError("AgentSession not found")
+        buffer = pending[0] if pending else None
+        actual_buffer_id = buffer.id if buffer is not None else None
+        if actual_buffer_id != expected_buffer_id:
+            raise InputBufferPreparationStaleError(
+                "Input buffer FIFO head changed during preparation"
+            )
+        if buffer is None:
+            return PreparedInputBufferFiles(attachments=[], file_parts=[])
+
+        file_parts = list(buffer.file_parts)
+        if not buffer.attachments:
+            return PreparedInputBufferFiles(attachments=[], file_parts=file_parts)
+        if buffer.actor_user_id is None:
+            raise ValueError("Input buffer attachments require an actor user")
+        materialized = await materialize_user_input_exchange_file_attachments(
+            buffer.attachments,
+            agent_id=agent_session.agent_id,
+            session_id=buffer.session_id,
+            exchange_file_service=self.exchange_file_service,
+            model_file_service=None,
+            user_id=buffer.actor_user_id,
+        )
+        return PreparedInputBufferFiles(
+            attachments=materialized.attachments,
+            file_parts=file_parts,
+        )
+
     async def _promote_claimed_buffers(
         self,
         session: AsyncSession,
@@ -542,6 +601,7 @@ class InputBufferService:
         claimed: list[InputBuffer],
         required_inference_profile: RequestedInferenceProfile | None,
         prepared_inference_state: SessionInferenceState | None,
+        prepared_files: PreparedInputBufferFiles,
         profile_resolution_failure: str | None,
         include_action_messages: bool,
     ) -> InputBufferPreparationOutcome:
@@ -575,6 +635,7 @@ class InputBufferService:
             session_id=session_id,
             required_inference_profile=required_inference_profile,
             prepared_inference_state=prepared_inference_state,
+            prepared_files=prepared_files,
         )
         processor = self._processor_for(buffer)
         return await processor.process(context, buffer)
@@ -613,6 +674,7 @@ class InputBufferService:
         session_id: str,
         buffer: InputBuffer,
         prepared_inference_state: SessionInferenceState | None,
+        prepared_files: PreparedInputBufferFiles,
     ) -> list[_PromotedInputBuffer]:
         """Apply Goal create side effect for one action_message buffer."""
         objective = buffer.content.strip()
@@ -649,11 +711,12 @@ class InputBufferService:
         except _GoalActionError as exc:
             return [_system_error_promoted_buffer(buffer, exc.message)]
         snapshot = GoalStateSnapshot.from_state(updated)
-        user_message = await self.buffer_to_user_message(
+        user_message = self.buffer_to_user_message(
             buffer,
             external_id=f"{buffer.id}:user_message",
             fallback_profile=_requested_inference_profile(buffer),
             prepared_inference_state=prepared_inference_state,
+            prepared_files=prepared_files,
         )
         return [
             _PromotedInputBuffer(
@@ -680,6 +743,7 @@ class InputBufferService:
         buffer: InputBuffer,
         action: SkillAction,
         prepared_inference_state: SessionInferenceState | None,
+        prepared_files: PreparedInputBufferFiles,
     ) -> list[_PromotedInputBuffer]:
         """Create durable reminder for one Skill action_message buffer."""
         agent_session = await self.agent_session_repository.get_by_id(
@@ -715,11 +779,12 @@ class InputBufferService:
             )
         ]
         if buffer.content.strip():
-            user_message = await self.buffer_to_user_message(
+            user_message = self.buffer_to_user_message(
                 buffer,
                 external_id=f"{buffer.id}:user_message",
                 fallback_profile=_requested_inference_profile(buffer),
                 prepared_inference_state=prepared_inference_state,
+                prepared_files=prepared_files,
             )
             promoted.append(
                 _PromotedInputBuffer(
@@ -732,46 +797,16 @@ class InputBufferService:
             )
         return promoted
 
-    async def buffer_to_user_message(
-        self,
+    @staticmethod
+    def buffer_to_user_message(
         buffer: InputBuffer,
         *,
         external_id: str | None = None,
         fallback_profile: RequestedInferenceProfile | None,
         prepared_inference_state: SessionInferenceState | None,
+        prepared_files: PreparedInputBufferFiles,
     ) -> RunUserMessage:
-        """Convert InputBuffer domain row to event run user message."""
-        attachments = []
-        file_parts = list(buffer.file_parts)
-        if buffer.attachments:
-            if buffer.actor_user_id is None:
-                raise ValueError("Input buffer attachments require an actor user")
-            async with self.session_manager() as session:
-                agent_session = await self.agent_session_repository.get_by_id(
-                    session,
-                    buffer.session_id,
-                )
-            if agent_session is None:
-                logger.warning(
-                    "Input buffer session disappeared before attachment "
-                    "materialization",
-                    extra={"session_id": buffer.session_id, "buffer_id": buffer.id},
-                )
-            else:
-                materialized = await materialize_user_input_exchange_file_attachments(
-                    buffer.attachments,
-                    agent_id=agent_session.agent_id,
-                    session_id=buffer.session_id,
-                    exchange_file_service=self.exchange_file_service,
-                    model_file_service=(
-                        None if file_parts else self.model_file_service
-                    ),
-                    user_id=buffer.actor_user_id,
-                )
-                attachments = materialized.attachments
-                if not file_parts:
-                    file_parts = materialized.file_parts
-
+        """Convert a prepared InputBuffer snapshot to a run user message."""
         requested_profile = _requested_inference_profile(buffer) or fallback_profile
         if prepared_inference_state is not None:
             applied_profile = prepared_inference_state.applied_profile
@@ -786,8 +821,8 @@ class InputBufferService:
         user_message = make_run_user_message(
             content=buffer.content,
             metadata=buffer.metadata,
-            attachments=attachments,
-            file_parts=file_parts,
+            attachments=prepared_files.attachments,
+            file_parts=prepared_files.file_parts,
             external_id=external_id or buffer.id,
             attachment_source="input_buffer",
             requested_inference_profile=requested_profile,
@@ -840,11 +875,12 @@ class _UserMessageInputBufferProcessor:
         context: InputBufferPreparationContext,
         buffer: InputBuffer,
     ) -> InputBufferPreparationOutcome:
-        user_message = await self.service.buffer_to_user_message(
+        user_message = self.service.buffer_to_user_message(
             buffer,
             external_id=f"{buffer.id}:user_message",
             fallback_profile=context.required_inference_profile,
             prepared_inference_state=context.prepared_inference_state,
+            prepared_files=context.prepared_files,
         )
         return _preparation_outcome(
             [
@@ -871,11 +907,12 @@ class _GoalContinuationInputBufferProcessor:
         context: InputBufferPreparationContext,
         buffer: InputBuffer,
     ) -> InputBufferPreparationOutcome:
-        user_message = await self.service.buffer_to_user_message(
+        user_message = self.service.buffer_to_user_message(
             buffer,
             external_id=f"{buffer.id}:goal_continuation",
             fallback_profile=context.required_inference_profile,
             prepared_inference_state=context.prepared_inference_state,
+            prepared_files=context.prepared_files,
         )
         return _preparation_outcome(
             [
@@ -902,11 +939,12 @@ class _AgentMessageInputBufferProcessor:
         context: InputBufferPreparationContext,
         buffer: InputBuffer,
     ) -> InputBufferPreparationOutcome:
-        user_message = await self.service.buffer_to_user_message(
+        user_message = self.service.buffer_to_user_message(
             buffer,
             external_id=f"{buffer.id}:agent_message",
             fallback_profile=context.required_inference_profile,
             prepared_inference_state=context.prepared_inference_state,
+            prepared_files=context.prepared_files,
         )
         return _preparation_outcome(
             [
@@ -940,6 +978,7 @@ class _GoalActionInputBufferProcessor:
             session_id=context.session_id,
             buffer=buffer,
             prepared_inference_state=context.prepared_inference_state,
+            prepared_files=context.prepared_files,
         )
         return _preparation_outcome(promoted, _turn_effect_for_promoted(promoted))
 
@@ -962,6 +1001,7 @@ class _SkillActionInputBufferProcessor:
             buffer=buffer,
             action=self.action,
             prepared_inference_state=context.prepared_inference_state,
+            prepared_files=context.prepared_files,
         )
         return _preparation_outcome(promoted, _turn_effect_for_promoted(promoted))
 

--- a/python/apps/azents/src/azents/services/input_buffer_test.py
+++ b/python/apps/azents/src/azents/services/input_buffer_test.py
@@ -1,5 +1,6 @@
 """InputBufferService tests."""
 
+import asyncio
 import dataclasses
 import datetime
 from unittest.mock import AsyncMock
@@ -51,7 +52,6 @@ from azents.repos.agent_session import AgentSessionRepository
 from azents.repos.exchange_file.data import ExchangeFile
 from azents.repos.input_buffer import InputBufferRepository
 from azents.repos.input_buffer.data import InputBuffer, InputBufferCreate
-from azents.repos.model_file.data import ModelFile
 from azents.repos.user import UserRepository
 from azents.repos.user.data import UserCreate
 from azents.repos.workspace import WorkspaceRepository
@@ -63,11 +63,6 @@ from azents.services.exchange_file import (
     FileAccessDenied,
     FileNotFound,
     SessionNotFound,
-)
-from azents.services.model_file import (
-    ModelFileCreateError,
-    ModelFileInvalidImage,
-    ModelFileService,
 )
 from azents.testing.model_selection import make_test_model_selection_dict
 
@@ -372,35 +367,51 @@ class _ExchangeFileService(ExchangeFileService):
         return Failure(FileNotFound())
 
 
-class _ModelFileService(ModelFileService):
-    """ModelFileService for tests."""
+class _DeletingExchangeFileService(_ExchangeFileService):
+    """Delete the prepared FIFO head while attachment metadata is resolving."""
 
-    def __init__(self) -> None:
-        """Store whether called."""
-        self.create_for_agent_pending_input_called = False
-
-    async def create_for_agent_pending_input(
+    def __init__(
         self,
         *,
-        agent_id: str,
+        session_manager: SessionManager[AsyncSession],
         session_id: str,
+        buffer_id: str,
+        metadata_result: Result[
+            ExchangeFile,
+            SessionNotFound | FileNotFound | FileAccessDenied,
+        ],
+    ) -> None:
+        """Store the row mutation performed by the external resolution phase."""
+        super().__init__(metadata_result)
+        self.session_manager = session_manager
+        self.session_id = session_id
+        self.buffer_id = buffer_id
+
+    async def resolve_attachment_metadata_for_agent(
+        self,
+        *,
+        uri: str,
+        agent_id: str,
         user_id: str,
-        filename: str | None,
-        media_type: str,
-        body: bytes,
-        metadata: dict[str, object] | None = None,
-    ) -> Result[ModelFile, ModelFileCreateError]:
-        """Record call and treat as failure."""
-        del agent_id, session_id, user_id, filename, media_type, body, metadata
-        self.create_for_agent_pending_input_called = True
-        return Failure(ModelFileInvalidImage())
+    ) -> Result[ExchangeFile, SessionNotFound | FileNotFound | FileAccessDenied]:
+        """Mutate FIFO state through another session before returning metadata."""
+        async with self.session_manager() as session:
+            await InputBufferRepository().delete_by_session_and_id(
+                session,
+                self.session_id,
+                self.buffer_id,
+            )
+        return await super().resolve_attachment_metadata_for_agent(
+            uri=uri,
+            agent_id=agent_id,
+            user_id=user_id,
+        )
 
 
 def _input_buffer_service(
     rdb_session_manager: SessionManager[AsyncSession],
     *,
     exchange_file_service: ExchangeFileService | None = None,
-    model_file_service: _ModelFileService | None = None,
     event_transcript_repository: EventTranscriptRepository | None = None,
 ) -> InputBufferService:
     """Create InputBufferService for tests."""
@@ -408,7 +419,6 @@ def _input_buffer_service(
         session_manager=rdb_session_manager,
         input_buffer_repository=InputBufferRepository(),
         exchange_file_service=exchange_file_service or _ExchangeFileService(),
-        model_file_service=model_file_service or _ModelFileService(),
         agent_session_repository=AgentSessionRepository(),
         event_transcript_repository=(
             event_transcript_repository or EventTranscriptRepository()
@@ -549,7 +559,6 @@ class TestInputBufferService:
             session_manager=rdb_session_manager,
             input_buffer_repository=repository,
             exchange_file_service=_ExchangeFileService(),
-            model_file_service=_ModelFileService(),
             agent_session_repository=AgentSessionRepository(),
             event_transcript_repository=EventTranscriptRepository(),
             agent_run_repository=AgentRunRepository(),
@@ -688,6 +697,52 @@ class TestInputBufferService:
         async with rdb_session_manager() as session:
             remaining = await InputBufferRepository().get_by_id(session, buffer_id)
         assert remaining is not None
+
+    async def test_flush_resolves_attachments_before_locking_fifo_head(
+        self,
+        rdb_session_manager: SessionManager[AsyncSession],
+    ) -> None:
+        """Attachment resolution cannot self-deadlock on the claimed buffer."""
+        session_id, user_id = await _create_fixture(
+            rdb_session_manager,
+            "input-buffer-attachment-revalidation",
+        )
+        attachment_uri = "exchange://exchange/workspace-001/session/report.txt"
+        buffer_id = await _create_buffer(
+            rdb_session_manager,
+            session_id=session_id,
+            user_id=user_id,
+            content="resolve before lock",
+            attachments=[attachment_uri],
+        )
+        exchange_file_service = _DeletingExchangeFileService(
+            session_manager=rdb_session_manager,
+            session_id=session_id,
+            buffer_id=buffer_id,
+            metadata_result=Success(
+                _exchange_file(
+                    file_id="1234567890abcdef1234567890abcdef",
+                    user_id=user_id,
+                    object_key=attachment_uri.removeprefix("exchange://"),
+                )
+            ),
+        )
+        service = _input_buffer_service(
+            rdb_session_manager,
+            exchange_file_service=exchange_file_service,
+        )
+
+        with pytest.raises(InputBufferPreparationStaleError):
+            async with asyncio.timeout(2):
+                await service.flush_session_input_buffers(
+                    session_id=session_id,
+                    model="gpt-5.4",
+                    required_inference_profile=None,
+                    expected_buffer_id=buffer_id,
+                    prepared_inference_state=None,
+                    profile_resolution_failure=None,
+                    active_run_id=None,
+                )
 
     async def test_flush_rolls_back_inference_state_and_buffer_on_event_failure(
         self,
@@ -1087,6 +1142,7 @@ class TestInputBufferService:
         assert payload.attachments[0].preview_thumbnail_uri == thumbnail_uri
         assert len(result.events) == 1
         assert result.events[0].id == event.id
+        assert not exchange_file_service.resolve_attachment_for_agent_called
 
     async def test_flush_reuses_buffer_file_parts_without_rematerializing(
         self,
@@ -1123,11 +1179,9 @@ class TestInputBufferService:
                 )
             )
         )
-        model_file_service = _ModelFileService()
         service = _input_buffer_service(
             rdb_session_manager,
             exchange_file_service=exchange_file_service,
-            model_file_service=model_file_service,
         )
 
         result = await service.flush_session_input_buffers(
@@ -1143,7 +1197,6 @@ class TestInputBufferService:
         promoted = result.user_messages[0]
         assert isinstance(promoted.payload.content, list)
         assert promoted.payload.content[1] == existing_part
-        assert not model_file_service.create_for_agent_pending_input_called
         assert not exchange_file_service.resolve_attachment_for_agent_called
 
     async def test_deleted_buffer_is_not_promoted(

--- a/python/apps/azents/src/azents/services/session_git_worktree/service_test.py
+++ b/python/apps/azents/src/azents/services/session_git_worktree/service_test.py
@@ -71,7 +71,6 @@ from azents.services.agent_project_catalog import AgentProjectCatalogService
 from azents.services.agent_session_input import AgentSessionInputService
 from azents.services.exchange_file import ExchangeFileService
 from azents.services.input_buffer import InputBufferService
-from azents.services.model_file import ModelFileService
 from azents.services.session_git_worktree import (
     GitWorktreeCleanupNotFound,
     GitWorktreeCleanupSubagentReadOnly,
@@ -421,13 +420,6 @@ class _ExchangeFileService(ExchangeFileService):
         """Bypass base dataclass initialization."""
 
 
-class _ModelFileService(ModelFileService):
-    """ModelFileService test double."""
-
-    def __init__(self) -> None:
-        """Bypass base dataclass initialization."""
-
-
 async def _create_agent_context(
     session: AsyncSession, slug: str
 ) -> tuple[str, str, str]:
@@ -525,7 +517,6 @@ def _input_service(
             session_manager=session_manager,
             input_buffer_repository=InputBufferRepository(),
             exchange_file_service=_ExchangeFileService(),
-            model_file_service=_ModelFileService(),
             agent_session_repository=AgentSessionRepository(),
             event_transcript_repository=EventTranscriptRepository(),
             agent_run_repository=AgentRunRepository(),
@@ -554,7 +545,6 @@ async def _execute_first_setup_action(
         session_manager=rdb_session_manager,
         input_buffer_repository=InputBufferRepository(),
         exchange_file_service=_ExchangeFileService(),
-        model_file_service=_ModelFileService(),
         agent_session_repository=AgentSessionRepository(),
         event_transcript_repository=EventTranscriptRepository(),
         agent_run_repository=AgentRunRepository(),


### PR DESCRIPTION
## What changed

- resolve InputBuffer attachment metadata before opening the Session/FIFO locking transaction
- re-lock and revalidate the same FIFO head before durable promotion
- stop rematerializing Exchange attachments into ModelFile/FilePart during flush
- make buffer-to-message conversion pure and remove the unused ModelFileService dependency
- document the transaction and creation-boundary FilePart invariants
- add a regression test that mutates the FIFO head through another DB session during attachment resolution

## Root cause

InputBuffer promotion locked the AgentSession and FIFO head, then attachment handling opened another database session and could insert a ModelFile referencing the already-locked AgentSession. That nested write waited on the outer transaction while the outer transaction awaited the nested call, creating an application-level self-deadlock. It also violated the rule that external preparation must not run while a database session or row lock is held.

## Impact

Attachment-bearing initial or follow-up messages can now be promoted without blocking subsequent sends. If the FIFO head changes while attachment metadata is being resolved, preparation is discarded and retried instead of applying stale results.

## Validation

- 70 related service integration tests passed
- 21 InputBufferService tests passed after the final refactor
- Ruff passed for the full azents source tree
- Pyright passed in the azents pre-commit hook and on the changed files
- all changed-file pre-commit hooks passed
- git diff --check passed
