### PR TITLE
fix(engine): harden session lifecycle transaction boundaries

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -16,7 +16,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Domain | Owner | Last Verified At | Spec Version |
 |---|---|---|---|---|
 | [Agent Domain Spec](spec/domain/agent.md) | agent | @Hardtack | 2026-07-12 | 46 |
-| [Conversation & Events](spec/domain/conversation.md) | conversation | @Hardtack | 2026-07-15 | 101 |
+| [Conversation & Events](spec/domain/conversation.md) | conversation | @Hardtack | 2026-07-15 | 102 |
 | [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-07-01 | 8 |
 | [Memory](spec/domain/memory.md) | memory | @Hardtack | 2026-07-09 | 4 |
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-07-14 | 7 |
@@ -30,13 +30,13 @@ _8 documents_
 
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
-| [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 84 |
+| [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 85 |
 | [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-12 | 17 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-14 | 29 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-14 | 8 |
 | [Context Compaction](spec/flow/context-compaction.md) | @Hardtack | 2026-07-14 | 21 |
-| [File Exchange Storage](spec/flow/file-exchange-storage.md) | @Hardtack | 2026-07-15 | 14 |
+| [File Exchange Storage](spec/flow/file-exchange-storage.md) | @Hardtack | 2026-07-15 | 15 |
 | [MCP OAuth Flow](spec/flow/mcp-oauth.md) | @Hardtack | 2026-06-29 | 4 |
 | [Periodic Execution Flow Spec](spec/flow/periodic-execution.md) | - | 2026-06-27 | 2 |
 | [Run Resume](spec/flow/run-resume.md) | @Hardtack | 2026-07-14 | 19 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -13,7 +13,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Domain | Title | Owner | Last Verified | Version |
 |---|---|---|---|---|
 | agent | [Agent Domain Spec](domain/agent.md) | @Hardtack | 2026-07-12 | 46 |
-| conversation | [Conversation & Events](domain/conversation.md) | @Hardtack | 2026-07-15 | 101 |
+| conversation | [Conversation & Events](domain/conversation.md) | @Hardtack | 2026-07-15 | 102 |
 | goal | [Goal Domain Spec](domain/goal.md) | - | 2026-07-01 | 8 |
 | memory | [Memory](domain/memory.md) | @Hardtack | 2026-07-09 | 4 |
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-07-14 | 7 |
@@ -25,13 +25,13 @@ Details of all living specs. Synchronized from frontmatter.
 
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
-| [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 84 |
+| [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-15 | 85 |
 | [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-12 | 17 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-03 | 3 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-14 | 29 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-14 | 8 |
 | [Context Compaction](flow/context-compaction.md) | @Hardtack | 2026-07-14 | 21 |
-| [File Exchange Storage](flow/file-exchange-storage.md) | @Hardtack | 2026-07-15 | 14 |
+| [File Exchange Storage](flow/file-exchange-storage.md) | @Hardtack | 2026-07-15 | 15 |
 | [MCP OAuth Flow](flow/mcp-oauth.md) | @Hardtack | 2026-06-29 | 4 |
 | [Periodic Execution Flow Spec](flow/periodic-execution.md) | - | 2026-06-27 | 2 |
 | [Run Resume](flow/run-resume.md) | @Hardtack | 2026-07-14 | 19 |

--- a/docs/azents/spec/domain/conversation.md
+++ b/docs/azents/spec/domain/conversation.md
@@ -92,7 +92,7 @@ api_routes:
   - /internal/agent-home/v1/runtimes/{agent_runtime_id}/hibernate
   - /internal/agent-home/v1/runtimes/{agent_runtime_id}/projects
 last_verified_at: 2026-07-15
-spec_version: 101
+spec_version: 102
 ---
 
 # Conversation & Events
@@ -488,6 +488,9 @@ Redis, while tests may use the in-memory implementation. Pending input buffers a
 input-buffer table and are exposed through `/live` as projections with metadata marking the projection
 source. Goal continuation starts as a pending `goal_continuation` input buffer and becomes a durable
 `goal_continuation` event only when the session runner flushes buffers into the next model input.
+The `/live` reader obtains access, pending input, active Run, Goal/Todo Toolkit state, and action
+execution projections in one short PostgreSQL session. It closes that session before reading Redis
+live projections and performs no nested database session reads inside the snapshot.
 `goal_updated` is appended when the user updates the session Goal. User-requested stop appends
 `interrupted` before the terminal run marker. The UI must not render these control events as user
 bubbles or delete controls; it may render non-interactive timeline indicators such as goal controls or
@@ -711,6 +714,8 @@ Current verification:
 
 ## 11. Changelog
 
+- **2026-07-15** — v102. Required `/live` to close its single PostgreSQL snapshot before Redis I/O
+  and prohibited nested Goal/Todo database sessions during output reconstruction.
 - **2026-07-15** — v101. Required input-buffer attachment metadata resolution outside the locking
   transaction, FIFO head revalidation afterward, and creation-boundary-only FileParts.
 - **2026-07-14** — v100. Defined action execution tables as active operation state, with owner-generation admission, atomic durable terminal snapshot/delete handover, explicit live removal, and cancelled no-reexecution recovery.

--- a/docs/azents/spec/flow/agent-execution-loop.md
+++ b/docs/azents/spec/flow/agent-execution-loop.md
@@ -42,7 +42,7 @@ code_paths:
   - typescript/apps/azents-web/src/features/chat/components/ChatView.tsx
   - typescript/apps/azents-web/src/features/chat/containers/useChatSessionContainer.ts
 last_verified_at: 2026-07-15
-spec_version: 84
+spec_version: 85
 ---
 
 # Agent Execution Loop
@@ -594,6 +594,14 @@ likewise runs after its snapshot session closes; promotion then locks and revali
 before applying any durable changes. Flush reuses only the FileParts stored at the input boundary and
 never downloads an attachment or creates a ModelFile while holding the Session/FIFO lock.
 
+ExchangeFile, ModelFile, and Artifact creation preallocates the entity ID and object key, closes its
+authorization snapshot, uploads the blob without an open database session, and then revalidates
+ownership in the short metadata transaction. A failed revalidation or metadata commit deletes the
+preuploaded object. Live snapshot reads finish their PostgreSQL-backed state snapshot, including
+Toolkit state, before reading Redis live projections. Lifecycle state helpers propagate database
+failures; they must not report a safe idle or terminal boundary from a failed durable check. Run-ID
+terminal and retry updates re-read the Run in the same short transaction and reject a Session mismatch.
+
 Row locks remain limited to persistence invariants. Tool-result finalization locks its `AgentRun`
 while appending the deterministic result and removing that call from `active_tool_calls`, so parallel
 tool completions cannot overwrite each other. MCP OAuth refresh reads a credential snapshot, closes
@@ -667,6 +675,8 @@ updated by the user.
 
 ## Changelog
 
+- **2026-07-15** (spec_version 85) — Required preallocated blob keys with S3 outside database
+  sessions, live PostgreSQL snapshot closure before Redis reads, and transparent lifecycle DB errors.
 - **2026-07-15** (spec_version 84) — Moved input-buffer attachment metadata resolution before the
   locking transaction, required FIFO revalidation afterward, and prohibited execution-time
   attachment-to-ModelFile rematerialization.

--- a/docs/azents/spec/flow/file-exchange-storage.md
+++ b/docs/azents/spec/flow/file-exchange-storage.md
@@ -31,7 +31,7 @@ code_paths:
   - typescript/apps/azents-web/src/features/chat/components/FileAttachmentList.tsx
   - typescript/apps/azents-web/src/features/chat/components/AttachmentPreviewViewer.tsx
 last_verified_at: 2026-07-15
-spec_version: 14
+spec_version: 15
 ---
 
 # File Exchange Storage
@@ -85,6 +85,10 @@ When `spawn_agent` forks parent model-visible context into a child session, File
 - There is no implicit conversion among Attachment, Artifact, and ModelFile/FilePart. URI is storage location, not entity reference, so do not add logic extracting entity id from URI string. A `model_file_id` is single-event scoped; reusing the same source bytes later requires materializing a new ModelFile/FilePart.
 - Attachment Exchange file and Artifact have time-based retention/TTL lifecycle. ModelFile has context-owned lifecycle based on model-input head cursor reachability and active run pins.
 - User upload, agent-presented file, and internal artifact must pass session/workspace ownership verification.
+- ExchangeFile, Artifact, and ModelFile creation preallocates the entity ID and storage key. It
+  validates ownership in a short DB session, closes that session before object-storage upload, and
+  revalidates ownership while atomically persisting metadata afterward. If revalidation or commit
+  fails, the preuploaded object is compensation-deleted; no DB transaction spans object-storage I/O.
 - Sandbox file query is possible only when active sandbox storage handle exists; inactive/hibernated state follows workspace API action contract.
 - General presigned upload such as Agent avatar uses `UploadService` category handler, but it is separate category/publish contract from chat exchange file.
 
@@ -109,6 +113,8 @@ When `spawn_agent` forks parent model-visible context into a child session, File
 
 ## Changelog
 
+- **2026-07-15** — v15. Required preallocated object keys, S3 upload outside DB sessions,
+  ownership revalidation, and compensation cleanup before metadata becomes visible.
 - **2026-07-15** — v14. Clarified that input-buffer promotion resolves only Exchange attachment
   metadata outside its locking transaction and reuses creation-boundary FileParts without download
   or rematerialization.

--- a/python/apps/azents/src/azents/engine/io/file_resource_lifecycle_verification_test.py
+++ b/python/apps/azents/src/azents/engine/io/file_resource_lifecycle_verification_test.py
@@ -49,12 +49,11 @@ class _FakeArtifactRepository:
 
     def __init__(self) -> None:
         self.artifacts: dict[str, Artifact] = {}
-        self.next_id = "a" * 32
 
     async def create(self, session: AsyncSession, create: ArtifactCreate) -> Artifact:
         """Store Artifact create input."""
         del session
-        artifact_id = self.next_id
+        artifact_id = create.id
         artifact = Artifact(
             id=artifact_id,
             workspace_id=create.workspace_id,

--- a/python/apps/azents/src/azents/engine/tools/todo.py
+++ b/python/apps/azents/src/azents/engine/tools/todo.py
@@ -99,10 +99,19 @@ class TodoStateStore:
     async def load(self, agent_id: str, session_id: str) -> TodoState:
         """Fetch session todo state."""
         async with self.session_manager() as session:
-            handle = await self._make_handle(session, agent_id, session_id)
-            if handle is None:
-                return TodoState()
-            return await handle.load(default_factory=TodoState)
+            return await self.load_in_session(session, agent_id, session_id)
+
+    async def load_in_session(
+        self,
+        session: AsyncSession,
+        agent_id: str,
+        session_id: str,
+    ) -> TodoState:
+        """Fetch session todo state inside the caller's transaction."""
+        handle = await self._make_handle(session, agent_id, session_id)
+        if handle is None:
+            return TodoState()
+        return await handle.load(default_factory=TodoState)
 
     async def update(
         self,

--- a/python/apps/azents/src/azents/repos/artifact/__init__.py
+++ b/python/apps/azents/src/azents/repos/artifact/__init__.py
@@ -11,12 +11,15 @@ from azents.rdb.models.artifact import RDBArtifact
 from .data import Artifact, ArtifactCreate
 
 
-def _storage_key(rdb: RDBArtifact) -> str:
+def artifact_storage_key(
+    *,
+    workspace_id: str,
+    session_id: str,
+    created_run_index: int,
+    artifact_id: str,
+) -> str:
     """Create Artifact object storage key."""
-    return (
-        f"artifacts/{rdb.workspace_id}/{rdb.session_id}/"
-        f"{rdb.created_run_index}/{rdb.id}"
-    )
+    return f"artifacts/{workspace_id}/{session_id}/{created_run_index}/{artifact_id}"
 
 
 class ArtifactRepository:
@@ -46,7 +49,13 @@ class ArtifactRepository:
             description=create.description,
             metadata_=create.metadata,
         )
-        rdb.storage_key = _storage_key(rdb)
+        rdb.id = create.id
+        rdb.storage_key = artifact_storage_key(
+            workspace_id=create.workspace_id,
+            session_id=create.session_id,
+            created_run_index=create.created_run_index,
+            artifact_id=create.id,
+        )
         session.add(rdb)
         await session.flush()
         return self._build(rdb)

--- a/python/apps/azents/src/azents/repos/artifact/data.py
+++ b/python/apps/azents/src/azents/repos/artifact/data.py
@@ -50,6 +50,7 @@ class Artifact(BaseModel):
 class ArtifactCreate(BaseModel):
     """Artifact create schema."""
 
+    id: str = Field(description="Artifact ID")
     workspace_id: str = Field(description="Workspace ID")
     session_id: str = Field(description="AgentSession ID")
     agent_id: str = Field(description="Agent ID")

--- a/python/apps/azents/src/azents/repos/exchange_file/__init__.py
+++ b/python/apps/azents/src/azents/repos/exchange_file/__init__.py
@@ -12,9 +12,9 @@ from azents.rdb.models.exchange_file import RDBExchangeFile
 from .data import ExchangeFile, ExchangeFileCreate
 
 
-def _object_key(rdb: RDBExchangeFile) -> str:
+def exchange_file_object_key(*, workspace_id: str, file_id: str) -> str:
     """Create Exchange file object storage key."""
-    return f"exchange/{rdb.workspace_id}/files/{rdb.id}/original"
+    return f"exchange/{workspace_id}/files/{file_id}/original"
 
 
 class ExchangeFileRepository:
@@ -44,7 +44,11 @@ class ExchangeFileRepository:
             preview_generated_at=create.preview_generated_at,
             expires_at=create.expires_at,
         )
-        rdb.object_key = _object_key(rdb)
+        rdb.id = create.id
+        rdb.object_key = exchange_file_object_key(
+            workspace_id=create.workspace_id,
+            file_id=create.id,
+        )
         session.add(rdb)
         await session.flush()
         return self._build(rdb)

--- a/python/apps/azents/src/azents/repos/exchange_file/data.py
+++ b/python/apps/azents/src/azents/repos/exchange_file/data.py
@@ -66,6 +66,7 @@ class ExchangeFile(BaseModel):
 class ExchangeFileCreate(BaseModel):
     """ExchangeFile create schema."""
 
+    id: str = Field(description="ExchangeFile ID")
     workspace_id: str = Field(description="Workspace ID")
     agent_id: str = Field(description="Agent ID")
     origin_type: ExchangeFileOrigin = Field(description="File creation origin")

--- a/python/apps/azents/src/azents/repos/llm_catalog/__init__.py
+++ b/python/apps/azents/src/azents/repos/llm_catalog/__init__.py
@@ -179,7 +179,9 @@ class LLMCatalogRepository:
             )
             .on_conflict_do_nothing(
                 index_elements=["provider_integration_id", "lowerer_target"],
-                index_where=RDBLLMCatalog.scope == LLMCatalogScope.INTEGRATION,
+                # Keep this predicate literal so PostgreSQL can infer the partial
+                # unique index after psycopg prepares the repeated statement.
+                index_where=sa.text("scope = 'integration'"),
             )
             .returning(RDBLLMCatalog)
         )
@@ -214,7 +216,9 @@ class LLMCatalogRepository:
             )
             .on_conflict_do_nothing(
                 index_elements=["provider", "lowerer_target"],
-                index_where=RDBLLMCatalog.scope == LLMCatalogScope.SYSTEM,
+                # Keep this predicate literal so PostgreSQL can infer the partial
+                # unique index after psycopg prepares the repeated statement.
+                index_where=sa.text("scope = 'system'"),
             )
             .returning(RDBLLMCatalog)
         )

--- a/python/apps/azents/src/azents/repos/llm_catalog/repository_test.py
+++ b/python/apps/azents/src/azents/repos/llm_catalog/repository_test.py
@@ -77,6 +77,71 @@ async def test_replace_current_snapshot_persists_snapshot_before_entries(
     assert entry_count == 1
 
 
+async def test_partial_catalog_upserts_survive_prepared_statement_reuse(
+    rdb_session: AsyncSession,
+) -> None:
+    """Partial-index upserts must remain inferable after psycopg prepares them."""
+    workspace_repository = WorkspaceRepository()
+    workspace_result = await workspace_repository.create(
+        rdb_session,
+        WorkspaceCreate(
+            name="Prepared catalog workspace",
+            handle="prepared-catalog-workspace",
+        ),
+    )
+    assert isinstance(workspace_result, Success)
+    workspace_id = await workspace_repository.resolve_id(
+        rdb_session, "prepared-catalog-workspace"
+    )
+    assert workspace_id is not None
+
+    integration = await LLMProviderIntegrationRepository(
+        CredentialCipher(Fernet.generate_key().decode())
+    ).create(
+        rdb_session,
+        LLMProviderIntegrationCreate(
+            workspace_id=workspace_id,
+            provider=LLMProvider.CHATGPT_OAUTH,
+            name="Prepared ChatGPT integration",
+            secrets=ChatGPTOAuthSecrets(
+                access_token="access-token",
+                refresh_token="refresh-token",
+                expires_at=datetime.datetime(2030, 1, 1, tzinfo=datetime.UTC),
+            ),
+            config=ChatGPTOAuthConfig(
+                connection_method="callback",
+                status="connected",
+            ),
+        ),
+    )
+
+    repository = LLMCatalogRepository()
+    integration_catalog_ids = {
+        (
+            await repository.ensure_integration_catalog(
+                rdb_session,
+                integration_id=integration.id,
+                provider=LLMProvider.CHATGPT_OAUTH,
+                lowerer_target=LLMCatalogLowererTarget.LITELLM,
+            )
+        ).id
+        for _ in range(8)
+    }
+    system_catalog_ids = {
+        (
+            await repository.ensure_system_catalog(
+                rdb_session,
+                provider=LLMProvider.OPENAI,
+                lowerer_target=LLMCatalogLowererTarget.LITELLM,
+            )
+        ).id
+        for _ in range(8)
+    }
+
+    assert len(integration_catalog_ids) == 1
+    assert len(system_catalog_ids) == 1
+
+
 async def test_chatgpt_integration_never_falls_back_to_system_catalog(
     rdb_session: AsyncSession,
 ) -> None:

--- a/python/apps/azents/src/azents/repos/model_file/__init__.py
+++ b/python/apps/azents/src/azents/repos/model_file/__init__.py
@@ -13,9 +13,14 @@ from azents.rdb.models.model_file_pin import RDBModelFilePin
 from .data import ModelFile, ModelFileCreate
 
 
-def _storage_key(rdb: RDBModelFile) -> str:
+def model_file_storage_key(
+    *,
+    workspace_id: str,
+    session_id: str,
+    model_file_id: str,
+) -> str:
     """Create ModelFile object storage key."""
-    return f"model-files/{rdb.workspace_id}/{rdb.session_id}/{rdb.id}"
+    return f"model-files/{workspace_id}/{session_id}/{model_file_id}"
 
 
 class ModelFileRepository:
@@ -41,7 +46,12 @@ class ModelFileRepository:
             sha256=create.sha256,
             metadata_=create.metadata,
         )
-        rdb.storage_key = _storage_key(rdb)
+        rdb.id = create.id
+        rdb.storage_key = model_file_storage_key(
+            workspace_id=create.workspace_id,
+            session_id=create.session_id,
+            model_file_id=create.id,
+        )
         session.add(rdb)
         await session.flush()
         return self._build(rdb)

--- a/python/apps/azents/src/azents/repos/model_file/data.py
+++ b/python/apps/azents/src/azents/repos/model_file/data.py
@@ -39,6 +39,7 @@ class ModelFile(BaseModel):
 class ModelFileCreate(BaseModel):
     """ModelFile create schema."""
 
+    id: str = Field(description="ModelFile ID")
     workspace_id: str = Field(description="Workspace ID")
     session_id: str = Field(description="AgentSession ID")
     agent_id: str = Field(description="Agent ID")

--- a/python/apps/azents/src/azents/repos/model_file/repository_test.py
+++ b/python/apps/azents/src/azents/repos/model_file/repository_test.py
@@ -3,6 +3,7 @@
 import datetime
 
 import sqlalchemy as sa
+from azcommon.uuid import uuid7
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from azents.core.enums import (
@@ -90,6 +91,7 @@ async def test_create_model_file_metadata(rdb_session: AsyncSession) -> None:
     created = await repo.create(
         rdb_session,
         ModelFileCreate(
+            id=uuid7().hex,
             workspace_id=workspace_id,
             session_id=session_id,
             agent_id=agent_id,
@@ -127,6 +129,7 @@ async def test_mark_deleted_if_unpinned_updates_available_rows(
     model_file = await repo.create(
         rdb_session,
         ModelFileCreate(
+            id=uuid7().hex,
             workspace_id=workspace_id,
             session_id=session_id,
             agent_id=agent_id,
@@ -164,6 +167,7 @@ async def test_list_statuses_for_session_returns_known_model_files(
     available = await repo.create(
         rdb_session,
         ModelFileCreate(
+            id=uuid7().hex,
             workspace_id=workspace_id,
             session_id=session_id,
             agent_id=agent_id,
@@ -180,6 +184,7 @@ async def test_list_statuses_for_session_returns_known_model_files(
     deleted = await repo.create(
         rdb_session,
         ModelFileCreate(
+            id=uuid7().hex,
             workspace_id=workspace_id,
             session_id=session_id,
             agent_id=agent_id,
@@ -219,6 +224,7 @@ async def test_release_terminal_run_pins_preserves_pending(
     model_file = await ModelFileRepository().create(
         rdb_session,
         ModelFileCreate(
+            id=uuid7().hex,
             workspace_id=workspace_id,
             session_id=session_id,
             agent_id=agent_id,

--- a/python/apps/azents/src/azents/services/artifact.py
+++ b/python/apps/azents/src/azents/services/artifact.py
@@ -1,6 +1,5 @@
 """Artifact service."""
 
-import asyncio
 import dataclasses
 import datetime
 import hashlib
@@ -11,6 +10,7 @@ from typing import Annotated
 from azcommon.infra.s3.service import S3Service
 from azcommon.result import Failure, Result, Success
 from azcommon.types import JSONValue
+from azcommon.uuid import uuid7
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,7 +21,7 @@ from azents.core.s3.deps import get_s3_service
 from azents.rdb.deps import get_session_manager
 from azents.rdb.session import SessionManager
 from azents.repos.agent_session import AgentSessionRepository
-from azents.repos.artifact import ArtifactRepository
+from azents.repos.artifact import ArtifactRepository, artifact_storage_key
 from azents.repos.artifact.data import Artifact, ArtifactCreate
 from azents.repos.workspace_user import WorkspaceUserRepository
 from azents.services.file_lifecycle_policy import artifact_expires_at
@@ -128,8 +128,37 @@ class ArtifactService:
         metadata: dict[str, object] | None = None,
     ) -> Result[Artifact, ArtifactSessionNotFound | ArtifactAccessDenied]:
         """Create Artifact metadata and object."""
-        uploaded_object_key: str | None = None
+        async with self.session_manager() as session:
+            agent_session = await self.agent_session_repository.get_by_id(
+                session,
+                session_id,
+            )
+            if agent_session is None:
+                return Failure(ArtifactSessionNotFound())
+            if not await self._has_workspace_access(
+                session,
+                workspace_id=agent_session.workspace_id,
+                user_id=user_id,
+            ):
+                return Failure(ArtifactAccessDenied())
+            workspace_id = agent_session.workspace_id
+            agent_id = agent_session.agent_id
+
+        artifact_id = uuid7().hex
+        uploaded_object_key = artifact_storage_key(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            created_run_index=created_run_index,
+            artifact_id=artifact_id,
+        )
+        succeeded = False
         try:
+            await self.s3_service.upload(
+                bucket=self.config.workspace_s3.bucket,
+                key=uploaded_object_key,
+                body=body,
+                content_type=media_type,
+            )
             async with self.session_manager() as session:
                 agent_session = await self.agent_session_repository.get_by_id(
                     session,
@@ -143,6 +172,11 @@ class ArtifactService:
                     user_id=user_id,
                 ):
                     return Failure(ArtifactAccessDenied())
+                if (
+                    agent_session.workspace_id != workspace_id
+                    or agent_session.agent_id != agent_id
+                ):
+                    return Failure(ArtifactSessionNotFound())
 
                 safe_filename = _sanitize_display_filename(filename)
                 sha256 = hashlib.sha256(body).hexdigest()
@@ -150,6 +184,7 @@ class ArtifactService:
                 created = await self.artifact_repository.create(
                     session,
                     ArtifactCreate(
+                        id=artifact_id,
                         workspace_id=agent_session.workspace_id,
                         session_id=session_id,
                         agent_id=agent_session.agent_id,
@@ -167,20 +202,11 @@ class ArtifactService:
                         metadata=_json_metadata(metadata),
                     ),
                 )
-                await self.s3_service.upload(
-                    bucket=self.config.workspace_s3.bucket,
-                    key=created.storage_key,
-                    body=body,
-                    content_type=media_type,
-                )
-                uploaded_object_key = created.storage_key
-                return Success(created)
-        except asyncio.CancelledError:
-            await self._cleanup_uploaded_object(uploaded_object_key)
-            raise
-        except Exception:
-            await self._cleanup_uploaded_object(uploaded_object_key)
-            raise
+            succeeded = True
+            return Success(created)
+        finally:
+            if not succeeded:
+                await self._cleanup_uploaded_object(uploaded_object_key)
 
     async def resolve(
         self,

--- a/python/apps/azents/src/azents/services/artifact_test.py
+++ b/python/apps/azents/src/azents/services/artifact_test.py
@@ -35,7 +35,6 @@ class _FakeArtifactRepository:
 
     def __init__(self) -> None:
         self.artifacts: dict[str, Artifact] = {}
-        self.next_id = "a" * 32
 
     async def create(
         self,
@@ -44,7 +43,7 @@ class _FakeArtifactRepository:
     ) -> Artifact:
         """Store create input as domain model as-is."""
         del session
-        artifact_id = self.next_id
+        artifact_id = create.id
         artifact = Artifact(
             id=artifact_id,
             workspace_id=create.workspace_id,
@@ -177,9 +176,10 @@ class _FakeWorkspaceUserRepository:
 class _FakeS3Service:
     """S3 service for tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, session_boundary: "_SessionBoundary") -> None:
         self.objects: dict[str, bytes] = {}
         self.deleted_keys: list[str] = []
+        self.session_boundary = session_boundary
 
     async def upload(
         self,
@@ -191,16 +191,19 @@ class _FakeS3Service:
     ) -> None:
         """Store object."""
         del bucket, content_type
+        assert self.session_boundary.active == 0
         self.objects[key] = body
 
     async def download_bytes(self, bucket: str, key: str) -> bytes | None:
         """Fetch object bytes."""
         del bucket
+        assert self.session_boundary.active == 0
         return self.objects.get(key)
 
     async def delete(self, bucket: str, key: str) -> None:
         """Delete object."""
         del bucket
+        assert self.session_boundary.active == 0
         self.deleted_keys.append(key)
         self.objects.pop(key, None)
 
@@ -224,10 +227,20 @@ class _Config:
     file_lifecycle = _FileLifecycleConfig()
 
 
-@asynccontextmanager
-async def _session_manager() -> AsyncGenerator[AsyncSession, None]:
-    """Session manager for tests."""
-    yield cast(AsyncSession, object())
+class _SessionBoundary:
+    """Track open DB scopes for external-I/O boundary assertions."""
+
+    def __init__(self) -> None:
+        self.active = 0
+
+    @asynccontextmanager
+    async def session_manager(self) -> AsyncGenerator[AsyncSession, None]:
+        """Yield a test DB session while tracking its lifetime."""
+        self.active += 1
+        try:
+            yield cast(AsyncSession, object())
+        finally:
+            self.active -= 1
 
 
 def _make_agent_session() -> AgentSession:
@@ -272,7 +285,8 @@ def _make_workspace_user() -> WorkspaceUser:
 def _make_service() -> tuple[ArtifactService, _FakeArtifactRepository, _FakeS3Service]:
     """Create ArtifactService for tests."""
     artifact_repo = _FakeArtifactRepository()
-    s3 = _FakeS3Service()
+    session_boundary = _SessionBoundary()
+    s3 = _FakeS3Service(session_boundary)
     service = ArtifactService(
         artifact_repository=cast(Any, artifact_repo),
         agent_session_repository=cast(
@@ -282,7 +296,7 @@ def _make_service() -> tuple[ArtifactService, _FakeArtifactRepository, _FakeS3Se
             Any,
             _FakeWorkspaceUserRepository(_make_workspace_user()),
         ),
-        session_manager=_session_manager,
+        session_manager=session_boundary.session_manager,
         s3_service=cast(Any, s3),
         config=cast(Any, _Config()),
     )
@@ -311,9 +325,9 @@ async def test_create_and_resolve_artifact() -> None:
 
     assert isinstance(created, Success)
     artifact = created.value
-    assert artifact.id == "a" * 32
+    assert len(artifact.id) == 32
     assert artifact.expires_at - datetime.timedelta(days=7) >= _NOW
-    assert artifact.storage_key == "artifacts/workspace-1/session-1/3/" + "a" * 32
+    assert artifact.storage_key == f"artifacts/workspace-1/session-1/3/{artifact.id}"
     assert artifact.uri == f"artifact://{artifact.storage_key}"
     assert s3.objects[artifact.storage_key] == b"hello"
     assert artifact_repo.artifacts[artifact.id].metadata == {"nested": {"count": 1}}
@@ -328,7 +342,6 @@ async def test_create_and_resolve_artifact() -> None:
 async def test_expired_artifact_is_denied_even_if_blob_exists() -> None:
     """Expired Artifact rejects resolution even when blob remains."""
     service, artifact_repo, s3 = _make_service()
-    artifact_repo.next_id = "b" * 32
     created = await service.create(
         session_id="session-1",
         user_id="user-1",

--- a/python/apps/azents/src/azents/services/chat/__init__.py
+++ b/python/apps/azents/src/azents/services/chat/__init__.py
@@ -996,11 +996,6 @@ class ChatSessionService:
             input_buffers = await self.input_buffer_service.list_by_session_id(
                 session, session_id
             )
-            partial_history_events = []
-            if live_event_store is not None:
-                partial_history_events = await live_event_store.list_by_session_id(
-                    session_id
-                )
             input_buffer_events = [
                 input_buffer_to_live_event(input_buffer)
                 for input_buffer in input_buffers
@@ -1009,24 +1004,21 @@ class ChatSessionService:
                 session,
                 session_id=session_id,
             )
-            partial_history_events = [
-                event
-                for event in partial_history_events
-                if not isinstance(event.payload, ClientToolCallPayload)
-            ]
-            if run is not None:
-                partial_history_events.extend(
-                    active_tool_call_to_live_event(session_id, active)
-                    for active in run.active_tool_calls
-                )
-            partial_history_events.sort(key=lambda event: (event.created_at, event.id))
             goal_store = GoalStateStore(session_manager=self.session_manager)
             goal = GoalStateSnapshot.from_state(
-                await goal_store.load(agent_session.agent_id, session_id)
+                await goal_store.load_in_session(
+                    session,
+                    agent_session.agent_id,
+                    session_id,
+                )
             )
             todo_store = TodoStateStore(session_manager=self.session_manager)
             todo = TodoStateSnapshot.from_state(
-                await todo_store.load(agent_session.agent_id, session_id)
+                await todo_store.load_in_session(
+                    session,
+                    agent_session.agent_id,
+                    session_id,
+                )
             )
             action_executions = (
                 await self.action_execution_repository.list_projections_by_session_id(
@@ -1035,64 +1027,85 @@ class ChatSessionService:
                 )
             )
             session_run_state = agent_session.run_state
-            if run is not None:
-                if session_run_state != AgentSessionRunState.RUNNING:
-                    logger.warning(
-                        "Active AgentRun contradicts persisted Session run state",
-                        extra={
-                            "session_id": session_id,
-                            "run_id": run.id,
-                            "run_status": run.status,
-                            "session_run_state": session_run_state,
-                        },
-                    )
-                session_run_state = AgentSessionRunState.RUNNING
-            return Success(
-                ChatLiveStateSnapshot(
-                    partial_history_events=partial_history_events,
-                    input_buffer_events=input_buffer_events,
-                    run=None
-                    if run is None
-                    else ChatLiveRunState(
-                        run_id=run.id,
-                        phase=run.phase,
-                        status=run.status,
-                        inference_profile=_require_session_inference_profile(
-                            agent_session
-                        ),
-                        model_call_started_at=run.model_call_started_at,
-                        retry=None
-                        if run.retry_state is None
-                        else ChatLiveRunRetryState(
-                            status=run.retry_state.status,
-                            last_error_message=run.retry_state.last_user_message,
-                            failed_attempt_count=run.retry_state.failed_attempt_count,
-                            max_retries=run.retry_state.max_retries,
-                            backoff_seconds=run.retry_state.backoff_seconds,
-                            next_retry_at=run.retry_state.next_retry_at.isoformat(),
-                            attempts=[
-                                ChatLiveRunRetryAttempt(
-                                    attempt_number=attempt.attempt_number,
-                                    user_message=attempt.user_message,
-                                    error_type=attempt.error_type,
-                                    source=attempt.source,
-                                    failed_at=attempt.failed_at.isoformat(),
-                                    backoff_seconds=attempt.backoff_seconds,
-                                    next_retry_at=attempt.next_retry_at.isoformat(),
-                                    retryability=attempt.retryability,
-                                    failure_code=attempt.failure_code,
-                                    truncated=attempt.truncated,
-                                )
-                                for attempt in run.retry_state.attempts
-                            ],
-                        ),
-                    ),
-                    session_run_state=session_run_state,
-                    todo=todo,
-                    goal=goal,
-                    action_executions=action_executions,
-                )
+            inference_profile = (
+                None
+                if run is None
+                else _require_session_inference_profile(agent_session)
             )
+
+        partial_history_events = []
+        if live_event_store is not None:
+            partial_history_events = await live_event_store.list_by_session_id(
+                session_id
+            )
+        partial_history_events = [
+            event
+            for event in partial_history_events
+            if not isinstance(event.payload, ClientToolCallPayload)
+        ]
+        if run is not None:
+            partial_history_events.extend(
+                active_tool_call_to_live_event(session_id, active)
+                for active in run.active_tool_calls
+            )
+        partial_history_events.sort(key=lambda event: (event.created_at, event.id))
+        live_run = None
+        if run is not None:
+            assert inference_profile is not None
+            if session_run_state != AgentSessionRunState.RUNNING:
+                logger.warning(
+                    "Active AgentRun contradicts persisted Session run state",
+                    extra={
+                        "session_id": session_id,
+                        "run_id": run.id,
+                        "run_status": run.status,
+                        "session_run_state": session_run_state,
+                    },
+                )
+            session_run_state = AgentSessionRunState.RUNNING
+            live_run = ChatLiveRunState(
+                run_id=run.id,
+                phase=run.phase,
+                status=run.status,
+                inference_profile=inference_profile,
+                model_call_started_at=run.model_call_started_at,
+                retry=None
+                if run.retry_state is None
+                else ChatLiveRunRetryState(
+                    status=run.retry_state.status,
+                    last_error_message=run.retry_state.last_user_message,
+                    failed_attempt_count=run.retry_state.failed_attempt_count,
+                    max_retries=run.retry_state.max_retries,
+                    backoff_seconds=run.retry_state.backoff_seconds,
+                    next_retry_at=run.retry_state.next_retry_at.isoformat(),
+                    attempts=[
+                        ChatLiveRunRetryAttempt(
+                            attempt_number=attempt.attempt_number,
+                            user_message=attempt.user_message,
+                            error_type=attempt.error_type,
+                            source=attempt.source,
+                            failed_at=attempt.failed_at.isoformat(),
+                            backoff_seconds=attempt.backoff_seconds,
+                            next_retry_at=attempt.next_retry_at.isoformat(),
+                            retryability=attempt.retryability,
+                            failure_code=attempt.failure_code,
+                            truncated=attempt.truncated,
+                        )
+                        for attempt in run.retry_state.attempts
+                    ],
+                ),
+            )
+        return Success(
+            ChatLiveStateSnapshot(
+                partial_history_events=partial_history_events,
+                input_buffer_events=input_buffer_events,
+                run=live_run,
+                session_run_state=session_run_state,
+                todo=todo,
+                goal=goal,
+                action_executions=action_executions,
+            )
+        )
 
     async def delete_session(
         self,

--- a/python/apps/azents/src/azents/services/chat/input_buffer_test.py
+++ b/python/apps/azents/src/azents/services/chat/input_buffer_test.py
@@ -1,6 +1,9 @@
 """ChatSessionService InputBuffer tests."""
 
 import datetime
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import cast
 from unittest.mock import patch
 
 from azcommon.result import Failure, Success
@@ -53,6 +56,39 @@ from azents.testing.model_selection import (
 
 from . import ChatSessionService
 from .data import SessionAccessDenied
+from .live_events import LiveEventStore
+
+
+class _TrackingSessionManager:
+    """Reject nested DB sessions and expose the active session count."""
+
+    def __init__(self, delegate: SessionManager[AsyncSession]) -> None:
+        self.delegate = delegate
+        self.active = 0
+
+    @asynccontextmanager
+    async def __call__(self) -> AsyncGenerator[AsyncSession]:
+        """Open exactly one delegated DB session at a time."""
+        assert self.active == 0
+        self.active += 1
+        try:
+            async with self.delegate() as session:
+                yield session
+        finally:
+            self.active -= 1
+
+
+class _BoundaryCheckingLiveEventStore:
+    """Live store asserting that Redis I/O runs after DB scope closure."""
+
+    def __init__(self, session_manager: _TrackingSessionManager) -> None:
+        self.session_manager = session_manager
+
+    async def list_by_session_id(self, session_id: str) -> list[object]:
+        """Return no live events after checking the transaction boundary."""
+        del session_id
+        assert self.session_manager.active == 0
+        return []
 
 
 async def _create_workspace(session: AsyncSession, handle: str) -> str:
@@ -227,6 +263,33 @@ class TestChatSessionInputBuffer:
         )
         assert result.value.partial_history_events == []
         assert result.value.session_run_state == AgentSessionRunState.IDLE
+
+    async def test_list_live_events_closes_db_before_live_store_io(
+        self,
+        rdb_session_manager: SessionManager[AsyncSession],
+    ) -> None:
+        """Live output reads Redis only after its single DB snapshot closes."""
+        async with rdb_session_manager() as session:
+            session_id, user_id, _ = await _create_session_with_buffer(
+                session,
+                handle="chat-live-db-boundary",
+                slug="chat-live-db-boundary",
+            )
+        tracking_manager = _TrackingSessionManager(rdb_session_manager)
+
+        result = await _service(
+            cast(SessionManager[AsyncSession], tracking_manager)
+        ).list_live_events(
+            session_id,
+            user_id=user_id,
+            live_event_store=cast(
+                LiveEventStore,
+                _BoundaryCheckingLiveEventStore(tracking_manager),
+            ),
+        )
+
+        assert isinstance(result, Success)
+        assert tracking_manager.active == 0
 
     async def test_list_live_events_running_run_overrides_idle_session_state(
         self,

--- a/python/apps/azents/src/azents/services/exchange_file/__init__.py
+++ b/python/apps/azents/src/azents/services/exchange_file/__init__.py
@@ -1,6 +1,5 @@
 """Exchange file service."""
 
-import asyncio
 import dataclasses
 import datetime
 import hashlib
@@ -11,6 +10,7 @@ from typing import Annotated
 
 from azcommon.infra.s3.service import S3Service
 from azcommon.result import Failure, Result, Success
+from azcommon.uuid import uuid7
 from fastapi import Depends
 from PIL import Image, ImageOps, UnidentifiedImageError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -23,7 +23,7 @@ from azents.rdb.deps import get_session_manager
 from azents.rdb.session import SessionManager
 from azents.repos.agent import AgentRepository
 from azents.repos.agent_session import AgentSessionRepository
-from azents.repos.exchange_file import ExchangeFileRepository
+from azents.repos.exchange_file import ExchangeFileRepository, exchange_file_object_key
 from azents.repos.exchange_file.data import ExchangeFile, ExchangeFileCreate
 from azents.repos.workspace_user import WorkspaceUserRepository
 from azents.services.file_lifecycle_policy import exchange_file_expires_at
@@ -93,6 +93,18 @@ class _PreviewThumbnail:
     width: int
     height: int
     generated_at: datetime.datetime
+
+
+@dataclasses.dataclass(frozen=True)
+class _PreparedExchangeFile:
+    """Exchange file metadata and blob prepared before persistence."""
+
+    create: ExchangeFileCreate
+    object_key: str
+    body: bytes
+    preview_width: int | None = None
+    preview_height: int | None = None
+    preview_generated_at: datetime.datetime | None = None
 
 
 def exchange_object_key_from_uri(uri: str) -> str | None:
@@ -259,35 +271,46 @@ class ExchangeFileService:
         origin_type: ExchangeFileOrigin,
     ) -> Result[ExchangeFile, SessionNotFound | FileAccessDenied]:
         """Create Exchange upload file without session by Agent."""
-        uploaded_object_keys: list[str] = []
+        async with self.session_manager() as session:
+            agent = await self.agent_repository.get_by_id(session, agent_id)
+            if agent is None:
+                return Failure(SessionNotFound())
+            if not await self._has_workspace_access(
+                session, workspace_id=agent.workspace_id, user_id=user_id
+            ):
+                return Failure(FileAccessDenied())
+            workspace_id = agent.workspace_id
+
+        prepared = self._prepare_files(
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            filename=filename,
+            media_type=media_type,
+            body=body,
+            origin_type=origin_type,
+        )
+        succeeded = False
         try:
+            await self._upload_prepared_files(prepared)
             async with self.session_manager() as session:
                 agent = await self.agent_repository.get_by_id(session, agent_id)
-                if agent is None:
+                if agent is None or agent.workspace_id != workspace_id:
                     return Failure(SessionNotFound())
                 if not await self._has_workspace_access(
-                    session, workspace_id=agent.workspace_id, user_id=user_id
+                    session,
+                    workspace_id=workspace_id,
+                    user_id=user_id,
                 ):
                     return Failure(FileAccessDenied())
-
-                created, object_keys = await self._create_file_in_scope(
-                    session=session,
-                    workspace_id=agent.workspace_id,
-                    agent_id=agent.id,
-                    user_id=user_id,
-                    filename=filename,
-                    media_type=media_type,
-                    body=body,
-                    origin_type=origin_type,
+                created = await self._persist_prepared_files(session, prepared)
+            succeeded = True
+            return Success(created)
+        finally:
+            if not succeeded:
+                await self._cleanup_uploaded_objects(
+                    [file.object_key for file in prepared]
                 )
-                uploaded_object_keys.extend(object_keys)
-                return Success(created)
-        except asyncio.CancelledError:
-            await self._cleanup_uploaded_objects(uploaded_object_keys)
-            raise
-        except Exception:
-            await self._cleanup_uploaded_objects(uploaded_object_keys)
-            raise
 
     async def _create_agent_session_file(
         self,
@@ -301,37 +324,54 @@ class ExchangeFileService:
         origin_type: ExchangeFileOrigin,
     ) -> Result[ExchangeFile, SessionNotFound | FileAccessDenied]:
         """Create Exchange file by AgentSession."""
-        uploaded_object_keys: list[str] = []
+        async with self.session_manager() as session:
+            agent_session = await self.agent_session_repository.get_by_id(
+                session, session_id
+            )
+            if agent_session is None or agent_session.agent_id != agent_id:
+                return Failure(SessionNotFound())
+            if not await self._has_workspace_access(
+                session, workspace_id=agent_session.workspace_id, user_id=user_id
+            ):
+                return Failure(FileAccessDenied())
+            workspace_id = agent_session.workspace_id
+
+        prepared = self._prepare_files(
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            filename=filename,
+            media_type=media_type,
+            body=body,
+            origin_type=origin_type,
+        )
+        succeeded = False
         try:
+            await self._upload_prepared_files(prepared)
             async with self.session_manager() as session:
                 agent_session = await self.agent_session_repository.get_by_id(
                     session, session_id
                 )
-                if agent_session is None or agent_session.agent_id != agent_id:
+                if (
+                    agent_session is None
+                    or agent_session.agent_id != agent_id
+                    or agent_session.workspace_id != workspace_id
+                ):
                     return Failure(SessionNotFound())
                 if not await self._has_workspace_access(
-                    session, workspace_id=agent_session.workspace_id, user_id=user_id
+                    session,
+                    workspace_id=workspace_id,
+                    user_id=user_id,
                 ):
                     return Failure(FileAccessDenied())
-
-                created, object_keys = await self._create_file_in_scope(
-                    session=session,
-                    workspace_id=agent_session.workspace_id,
-                    agent_id=agent_session.agent_id,
-                    user_id=user_id,
-                    filename=filename,
-                    media_type=media_type,
-                    body=body,
-                    origin_type=origin_type,
+                created = await self._persist_prepared_files(session, prepared)
+            succeeded = True
+            return Success(created)
+        finally:
+            if not succeeded:
+                await self._cleanup_uploaded_objects(
+                    [file.object_key for file in prepared]
                 )
-                uploaded_object_keys.extend(object_keys)
-                return Success(created)
-        except asyncio.CancelledError:
-            await self._cleanup_uploaded_objects(uploaded_object_keys)
-            raise
-        except Exception:
-            await self._cleanup_uploaded_objects(uploaded_object_keys)
-            raise
 
     async def _create_file(
         self,
@@ -344,42 +384,59 @@ class ExchangeFileService:
         origin_type: ExchangeFileOrigin,
     ) -> Result[ExchangeFile, SessionNotFound | FileAccessDenied]:
         """Create Exchange file metadata and object."""
-        uploaded_object_keys: list[str] = []
+        async with self.session_manager() as session:
+            agent_session = await self.agent_session_repository.get_by_id(
+                session, session_id
+            )
+            if agent_session is None:
+                return Failure(SessionNotFound())
+            if not await self._has_workspace_access(
+                session, workspace_id=agent_session.workspace_id, user_id=user_id
+            ):
+                return Failure(FileAccessDenied())
+            workspace_id = agent_session.workspace_id
+            agent_id = agent_session.agent_id
+
+        prepared = self._prepare_files(
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            filename=filename,
+            media_type=media_type,
+            body=body,
+            origin_type=origin_type,
+        )
+        succeeded = False
         try:
+            await self._upload_prepared_files(prepared)
             async with self.session_manager() as session:
                 agent_session = await self.agent_session_repository.get_by_id(
                     session, session_id
                 )
-                if agent_session is None:
+                if (
+                    agent_session is None
+                    or agent_session.agent_id != agent_id
+                    or agent_session.workspace_id != workspace_id
+                ):
                     return Failure(SessionNotFound())
                 if not await self._has_workspace_access(
-                    session, workspace_id=agent_session.workspace_id, user_id=user_id
+                    session,
+                    workspace_id=workspace_id,
+                    user_id=user_id,
                 ):
                     return Failure(FileAccessDenied())
-
-                created, object_keys = await self._create_file_in_scope(
-                    session=session,
-                    workspace_id=agent_session.workspace_id,
-                    agent_id=agent_session.agent_id,
-                    user_id=user_id,
-                    filename=filename,
-                    media_type=media_type,
-                    body=body,
-                    origin_type=origin_type,
+                created = await self._persist_prepared_files(session, prepared)
+            succeeded = True
+            return Success(created)
+        finally:
+            if not succeeded:
+                await self._cleanup_uploaded_objects(
+                    [file.object_key for file in prepared]
                 )
-                uploaded_object_keys.extend(object_keys)
-                return Success(created)
-        except asyncio.CancelledError:
-            await self._cleanup_uploaded_objects(uploaded_object_keys)
-            raise
-        except Exception:
-            await self._cleanup_uploaded_objects(uploaded_object_keys)
-            raise
 
-    async def _create_file_in_scope(
+    def _prepare_files(
         self,
         *,
-        session: AsyncSession,
         workspace_id: str,
         agent_id: str,
         user_id: str,
@@ -387,75 +444,117 @@ class ExchangeFileService:
         media_type: str,
         body: bytes,
         origin_type: ExchangeFileOrigin,
-    ) -> tuple[ExchangeFile, list[str]]:
-        """Create Exchange file row and object in verified workspace/agent scope."""
+    ) -> list[_PreparedExchangeFile]:
+        """Prepare stable metadata and object keys before external upload."""
         safe_filename = _sanitize_display_filename(filename)
         sha256 = hashlib.sha256(body).hexdigest()
         now = datetime.datetime.now(datetime.UTC)
         expires_at = exchange_file_expires_at(now=now, config=self.config)
-        uploaded_object_keys: list[str] = []
-        created = await self.exchange_file_repository.create(
-            session,
-            ExchangeFileCreate(
-                workspace_id=workspace_id,
-                agent_id=agent_id,
-                origin_type=origin_type,
-                filename=safe_filename,
-                media_type=media_type,
-                size_bytes=len(body),
-                sha256=sha256,
-                created_by_user_id=user_id,
-                expires_at=expires_at,
-                preview_title=safe_filename,
-                preview_summary=_make_text_preview(body, media_type),
-                preview_generated_at=now,
-            ),
-        )
-        await self.s3_service.upload(
-            bucket=self.config.workspace_s3.bucket,
-            key=created.object_key,
-            body=body,
-            content_type=media_type,
-        )
-        uploaded_object_keys.append(created.object_key)
+        file_id = uuid7().hex
+        prepared = [
+            _PreparedExchangeFile(
+                create=ExchangeFileCreate(
+                    id=file_id,
+                    workspace_id=workspace_id,
+                    agent_id=agent_id,
+                    origin_type=origin_type,
+                    filename=safe_filename,
+                    media_type=media_type,
+                    size_bytes=len(body),
+                    sha256=sha256,
+                    created_by_user_id=user_id,
+                    expires_at=expires_at,
+                    preview_title=safe_filename,
+                    preview_summary=_make_text_preview(body, media_type),
+                    preview_generated_at=now,
+                ),
+                object_key=exchange_file_object_key(
+                    workspace_id=workspace_id,
+                    file_id=file_id,
+                ),
+                body=body,
+            )
+        ]
 
         thumbnail_body = _make_preview_thumbnail(body, media_type)
         if thumbnail_body is None:
-            return created, uploaded_object_keys
+            return prepared
 
+        thumbnail_id = uuid7().hex
+        prepared.append(
+            _PreparedExchangeFile(
+                create=ExchangeFileCreate(
+                    id=thumbnail_id,
+                    workspace_id=workspace_id,
+                    agent_id=agent_id,
+                    origin_type=origin_type,
+                    filename=f"{safe_filename}.preview.jpg",
+                    media_type=_PREVIEW_THUMBNAIL_MEDIA_TYPE,
+                    size_bytes=len(thumbnail_body.body),
+                    sha256=hashlib.sha256(thumbnail_body.body).hexdigest(),
+                    created_by_user_id=user_id,
+                    expires_at=expires_at,
+                    preview_title=f"{safe_filename} preview",
+                    preview_generated_at=thumbnail_body.generated_at,
+                ),
+                object_key=exchange_file_object_key(
+                    workspace_id=workspace_id,
+                    file_id=thumbnail_id,
+                ),
+                body=thumbnail_body.body,
+                preview_width=thumbnail_body.width,
+                preview_height=thumbnail_body.height,
+                preview_generated_at=thumbnail_body.generated_at,
+            )
+        )
+        return prepared
+
+    async def _upload_prepared_files(
+        self,
+        prepared: list[_PreparedExchangeFile],
+    ) -> None:
+        """Upload prepared blobs without an open DB session."""
+        for file in prepared:
+            await self.s3_service.upload(
+                bucket=self.config.workspace_s3.bucket,
+                key=file.object_key,
+                body=file.body,
+                content_type=file.create.media_type,
+            )
+
+    async def _persist_prepared_files(
+        self,
+        session: AsyncSession,
+        prepared: list[_PreparedExchangeFile],
+    ) -> ExchangeFile:
+        """Persist uploaded file metadata atomically in the verified scope."""
+        source = await self.exchange_file_repository.create(
+            session,
+            prepared[0].create,
+        )
+        if len(prepared) == 1:
+            return source
+
+        thumbnail_prepared = prepared[1]
         thumbnail = await self.exchange_file_repository.create(
             session,
-            ExchangeFileCreate(
-                workspace_id=workspace_id,
-                agent_id=agent_id,
-                origin_type=origin_type,
-                filename=f"{safe_filename}.preview.jpg",
-                media_type=_PREVIEW_THUMBNAIL_MEDIA_TYPE,
-                size_bytes=len(thumbnail_body.body),
-                sha256=hashlib.sha256(thumbnail_body.body).hexdigest(),
-                created_by_user_id=user_id,
-                expires_at=expires_at,
-                preview_title=f"{safe_filename} preview",
-                preview_generated_at=thumbnail_body.generated_at,
-            ),
+            thumbnail_prepared.create,
         )
-        await self.s3_service.upload(
-            bucket=self.config.workspace_s3.bucket,
-            key=thumbnail.object_key,
-            body=thumbnail_body.body,
-            content_type=_PREVIEW_THUMBNAIL_MEDIA_TYPE,
-        )
-        uploaded_object_keys.append(thumbnail.object_key)
-        created = await self.exchange_file_repository.set_preview_thumbnail_file_id(
+        if (
+            thumbnail_prepared.preview_width is None
+            or thumbnail_prepared.preview_height is None
+            or thumbnail_prepared.preview_generated_at is None
+        ):
+            raise ValueError("Prepared thumbnail metadata is incomplete")
+        return await self.exchange_file_repository.set_preview_thumbnail_file_id(
             session,
-            file_id=created.id,
+            file_id=source.id,
             preview_thumbnail_file_id=thumbnail.id,
             preview_thumbnail_media_type=_PREVIEW_THUMBNAIL_MEDIA_TYPE,
-            preview_thumbnail_width=thumbnail_body.width,
-            preview_thumbnail_height=thumbnail_body.height,
-            preview_generated_at=thumbnail_body.generated_at,
+            preview_thumbnail_width=thumbnail_prepared.preview_width,
+            preview_thumbnail_height=thumbnail_prepared.preview_height,
+            preview_generated_at=thumbnail_prepared.preview_generated_at,
         )
-        return created, uploaded_object_keys
 
     async def download(
         self,

--- a/python/apps/azents/src/azents/services/exchange_file/service_test.py
+++ b/python/apps/azents/src/azents/services/exchange_file/service_test.py
@@ -48,7 +48,6 @@ class _FakeExchangeFileRepository:
 
     def __init__(self) -> None:
         self.files: dict[str, ExchangeFile] = {}
-        self.next_id = 1
 
     async def create(
         self,
@@ -57,8 +56,7 @@ class _FakeExchangeFileRepository:
     ) -> ExchangeFile:
         """Store create input as domain model as-is."""
         del session
-        file_id = f"{self.next_id:032x}"
-        self.next_id += 1
+        file_id = create.id
         file = ExchangeFile(
             id=file_id,
             workspace_id=create.workspace_id,
@@ -200,9 +198,10 @@ class _FakeExchangeFileRepository:
 class _FakeS3Service:
     """S3 service for tests."""
 
-    def __init__(self) -> None:
+    def __init__(self, session_boundary: "_SessionBoundary") -> None:
         self.objects: dict[str, bytes] = {}
         self.fail_delete = False
+        self.session_boundary = session_boundary
 
     async def upload(
         self,
@@ -214,16 +213,19 @@ class _FakeS3Service:
     ) -> None:
         """Store object."""
         del bucket, content_type
+        assert self.session_boundary.active == 0
         self.objects[key] = body
 
     async def download_bytes(self, bucket: str, key: str) -> bytes | None:
         """Fetch object bytes."""
         del bucket
+        assert self.session_boundary.active == 0
         return self.objects.get(key)
 
     async def delete(self, bucket: str, key: str) -> None:
         """Delete object."""
         del bucket
+        assert self.session_boundary.active == 0
         if self.fail_delete:
             msg = "delete failed"
             raise RuntimeError(msg)
@@ -249,10 +251,20 @@ class _Config:
     file_lifecycle = _FileLifecycleConfig()
 
 
-@asynccontextmanager
-async def _session_manager() -> AsyncGenerator[AsyncSession, None]:
-    """Session manager for tests."""
-    yield cast(AsyncSession, object())
+class _SessionBoundary:
+    """Track open DB scopes for external-I/O boundary assertions."""
+
+    def __init__(self) -> None:
+        self.active = 0
+
+    @asynccontextmanager
+    async def session_manager(self) -> AsyncGenerator[AsyncSession, None]:
+        """Yield a test DB session while tracking its lifetime."""
+        self.active += 1
+        try:
+            yield cast(AsyncSession, object())
+        finally:
+            self.active -= 1
 
 
 def _make_agent_session() -> AgentSession:
@@ -342,13 +354,14 @@ def _make_service(
     workspace_user_repository.get_by_workspace_and_user.return_value = workspace_user
 
     exchange_file_repository = _FakeExchangeFileRepository()
-    s3_service = _FakeS3Service()
+    session_boundary = _SessionBoundary()
+    s3_service = _FakeS3Service(session_boundary)
     service = ExchangeFileService(
         exchange_file_repository=cast(Any, exchange_file_repository),
         agent_repository=agent_repository,
         agent_session_repository=agent_session_repository,
         workspace_user_repository=workspace_user_repository,
-        session_manager=_session_manager,
+        session_manager=session_boundary.session_manager,
         s3_service=cast(Any, s3_service),
         config=cast(Any, _Config()),
     )

--- a/python/apps/azents/src/azents/services/model_file.py
+++ b/python/apps/azents/src/azents/services/model_file.py
@@ -9,6 +9,7 @@ from typing import Annotated, Literal
 from azcommon.infra.s3.service import S3Service
 from azcommon.result import Failure, Result, Success
 from azcommon.types import JSONValue
+from azcommon.uuid import uuid7
 from fastapi import Depends
 from PIL import Image, ImageOps, UnidentifiedImageError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,10 +20,9 @@ from azents.core.enums import ModelFileStatus
 from azents.core.s3.deps import get_s3_service
 from azents.rdb.deps import get_session_manager
 from azents.rdb.session import SessionManager
-from azents.repos.agent import AgentRepository
 from azents.repos.agent_execution import AgentRunRepository
 from azents.repos.agent_session import AgentSessionRepository
-from azents.repos.model_file import ModelFileRepository
+from azents.repos.model_file import ModelFileRepository, model_file_storage_key
 from azents.repos.model_file.data import ModelFile, ModelFileCreate
 from azents.repos.workspace_user import WorkspaceUserRepository
 
@@ -109,7 +109,6 @@ class ModelFileService:
     """Coordinate ModelFile metadata and object storage."""
 
     model_file_repository: Annotated[ModelFileRepository, Depends(ModelFileRepository)]
-    agent_repository: Annotated[AgentRepository, Depends(AgentRepository)]
     agent_session_repository: Annotated[
         AgentSessionRepository,
         Depends(AgentSessionRepository),
@@ -145,10 +144,37 @@ class ModelFileService:
         if isinstance(normalized, Failure):
             return Failure(normalized.error)
 
-        uploaded_object_key: str | None = None
+        async with self.session_manager() as session:
+            agent_session = await self.agent_session_repository.get_by_id(
+                session,
+                session_id,
+            )
+            if agent_session is None:
+                return Failure(ModelFileSessionNotFound())
+            if not await self._has_workspace_access(
+                session,
+                workspace_id=agent_session.workspace_id,
+                user_id=user_id,
+            ):
+                return Failure(ModelFileAccessDenied())
+            workspace_id = agent_session.workspace_id
+            agent_id = agent_session.agent_id
+
+        normalized_body = normalized.value
+        model_file_id = uuid7().hex
+        uploaded_object_key = model_file_storage_key(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            model_file_id=model_file_id,
+        )
         succeeded = False
         try:
-            created_result: Success[ModelFile] | None = None
+            await self.s3_service.upload(
+                bucket=self.config.workspace_s3.bucket,
+                key=uploaded_object_key,
+                body=normalized_body.body,
+                content_type=normalized_body.media_type,
+            )
             async with self.session_manager() as session:
                 agent_session = await self.agent_session_repository.get_by_id(
                     session,
@@ -162,11 +188,15 @@ class ModelFileService:
                     user_id=user_id,
                 ):
                     return Failure(ModelFileAccessDenied())
-
-                normalized_body = normalized.value
+                if (
+                    agent_session.workspace_id != workspace_id
+                    or agent_session.agent_id != agent_id
+                ):
+                    return Failure(ModelFileSessionNotFound())
                 created = await self.model_file_repository.create(
                     session,
                     ModelFileCreate(
+                        id=model_file_id,
                         workspace_id=agent_session.workspace_id,
                         session_id=session_id,
                         agent_id=agent_session.agent_id,
@@ -180,16 +210,8 @@ class ModelFileService:
                         metadata=_json_metadata(metadata),
                     ),
                 )
-                await self.s3_service.upload(
-                    bucket=self.config.workspace_s3.bucket,
-                    key=created.storage_key,
-                    body=normalized_body.body,
-                    content_type=normalized_body.media_type,
-                )
-                uploaded_object_key = created.storage_key
-                created_result = Success(created)
             succeeded = True
-            return created_result
+            return Success(created)
         finally:
             if not succeeded:
                 await self._cleanup_uploaded_object(uploaded_object_key)
@@ -236,17 +258,50 @@ class ModelFileService:
         if isinstance(normalized, Failure):
             return Failure(normalized.error)
 
-        uploaded_object_key: str | None = None
+        async with self.session_manager() as session:
+            agent_session = await self.agent_session_repository.get_by_id(
+                session,
+                session_id,
+            )
+            if agent_session is None or agent_session.agent_id != agent_id:
+                return Failure(ModelFileSessionNotFound())
+            if not await self._has_workspace_access(
+                session,
+                workspace_id=agent_session.workspace_id,
+                user_id=user_id,
+            ):
+                return Failure(ModelFileAccessDenied())
+            workspace_id = agent_session.workspace_id
+
+        normalized_body = normalized.value
+        model_file_id = uuid7().hex
+        uploaded_object_key = model_file_storage_key(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            model_file_id=model_file_id,
+        )
         succeeded = False
         try:
-            created_result: Success[ModelFile] | None = None
+            await self.s3_service.upload(
+                bucket=self.config.workspace_s3.bucket,
+                key=uploaded_object_key,
+                body=normalized_body.body,
+                content_type=normalized_body.media_type,
+            )
             async with self.session_manager() as session:
-                agent = await self.agent_repository.get_by_id(session, agent_id)
-                if agent is None:
+                agent_session = await self.agent_session_repository.get_by_id(
+                    session,
+                    session_id,
+                )
+                if (
+                    agent_session is None
+                    or agent_session.agent_id != agent_id
+                    or agent_session.workspace_id != workspace_id
+                ):
                     return Failure(ModelFileSessionNotFound())
                 if not await self._has_workspace_access(
                     session,
-                    workspace_id=agent.workspace_id,
+                    workspace_id=agent_session.workspace_id,
                     user_id=user_id,
                 ):
                     return Failure(ModelFileAccessDenied())
@@ -255,13 +310,13 @@ class ModelFileService:
                     session_id=session_id,
                 )
 
-                normalized_body = normalized.value
                 created = await self.model_file_repository.create(
                     session,
                     ModelFileCreate(
-                        workspace_id=agent.workspace_id,
+                        id=model_file_id,
+                        workspace_id=agent_session.workspace_id,
                         session_id=session_id,
-                        agent_id=agent.id,
+                        agent_id=agent_session.agent_id,
                         name=_sanitize_display_filename(filename),
                         media_type=normalized_body.media_type,
                         kind=normalized_body.kind,
@@ -272,16 +327,8 @@ class ModelFileService:
                         metadata=_json_metadata(metadata),
                     ),
                 )
-                await self.s3_service.upload(
-                    bucket=self.config.workspace_s3.bucket,
-                    key=created.storage_key,
-                    body=normalized_body.body,
-                    content_type=normalized_body.media_type,
-                )
-                uploaded_object_key = created.storage_key
-                created_result = Success(created)
             succeeded = True
-            return created_result
+            return Success(created)
         finally:
             if not succeeded:
                 await self._cleanup_uploaded_object(uploaded_object_key)

--- a/python/apps/azents/src/azents/services/model_file_test.py
+++ b/python/apps/azents/src/azents/services/model_file_test.py
@@ -1,16 +1,108 @@
 """ModelFileService tests."""
 
+import datetime
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from io import BytesIO
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
+import pytest
 from azcommon.result import Failure, Success
 from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from azents.core.enums import ModelFileStatus
+from azents.repos.model_file import model_file_storage_key
+from azents.repos.model_file.data import ModelFile, ModelFileCreate
 from azents.services.model_file import (
     ModelFileInvalidImage,
     ModelFileOversized,
+    ModelFileService,
     model_file_size_limit_message,
     normalize_model_file_body,
 )
+
+
+class _SessionBoundary:
+    """Track DB scope lifetime around object-storage calls."""
+
+    def __init__(self) -> None:
+        self.active = 0
+
+    @asynccontextmanager
+    async def session_manager(self) -> AsyncGenerator[AsyncSession, None]:
+        """Yield one tracked fake DB session."""
+        self.active += 1
+        try:
+            yield cast(AsyncSession, object())
+        finally:
+            self.active -= 1
+
+
+class _ModelFileRepository:
+    """ModelFile repository honoring the service-preallocated ID."""
+
+    def __init__(self, boundary: _SessionBoundary) -> None:
+        self.boundary = boundary
+
+    async def create(
+        self,
+        session: AsyncSession,
+        create: ModelFileCreate,
+    ) -> ModelFile:
+        """Persist metadata only while the DB scope is active."""
+        del session
+        assert self.boundary.active == 1
+        return ModelFile(
+            id=create.id,
+            workspace_id=create.workspace_id,
+            session_id=create.session_id,
+            agent_id=create.agent_id,
+            name=create.name,
+            media_type=create.media_type,
+            kind=create.kind,
+            size_bytes=create.size_bytes,
+            created_run_index=create.created_run_index,
+            storage_key=model_file_storage_key(
+                workspace_id=create.workspace_id,
+                session_id=create.session_id,
+                model_file_id=create.id,
+            ),
+            status=ModelFileStatus.AVAILABLE,
+            normalized_format=create.normalized_format,
+            sha256=create.sha256,
+            metadata=create.metadata,
+            created_at=datetime.datetime.now(datetime.UTC),
+        )
+
+
+class _S3Service:
+    """Object storage asserting that no DB session is open."""
+
+    def __init__(self, boundary: _SessionBoundary) -> None:
+        self.boundary = boundary
+        self.objects: dict[str, bytes] = {}
+
+    async def upload(
+        self,
+        bucket: str,
+        key: str,
+        body: bytes,
+        *,
+        content_type: str | None = None,
+    ) -> None:
+        """Store bytes only outside a DB scope."""
+        del bucket, content_type
+        assert self.boundary.active == 0
+        self.objects[key] = body
+
+    async def delete(self, bucket: str, key: str) -> None:
+        """Delete bytes only outside a DB scope."""
+        del bucket
+        assert self.boundary.active == 0
+        self.objects.pop(key, None)
 
 
 def _png_bytes() -> bytes:
@@ -64,3 +156,42 @@ def test_non_image_model_file_rejects_oversized_input() -> None:
     assert "File size exceeds the allowed limit" in model_file_size_limit_message(
         result.error
     )
+
+
+@pytest.mark.asyncio
+async def test_model_file_upload_closes_db_session_before_s3_io() -> None:
+    """ModelFile creation uploads outside DB and persists its stable key afterward."""
+    boundary = _SessionBoundary()
+    s3 = _S3Service(boundary)
+    agent_session_repository = AsyncMock()
+    agent_session_repository.get_by_id.return_value = SimpleNamespace(
+        workspace_id="workspace-1",
+        agent_id="agent-1",
+    )
+    workspace_user_repository = AsyncMock()
+    workspace_user_repository.get_by_workspace_and_user.return_value = object()
+    service = ModelFileService(
+        model_file_repository=cast(Any, _ModelFileRepository(boundary)),
+        agent_session_repository=agent_session_repository,
+        agent_run_repository=AsyncMock(),
+        workspace_user_repository=workspace_user_repository,
+        session_manager=boundary.session_manager,
+        s3_service=cast(Any, s3),
+        config=cast(
+            Any,
+            SimpleNamespace(workspace_s3=SimpleNamespace(bucket="test-bucket")),
+        ),
+    )
+
+    result = await service.create(
+        session_id="session-1",
+        user_id="user-1",
+        created_run_index=1,
+        filename="notes.txt",
+        media_type="text/plain",
+        body=b"hello",
+    )
+
+    assert isinstance(result, Success)
+    assert s3.objects[result.value.storage_key] == b"hello"
+    assert boundary.active == 0

--- a/python/apps/azents/src/azents/worker/session/lifecycle.py
+++ b/python/apps/azents/src/azents/worker/session/lifecycle.py
@@ -1,6 +1,5 @@
 """Session lifecycle state and ownership management."""
 
-import asyncio
 import dataclasses
 import datetime
 import logging
@@ -84,9 +83,7 @@ class SessionLifecycleService:
     async def mark_session_running(self, session_id: str) -> None:
         """Transition ``run_state`` to RUNNING and initialize heartbeat."""
         await self.run_short_db(
-            lambda db: self.agent_session_repository.mark_running(db, session_id),
-            error_log="Failed to mark session running",
-            session_id=session_id,
+            lambda db: self.agent_session_repository.mark_running(db, session_id)
         )
 
     async def mark_session_idle(self, session_id: str) -> bool:
@@ -126,13 +123,7 @@ class SessionLifecycleService:
             await self.agent_session_repository.mark_idle(db_session, session_id)
             return True
 
-        marked_idle = await self.run_short_db(
-            mark_idle_if_no_run,
-            error_log="Failed to mark session idle",
-            session_id=session_id,
-            default=False,
-        )
-        return bool(marked_idle)
+        return await self.run_short_db(mark_idle_if_no_run)
 
     async def has_active_agent_run(self, session_id: str) -> bool:
         """Return whether the session still has a pending or running AgentRun."""
@@ -144,20 +135,12 @@ class SessionLifecycleService:
             )
             return active_run is not None
 
-        active = await self.run_short_db(
-            get_active,
-            error_log="Failed to check active agent run",
-            session_id=session_id,
-            default=True,
-        )
-        return bool(active)
+        return await self.run_short_db(get_active)
 
     async def heartbeat_session(self, session_id: str) -> None:
         """Refresh DB heartbeat and Redis owner heartbeat of RUNNING session."""
         await self.run_short_db(
-            lambda db: self.agent_session_repository.heartbeat_running(db, session_id),
-            error_log="Failed to heartbeat session",
-            session_id=session_id,
+            lambda db: self.agent_session_repository.heartbeat_running(db, session_id)
         )
         await self.broker.renew_session_owner_heartbeat(session_id)
 
@@ -300,8 +283,6 @@ class SessionLifecycleService:
                 status=status,
                 ended_at=datetime.datetime.now(datetime.UTC),
             ),
-            error_log="Failed to mark session agent runs terminal",
-            session_id=session_id,
         )
 
     async def mark_agent_run_terminal_if_running(
@@ -312,16 +293,19 @@ class SessionLifecycleService:
         status: AgentRunStatus,
     ) -> None:
         """Close AgentRun row as terminal state if still running."""
-        await self.run_short_db(
-            lambda db: self.agent_run_repository.mark_terminal_if_running(
-                db,
+
+        async def mark_terminal(db_session: AsyncSession) -> None:
+            run = await self.agent_run_repository.get_by_id(db_session, run_id)
+            if run is not None and run.session_id != session_id:
+                raise ValueError("AgentRun session mismatch")
+            await self.agent_run_repository.mark_terminal_if_running(
+                db_session,
                 run_id,
                 status,
                 ended_at=datetime.datetime.now(datetime.UTC),
-            ),
-            error_log="Failed to mark agent run terminal",
-            session_id=session_id,
-        )
+            )
+
+        await self.run_short_db(mark_terminal)
 
     async def update_agent_run_retry_state(
         self,
@@ -331,30 +315,23 @@ class SessionLifecycleService:
         retry_state: FailedRunRetryState | None,
     ) -> None:
         """Set or clear the AgentRun retry state."""
-        await self.run_short_db(
-            lambda db: self.agent_run_repository.update_retry_state(
-                db,
+
+        async def update_retry(db_session: AsyncSession) -> None:
+            run = await self.agent_run_repository.get_by_id(db_session, run_id)
+            if run is None or run.session_id != session_id:
+                raise ValueError("AgentRun not found in session")
+            await self.agent_run_repository.update_retry_state(
+                db_session,
                 run_id,
                 retry_state,
-            ),
-            error_log="Failed to update agent run retry state",
-            session_id=session_id,
-        )
+            )
+
+        await self.run_short_db(update_retry)
 
     async def run_short_db(
         self,
         action: Callable[[AsyncSession], Awaitable[_T]],
-        *,
-        error_log: str,
-        session_id: str,
-        default: _T | None = None,
-    ) -> _T | None:
+    ) -> _T:
         """Run ``action`` in short-lived DB transaction."""
-        try:
-            async with self.session_manager() as db_session:
-                return await action(db_session)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception(error_log, extra={"session_id": session_id})
-            return default
+        async with self.session_manager() as db_session:
+            return await action(db_session)

--- a/python/apps/azents/src/azents/worker/session/lifecycle_test.py
+++ b/python/apps/azents/src/azents/worker/session/lifecycle_test.py
@@ -110,10 +110,13 @@ class _AgentRunRepository:
         running_run: AgentRunState | None,
         *,
         activated_run: AgentRunState | None = None,
+        active_lookup_error: Exception | None = None,
     ) -> None:
         self.running_run = running_run
         self.activated_run = activated_run
+        self.active_lookup_error = active_lookup_error
         self.terminal_session_ids: list[str] = []
+        self.terminal_run_ids: list[str] = []
         self.activation_run_ids: list[str] = []
 
     async def get_active_by_session_id(
@@ -124,6 +127,32 @@ class _AgentRunRepository:
     ) -> AgentRunState | None:
         """Return test-specified active run."""
         del session, session_id
+        if self.active_lookup_error is not None:
+            raise self.active_lookup_error
+        return self.running_run
+
+    async def get_by_id(
+        self,
+        session: AsyncSession,
+        run_id: str,
+    ) -> AgentRunState | None:
+        """Return the configured run only when its ID matches."""
+        del session
+        if self.running_run is None or self.running_run.id != run_id:
+            return None
+        return self.running_run
+
+    async def mark_terminal_if_running(
+        self,
+        session: AsyncSession,
+        run_id: str,
+        status: AgentRunStatus,
+        *,
+        ended_at: datetime,
+    ) -> AgentRunState | None:
+        """Record a run-level terminal transition."""
+        del session, status, ended_at
+        self.terminal_run_ids.append(run_id)
         return self.running_run
 
     async def activate_pending(
@@ -244,6 +273,43 @@ async def test_mark_session_idle_allows_terminal_run_boundary() -> None:
     assert marked_idle
     assert agent_session_repository.idle_session_ids == ["session-001"]
     assert agent_run_repository.terminal_session_ids == []
+
+
+@pytest.mark.asyncio
+async def test_mark_session_idle_propagates_db_failure() -> None:
+    """A failed DB check cannot be reported as a safe idle boundary."""
+    service = _service(
+        agent_run_repository=_AgentRunRepository(
+            None,
+            active_lookup_error=RuntimeError("database unavailable"),
+        ),
+        agent_session_repository=_AgentSessionRepository(),
+        pending_input=False,
+    )
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await service.mark_session_idle("session-001")
+
+
+@pytest.mark.asyncio
+async def test_terminal_update_rejects_cross_session_run() -> None:
+    """A stale session runner cannot close another session's run by ID."""
+    run = _running_run().model_copy(update={"session_id": "session-002"})
+    agent_run_repository = _AgentRunRepository(run)
+    service = _service(
+        agent_run_repository=agent_run_repository,
+        agent_session_repository=_AgentSessionRepository(),
+        pending_input=False,
+    )
+
+    with pytest.raises(ValueError, match="AgentRun session mismatch"):
+        await service.mark_agent_run_terminal_if_running(
+            "session-001",
+            run_id=run.id,
+            status=AgentRunStatus.STOPPED,
+        )
+
+    assert agent_run_repository.terminal_run_ids == []
 
 
 @pytest.mark.asyncio

--- a/python/apps/azents/src/azents/worker/session/runner.py
+++ b/python/apps/azents/src/azents/worker/session/runner.py
@@ -59,7 +59,7 @@ class AgentSessionCommandReader(Protocol):
 
 @dataclasses.dataclass(frozen=True)
 class _PendingIdleBoundary:
-    """stale wake-up 뒤에 닫아야 하는 terminal run boundary."""
+    """Terminal run boundary to close after a stale wake-up."""
 
     message: SessionWakeUp
     toolkits: list[ToolkitBinding]

--- a/python/apps/azents/src/azents/worker/session/user_stop_finalizer.py
+++ b/python/apps/azents/src/azents/worker/session/user_stop_finalizer.py
@@ -336,14 +336,19 @@ class UserStopFinalizer:
         status: AgentRunStatus,
     ) -> None:
         """Close AgentRun row as terminal state if still running."""
-        await self._run_short_db(
-            lambda db: self.agent_run_repository.mark_terminal_if_running(
-                db,
+
+        async def mark_terminal(db_session: AsyncSession) -> None:
+            run = await self.agent_run_repository.get_by_id(db_session, run_id)
+            if run is not None and run.session_id != session_id:
+                raise ValueError("AgentRun session mismatch")
+            await self.agent_run_repository.mark_terminal_if_running(
+                db_session,
                 run_id,
                 status,
                 ended_at=datetime.datetime.now(datetime.UTC),
             )
-        )
+
+        await self._run_short_db(mark_terminal)
 
     async def _run_short_db(
         self,

--- a/python/apps/azents/src/azents/worker/session/user_stop_finalizer_test.py
+++ b/python/apps/azents/src/azents/worker/session/user_stop_finalizer_test.py
@@ -107,6 +107,17 @@ class _AgentRunRepository:
         del session, session_id
         return self.running_run
 
+    async def get_by_id(
+        self,
+        session: AsyncSession,
+        run_id: str,
+    ) -> AgentRunState | None:
+        """Return the configured Run only when its ID matches."""
+        del session
+        if self.running_run is None or self.running_run.id != run_id:
+            return None
+        return self.running_run
+
     async def mark_session_running_terminal(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

- keep S3, Redis, broker, model, runtime, and hook I/O outside database session scopes across session input, run lifecycle, and output reconstruction
- preallocate ExchangeFile, ModelFile, and Artifact IDs/object keys, upload with no DB session, then revalidate ownership and atomically persist metadata with compensation cleanup
- build the PostgreSQL-backed live snapshot in one short session, close it before Redis reads, and remove nested Goal/Todo sessions
- propagate lifecycle DB failures instead of silently reporting fallback state, and fence run terminal/retry mutations by session ownership
- update living specs and add transaction-boundary regression coverage

## Root cause

Several session lifecycle paths held a database session while awaiting external storage or Redis I/O. The live-state reader also opened nested DB sessions for Goal/Todo state, while the lifecycle helper swallowed unexpected DB failures and returned values that could be interpreted as a safe idle/terminal result. These patterns lengthened transaction lifetime, increased lock contention, and could hide incomplete durable transitions.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright .`
- `uv run pytest -q -m "not live_external and not runtime_provider" ./src` - 1,638 passed
- repository pre-commit hooks, including docs index regeneration and OpenAPI dump
