### PR TITLE
Fix Runtime Control rollout authentication

### DIFF
--- a/infra/charts/azents/templates/server/runtime-control-deployment.yaml.tpl
+++ b/infra/charts/azents/templates/server/runtime-control-deployment.yaml.tpl
@@ -29,7 +29,7 @@ spec:
         - name: runtime-control
           image: {{ include "azents.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy | quote }}
-          command: ["python", "src/cli/runtime_control_server.py"]
+          command: ["./bin/runtime-control.sh"]
           ports:
             - name: grpc
               containerPort: 8030
@@ -51,6 +51,8 @@ spec:
               value: {{ .Values.server.runtimeControl.startTimeoutSeconds | quote }}
             - name: AZ_RUNTIME_CONTROL_ALLOW_INSECURE
               value: "false"
+            - name: AZ_RUNTIME_CONTROL_KUBERNETES_TOKEN_REVIEW_ENABLED
+              value: {{ .Values.runtimeProviderKubernetes.enabled | quote }}
             - name: AZ_RUNTIME_CONTROL_TLS_CERTIFICATE_FILE
               value: "/var/run/secrets/azents/runtime-control-tls/tls.crt"
             - name: AZ_RUNTIME_CONTROL_TLS_PRIVATE_KEY_FILE

--- a/infra/charts/azents/tests/runtime_control_render_test.py
+++ b/infra/charts/azents/tests/runtime_control_render_test.py
@@ -69,10 +69,11 @@ def test_runtime_control_enabled_render_contract() -> None:
         "secrets.existingSecrets.auth=azents-auth",
     )
 
-    assert "src/cli/runtime_control_server.py" in rendered
+    assert 'command: ["./bin/runtime-control.sh"]' in rendered
     assert "initialDelaySeconds: 5" in rendered
     assert "AZ_RUNTIME_CONTROL_AUTH_TOKEN" not in rendered
     assert "AZ_RUNTIME_CONTROL_ALLOW_INSECURE" in rendered
+    assert "AZ_RUNTIME_CONTROL_KUBERNETES_TOKEN_REVIEW_ENABLED" in rendered
     assert "AZ_RUNTIME_CONTROL_TLS_CERTIFICATE_FILE" in rendered
     assert "azents-runtime-control-tls" in rendered
     assert "AZ_RUNTIME_RUNNER_IMAGE" in rendered
@@ -88,6 +89,26 @@ def test_runtime_control_enabled_render_contract() -> None:
     assert 'name: "azents-server"' in tokenreview_binding
     assert 'namespace: "default"' in tokenreview_binding
     assert "azents-runtime-provider-kubernetes" not in tokenreview_binding
+
+
+def test_runtime_control_enables_token_review_for_kubernetes_provider() -> None:
+    """Kubernetes Provider enables TokenReview on Runtime Control."""
+    rendered = _helm_template(
+        "server.runtimeControl.enabled=true",
+        "server.runtimeControl.runnerImage.repository=repo/runner",
+        "server.runtimeControl.runnerImage.tag=sha",
+        "runtimeProviderKubernetes.enabled=true",
+        "runtimeProviderKubernetes.image.repository=repo/provider",
+        "runtimeProviderKubernetes.image.tag=sha",
+        "runtimeProviderKubernetes.runnerImage.repository=repo/runner",
+        "runtimeProviderKubernetes.runnerImage.tag=sha",
+    )
+
+    runtime_control = rendered[rendered.index("name: runtime-control") :]
+    assert (
+        "name: AZ_RUNTIME_CONTROL_KUBERNETES_TOKEN_REVIEW_ENABLED\n"
+        '              value: "true"'
+    ) in runtime_control
 
 
 def test_runtime_control_allows_single_replica_configuration() -> None:

--- a/python/apps/azents/bin/runtime-control.sh
+++ b/python/apps/azents/bin/runtime-control.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+alembic_cfg="db-schemas/rdb/alembic.ini"
+revision_file="db-schemas/rdb/revision"
+
+if [ -f "${revision_file}" ]; then
+    if [ "$(cat "${revision_file}")" != "$(alembic -c "${alembic_cfg}" current 2> /dev/null | awk '{print $1}')" ]; then
+        echo "Database schema does not match. Upgrading..."
+        xargs alembic -c "${alembic_cfg}" upgrade < "${revision_file}"
+    fi
+fi
+
+exec python src/cli/runtime_control_server.py "$@"

--- a/python/apps/azents/db-schemas/rdb/migrations/env.py
+++ b/python/apps/azents/db-schemas/rdb/migrations/env.py
@@ -9,7 +9,7 @@ from logging.config import fileConfig
 import alembic_postgresql_enum  # noqa: F401  # pyright: ignore[reportUnusedImport]
 import boto3
 from alembic import context
-from sqlalchemy import pool
+from sqlalchemy import pool, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
@@ -44,6 +44,8 @@ if config.config_file_name is not None:
 # add your model's MetaData object here
 # for 'autogenerate' support
 target_metadata = RDBModel.metadata
+
+_MIGRATION_LOCK_KEY = (0x415A454E, 0x54534442)
 
 # Model imports
 import_db_models("azents.rdb.models")
@@ -115,6 +117,14 @@ async def run_async_migrations() -> None:
     )
 
     async with connectable.connect() as connection:
+        await connection.execute(
+            text("SELECT pg_advisory_lock(:namespace, :operation)"),
+            {
+                "namespace": _MIGRATION_LOCK_KEY[0],
+                "operation": _MIGRATION_LOCK_KEY[1],
+            },
+        )
+        await connection.commit()
         await connection.run_sync(do_run_migrations)
 
     await connectable.dispose()


### PR DESCRIPTION
## Summary

- enable Kubernetes TokenReview whenever the bundled Kubernetes Runtime Provider is enabled
- gate Runtime Control startup on the packaged Alembic revision
- serialize all online Alembic migrations with a PostgreSQL session advisory lock
- add Helm render coverage for the TokenReview and startup contracts

## Root cause

The production rollout enabled projected ServiceAccount credentials and TokenReview RBAC, but the Runtime Control Deployment never enabled the TokenReview verifier. The new Provider therefore received generic `UNAUTHENTICATED` responses. Runtime Control also started directly without the schema gate used by the other server workloads, allowing it to query new ORM columns before another workload finished migrations.

The retained pre-TLS Provider ReplicaSet was also the source of the observed `WRONG_VERSION_NUMBER` handshakes; it should scale down naturally after the new Provider becomes ready.

## Validation

- `helm lint infra/charts/azents ...`
- `uv run --with pytest pytest tests` in `infra/charts/azents` (29 passed)
- Ruff and Pyright for the Alembic environment
- `uv run alembic -c db-schemas/rdb/alembic.ini heads` (single head `2743073ba95b`)
- repository pre-commit hooks
- independent rollout/security review with no remaining actionable findings

## Live evidence before remediation

- Kubernetes Provider revision `948e22a946fc` remains unready with repeated `UNAUTHENTICATED`
- Runtime Control TokenReview RBAC is present, but the enable env was absent
- Admin bootstrap reconciled the `system-kubernetes` declaration with no conflicts
- all three Runtime PVC UIDs and bound PV names still match the pre-rollout baseline

No live cluster writes were performed.