### PR TITLE
Runtime Provider 인증 ID 분리 및 Snapshot 자동 생성 복구

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,8 +1,9 @@
 name: Snapshot
 
 on:
-  # Automatic main snapshots are temporarily paused while the Runtime Control
-  # authentication stack is merged. Keep manual dispatch for the final snapshot.
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/python/apps/azents/src/azents/runtime/control_protocol/grpc/provider_server_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/grpc/provider_server_test.py
@@ -64,6 +64,7 @@ class FakeProviderCredentialBridge:
             binding_id="binding-1",
             credential_id="credential-1",
             provider_id="provider-1",
+            provider_resource_id="provider-row-1",
             provider_kind=RuntimeProviderKind.DOCKER,
             provider_scope=RuntimeProviderScope.SYSTEM,
             provider_workspace_id=None,

--- a/python/apps/azents/src/azents/services/runtime_provider_bootstrap/enrollment.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_bootstrap/enrollment.py
@@ -102,7 +102,7 @@ class RuntimeProviderBootstrapEnrollmentService:
             except RuntimeProviderCredentialUnavailable:
                 pass
             else:
-                if authentication.provider_id == provider_id:
+                if authentication.provider_resource_id == provider_id:
                     return RuntimeProviderBootstrapCredential(
                         secret=existing_secret,
                         changed=False,

--- a/python/apps/azents/src/azents/services/runtime_provider_control/data.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_control/data.py
@@ -32,11 +32,12 @@ class RuntimeProviderCredentialIssued:
 
 @dataclass(frozen=True)
 class RuntimeProviderCredentialAuthentication:
-    """Authenticated identity bound to a durable Provider."""
+    """Authenticated logical and resource identities for one durable Provider."""
 
     binding_id: str
     credential_id: str | None
     provider_id: str
+    provider_resource_id: str
     provider_kind: RuntimeProviderKind
     provider_scope: RuntimeProviderScope
     provider_workspace_id: str | None

--- a/python/apps/azents/src/azents/services/runtime_provider_control/provider_auth.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_control/provider_auth.py
@@ -213,7 +213,8 @@ class IssuedTokenProviderAuthVerifier:
         return RuntimeProviderCredentialAuthentication(
             binding_id=binding.id,
             credential_id=credential.id,
-            provider_id=provider.id,
+            provider_id=provider.provider_id,
+            provider_resource_id=provider.id,
             provider_kind=provider.kind,
             provider_scope=provider.scope,
             provider_workspace_id=provider.workspace_id,
@@ -295,7 +296,8 @@ class KubernetesServiceAccountProviderAuthVerifier:
         return RuntimeProviderCredentialAuthentication(
             binding_id=binding.id,
             credential_id=None,
-            provider_id=provider.id,
+            provider_id=provider.provider_id,
+            provider_resource_id=provider.id,
             provider_kind=provider.kind,
             provider_scope=provider.scope,
             provider_workspace_id=provider.workspace_id,

--- a/python/apps/azents/src/azents/services/runtime_provider_control/provider_auth_test.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_control/provider_auth_test.py
@@ -107,6 +107,7 @@ def _authentication(
             else None
         ),
         provider_id="provider-1",
+        provider_resource_id="provider-1",
         provider_kind=RuntimeProviderKind.KUBERNETES,
         provider_scope=RuntimeProviderScope.SYSTEM,
         provider_workspace_id=None,
@@ -138,6 +139,7 @@ def test_authentication_rejects_method_specific_evidence_mismatch(
             binding_id="binding-1",
             credential_id=credential_id,
             provider_id="provider-1",
+            provider_resource_id="provider-1",
             provider_kind=RuntimeProviderKind.KUBERNETES,
             provider_scope=RuntimeProviderScope.SYSTEM,
             provider_workspace_id=None,
@@ -444,7 +446,8 @@ async def test_kubernetes_verifier_resolves_exact_bootstrap_binding() -> None:
     result = await verifier.verify(secret="service-account-token", now=_NOW)
 
     assert result.binding_id == "binding-1"
-    assert result.provider_id == "provider-row-1"
+    assert result.provider_id == "system-kubernetes"
+    assert result.provider_resource_id == "provider-row-1"
     assert result.credential_id is None
     assert result.auth_method is RuntimeProviderAuthMethod.KUBERNETES_SERVICE_ACCOUNT
     binding_repository.mark_authenticated.assert_awaited_once()

--- a/python/apps/azents/src/azents/services/runtime_provider_control/service.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_control/service.py
@@ -332,7 +332,7 @@ class RuntimeProviderEnrollmentService:
         async with self.session_manager() as session:
             provider = await self.provider_repository.get_by_id(
                 session,
-                provider_id=authentication.provider_id,
+                provider_id=authentication.provider_resource_id,
                 for_update=True,
             )
             if provider is None or provider.lifecycle_state in _TERMINAL:
@@ -344,7 +344,7 @@ class RuntimeProviderEnrollmentService:
             )
             if (
                 binding is None
-                or binding.provider_id != authentication.provider_id
+                or binding.provider_id != authentication.provider_resource_id
                 or binding.auth_method is not authentication.auth_method
                 or binding.subject != authentication.auth_subject
                 or binding.state is not RuntimeProviderBindingState.ACTIVE
@@ -371,7 +371,7 @@ class RuntimeProviderEnrollmentService:
             connection = await self.repository.create_connection(
                 session,
                 create=RuntimeProviderConnectionCreate(
-                    provider_id=authentication.provider_id,
+                    provider_id=authentication.provider_resource_id,
                     binding_id=authentication.binding_id,
                     credential_id=authentication.credential_id,
                     auth_method=authentication.auth_method,
@@ -389,7 +389,7 @@ class RuntimeProviderEnrollmentService:
                 revoked_credentials = (
                     await self.repository.revoke_older_bootstrap_credentials(
                         session,
-                        provider_id=authentication.provider_id,
+                        provider_id=authentication.provider_resource_id,
                         current_credential_id=authentication.credential_id,
                         revoked_at=connected_at,
                     )
@@ -397,7 +397,7 @@ class RuntimeProviderEnrollmentService:
             await self.provider_repository.append_audit_event(
                 session,
                 create=RuntimeProviderAuditEventCreate(
-                    provider_id=authentication.provider_id,
+                    provider_id=authentication.provider_resource_id,
                     event_type=RuntimeProviderAuditEventType.CONNECTION_OPENED,
                     actor_user_id=None,
                     metadata={
@@ -432,7 +432,7 @@ class RuntimeProviderEnrollmentService:
         async with self.session_manager() as session:
             return await self.repository.heartbeat_connection(
                 session,
-                provider_id=authentication.provider_id,
+                provider_id=authentication.provider_resource_id,
                 binding_id=authentication.binding_id,
                 credential_id=authentication.credential_id,
                 auth_method=authentication.auth_method,
@@ -452,7 +452,7 @@ class RuntimeProviderEnrollmentService:
         async with self.session_manager() as session:
             return await self.repository.connection_active(
                 session,
-                provider_id=authentication.provider_id,
+                provider_id=authentication.provider_resource_id,
                 binding_id=authentication.binding_id,
                 credential_id=authentication.credential_id,
                 auth_method=authentication.auth_method,
@@ -472,7 +472,7 @@ class RuntimeProviderEnrollmentService:
         async with self.session_manager() as session:
             disconnected = await self.repository.disconnect_connection(
                 session,
-                provider_id=authentication.provider_id,
+                provider_id=authentication.provider_resource_id,
                 binding_id=authentication.binding_id,
                 credential_id=authentication.credential_id,
                 auth_method=authentication.auth_method,
@@ -484,7 +484,7 @@ class RuntimeProviderEnrollmentService:
                 await self.provider_repository.append_audit_event(
                     session,
                     create=RuntimeProviderAuditEventCreate(
-                        provider_id=authentication.provider_id,
+                        provider_id=authentication.provider_resource_id,
                         event_type=RuntimeProviderAuditEventType.CONNECTION_CLOSED,
                         actor_user_id=None,
                         metadata={


### PR DESCRIPTION
## 변경 사항

- 인증된 Runtime Provider identity에 논리 ID와 내부 리소스 ID를 함께 유지합니다.
- gRPC 등록 payload는 stable logical ID와 검증하고, 연결/바인딩 영속성은 내부 resource ID를 사용합니다.
- main push 시 Snapshot workflow가 다시 자동 실행되도록 트리거를 복구합니다.

## 원인

Kubernetes ServiceAccount TokenReview와 durable binding 조회는 성공했지만, 인증 결과에 runtime_providers.id 내부 리소스 ID만 담았습니다. gRPC 등록 payload의 system-kubernetes 논리 ID를 이 내부 ID와 비교해 정상 Provider도 PERMISSION_DENIED로 거절했습니다.

## 영향

정상 바인딩의 Kubernetes Runtime Provider가 system-kubernetes ID를 유지한 채 연결할 수 있습니다. 병합 후 main Snapshot 이미지가 자동 생성되고 downstream dispatch가 다시 수행됩니다.

## 검증

- Runtime Provider auth/control/gRPC pytest: 34 passed
- Ruff check 및 format check
- Pyright
- pre-commit 전체 커밋 훅
- Snapshot workflow YAML 검증