### PR TITLE
Fix Runtime Provider contract bootstrap lifecycle

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -21,7 +21,7 @@ Design documents are accumulated records and are not listed individually in this
 | [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-07-26 | 12 |
 | [Memory](spec/domain/memory.md) | memory | @Hardtack | 2026-07-24 | 6 |
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-07-21 | 17 |
-| [Runtime Provider](spec/domain/runtime-provider.md) | runtime-provider | - | 2026-07-26 | 4 |
+| [Runtime Provider](spec/domain/runtime-provider.md) | runtime-provider | - | 2026-07-27 | 5 |
 | [System Settings](spec/domain/system-settings.md) | system-settings | @Hardtack | 2026-07-23 | 4 |
 | [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-07-26 | 75 |
 | [User & Authentication](spec/domain/user-auth.md) | user-auth | @Hardtack | 2026-07-20 | 8 |
@@ -33,7 +33,7 @@ Design documents are accumulated records and are not listed individually in this
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-26 | 134 |
 | [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-26 | 31 |
-| [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-26 | 6 |
+| [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 7 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |
 | [Context Compaction](spec/flow/context-compaction.md) | @Hardtack | 2026-07-22 | 31 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -18,7 +18,7 @@ Details of all living specs. Synchronized from frontmatter.
 | goal | [Goal Domain Spec](domain/goal.md) | - | 2026-07-26 | 12 |
 | memory | [Memory](domain/memory.md) | @Hardtack | 2026-07-24 | 6 |
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-07-21 | 17 |
-| runtime-provider | [Runtime Provider](domain/runtime-provider.md) | - | 2026-07-26 | 4 |
+| runtime-provider | [Runtime Provider](domain/runtime-provider.md) | - | 2026-07-27 | 5 |
 | system-settings | [System Settings](domain/system-settings.md) | @Hardtack | 2026-07-23 | 4 |
 | toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-07-26 | 75 |
 | user-auth | [User & Authentication](domain/user-auth.md) | @Hardtack | 2026-07-20 | 8 |
@@ -30,7 +30,7 @@ Details of all living specs. Synchronized from frontmatter.
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-26 | 134 |
 | [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-26 | 31 |
-| [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-26 | 6 |
+| [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 7 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |
 | [Context Compaction](flow/context-compaction.md) | @Hardtack | 2026-07-22 | 31 |

--- a/docs/azents/spec/domain/runtime-provider.md
+++ b/docs/azents/spec/domain/runtime-provider.md
@@ -18,6 +18,7 @@ code_paths:
   - python/apps/azents/src/azents/services/runtime_provider_binding_admin/**
   - python/apps/azents/src/azents/services/runtime_provider_bootstrap/**
   - python/apps/azents/src/azents/services/runtime_provider_control/**
+  - python/apps/azents/src/azents/services/runtime_provider_contract/**
   - python/apps/azents/src/azents/services/runtime_provider_public/**
   - python/apps/azents/src/azents/services/runtime_provider_selection/**
   - python/apps/azents/src/azents/services/runtime_execution_policy/**
@@ -28,6 +29,9 @@ code_paths:
   - python/apps/azents/src/azents/rdb/models/agent_runtime.py
   - python/apps/azents/src/azents/services/agent_runtime/**
   - python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
+  - python/apps/azents-runtime-provider-docker/src/azents_runtime_provider_docker/main.py
+  - python/libs/azents-runtime-control/src/azents_runtime_control/**
+  - proto/azents/runtime_control/v1/runtime_provider_control.proto
   - infra/charts/azents/templates/runtime-provider-kubernetes/**
   - infra/charts/azents/templates/server/rbac.yaml.tpl
   - infra/charts/azents/templates/server/runtime-control-deployment.yaml.tpl
@@ -37,8 +41,8 @@ code_paths:
   - typescript/apps/azents-admin-web/src/app/runtime-providers/**
   - typescript/apps/azents-admin-web/src/features/runtime-providers/**
   - typescript/apps/azents-admin-web/src/trpc/routers/runtimeProvider.ts
-last_verified_at: 2026-07-26
-spec_version: 4
+last_verified_at: 2026-07-27
+spec_version: 5
 ---
 
 # Runtime Provider
@@ -55,6 +59,14 @@ Providers are optional. A Provider must be enabled, active, connected, Workspace
 
 The aggregate stores lifecycle state, enablement, scope, Workspace availability mode, declared capabilities, accepted contract revision, active configuration revision, and an incrementing Admin policy version. Contract revisions are immutable and move through candidate, accepted, rejected, and superseded states. Configuration revisions are immutable candidates that require Provider validation and explicit activation; active configuration is tied to the accepted contract and is never returned with secret plaintext.
 
+After workload authentication and identity matching, Provider registration submits the complete
+restricted capability contract. Runtime Control validates its implementation and protocol identity,
+canonicalizes the payload, and creates or finds the Provider-local digest revision before accepting
+the connection. A first or changed valid digest remains a candidate: the Provider may stay connected
+for observation, but it is not provisioning-ready until a System Admin explicitly accepts that exact
+revision. Admin routes expose contract history and expected-`admin_version` acceptance, and the Admin
+Provider detail presents pending revisions with an explicit acceptance action.
+
 Admin routes expose inventory and mutable policy/availability operations under `/runtime-provider/v1/providers`. Public discovery exposes only safe option metadata under `/runtime-provider/v1/workspaces/{handle}/providers`; credentials, authentication evidence, encrypted secrets, audit state, and mutable Runtime bindings are excluded.
 
 ## Runtime binding
@@ -62,6 +74,12 @@ Admin routes expose inventory and mutable policy/availability operations under `
 New logical Runtime creation uses one exact Provider candidate. Agent preference is evaluated before the Platform Runtime System Setting default, and no fallback occurs after an explicit candidate is ineligible. The resolver checks lifecycle, enablement, Platform scope, Workspace allow-list, connection readiness, accepted contract ownership/status, configuration validity, and requested capabilities.
 
 The selected Provider resource ID, opaque logical ID, binding origin, contract/configuration revision identifiers, and policy digest are persisted on the logical Runtime. An immutable effective policy snapshot is attached before lifecycle dispatch. Later default, availability, contract, or configuration changes never move an existing logical Runtime.
+
+A pre-contract Runtime with only its historical logical Provider ID is upgraded lazily at the same
+selection boundary. The service resolves that exact logical ID, validates the accepted contract,
+stores a `migration` resource binding, and attaches the initial immutable policy snapshot in one
+transaction. This compatibility path preserves the logical Runtime, desired generation, and
+Provider-owned workspace storage; it neither invokes reset nor selects a different Provider.
 
 When no eligible Provider exists, Public Agent Runtime lifecycle endpoints return a stable `409` unavailable outcome instead of creating a partial Runtime or selecting a deployment/environment default.
 
@@ -131,6 +149,7 @@ Authentication rollout does not render, own, select, delete, rename, or recreate
 
 ## Version history
 
+- **5 (2026-07-27):** Connected authenticated Provider contract proposal, immutable candidate persistence, explicit Admin acceptance, and storage-preserving legacy Runtime policy binding.
 - **4 (2026-07-26):** Added restrictive Runtime Execution Profile compatibility, explicit Apply versus automatic tightening convergence, safe policy projections, and the current fail-closed privileged-engine boundary.
 - **3 (2026-07-23):** Promoted durable authentication bindings, explicit issued-token and Kubernetes ServiceAccount methods, Admin binding lifecycle, TokenReview workload identity, secret-free Helm deployment, and Runtime storage preservation behavior.
 - **2 (2026-07-23):** Added Provider policy, selection, and credential-bootstrap deployment behavior.

--- a/docs/azents/spec/flow/agent-runtime-persistence.md
+++ b/docs/azents/spec/flow/agent-runtime-persistence.md
@@ -17,8 +17,8 @@ code_paths:
   - python/apps/azents-runtime-runner/**
   - infra/charts/azents/**
   - infra/argocd/azents-runtime-provider-kubernetes/**
-last_verified_at: 2026-07-26
-spec_version: 6
+last_verified_at: 2026-07-27
+spec_version: 7
 ---
 
 # Agent Runtime Persistence
@@ -41,6 +41,14 @@ revision IDs, and an immutable policy snapshot are stored before lifecycle comma
 A later availability, default, contract, or configuration change does not reassign an existing logical
 Runtime. If no Provider can satisfy the request, the lifecycle API returns an explicit unavailable
 conflict and no partial Runtime is persisted.
+
+Runtime rows created before durable Provider contracts may contain only the historical logical
+Provider ID. On the next Runtime access or lifecycle request, selection resolves that same logical
+Provider, requires its accepted contract, stores the internal Provider resource ID with `migration`
+origin, and attaches the initial policy snapshot transactionally. This upgrade does not replace the
+logical Runtime, advance its desired generation, delete its workspace, or invoke a Provider
+lifecycle command. A later explicit start or restart uses the normal generation-fenced policy and
+preserves the existing host directory or PVC.
 
 Runtime execution policy stores Agent intent separately from the applied Runtime target. Platform
 and Workspace restrictions can only narrow policy. An Agent Profile/override change is pending until
@@ -165,6 +173,7 @@ Required checks:
 
 ## Changelog
 
+- **2026-07-27 (spec_version=7)** — Added lazy exact-Provider binding and initial policy snapshot attachment for pre-contract Runtime rows without workspace replacement.
 - **2026-07-26 (spec_version=6)** — Added durable execution-policy target/applied snapshots, reset-free restrictive convergence, fixed Kubernetes topology isolation, and separate unqualified nested-engine storage.
 - **2026-07-26 (spec_version=5)** — Added storage-preserving periodic convergence for desired-running Runtime workload image and configuration drift.
 - **2026-07-03 (spec_version=3)** — Reflected Project-first Workspace browser ownership and registry-scoped Project root action boundary.

--- a/proto/azents/runtime_control/v1/runtime_provider_control.proto
+++ b/proto/azents/runtime_control/v1/runtime_provider_control.proto
@@ -45,6 +45,7 @@ message ProviderRegister {
   string config_schema_version = 7;
   google.protobuf.Struct metadata = 8;
   string auth_credential_id = 9;
+  google.protobuf.Struct capability_contract = 10;
 }
 
 message ProviderRegisterAccepted {

--- a/python/apps/azents-runtime-provider-docker/src/azents_runtime_provider_docker/main.py
+++ b/python/apps/azents-runtime-provider-docker/src/azents_runtime_provider_docker/main.py
@@ -15,6 +15,7 @@ from azents_runtime_control.grpc_provider_client import (
 )
 from azents_runtime_control.grpc_tls import GrpcClientTlsConfig
 from azents_runtime_control.provider import (
+    JsonValue,
     ProviderConnectionRejected,
     ProviderRegistration,
     ProviderRunLoop,
@@ -33,6 +34,28 @@ _CONFIG_SCHEMA_VERSION = "agent-runtime-provider-docker-v1"
 _DEFAULT_COMMAND_BLOCK_MS = 5_000
 _CONTROL_RECONNECT_DELAY_SECONDS = 1.0
 _LOGGER = logging.getLogger(__name__)
+
+_CAPABILITY_CONTRACT: dict[str, JsonValue] = {
+    "schema_version": 1,
+    "implementation_key": "docker",
+    "implementation_version": "0.1.0",
+    "protocol_version": _PROTOCOL_VERSION,
+    "core_lifecycle_operations": [
+        "start",
+        "stop",
+        "restart",
+        "reset",
+        "observe",
+        "terminal_delete",
+    ],
+    "optional_capabilities": [],
+    "persistence": {
+        "kind": "persistent",
+        "reset_destroys_workspace": True,
+        "terminal_delete_destroys_workspace": True,
+    },
+    "configuration_fields": [],
+}
 
 
 def main() -> None:
@@ -102,6 +125,7 @@ async def _run_control_loop(
             "workspace_path": settings.workspace_path,
             "tmp_path": settings.tmp_path,
         },
+        capability_contract=_CAPABILITY_CONTRACT,
     )
     while not stop.is_set():
         control_client = create_provider_control_client(settings)

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
@@ -18,6 +18,7 @@ from azents_runtime_control.grpc_provider_client import (
 )
 from azents_runtime_control.grpc_tls import GrpcClientTlsConfig
 from azents_runtime_control.provider import (
+    JsonValue,
     ProviderConnectionRejected,
     ProviderRegistration,
     ProviderRunLoop,
@@ -52,6 +53,32 @@ _CREDENTIAL_POLL_INTERVAL_SECONDS = 1.0
 _LEADERSHIP_WAIT_LOG_INTERVAL_SECONDS = 60.0
 _MIN_LEADERSHIP_POLL_SECONDS = 1.0
 _LOGGER = logging.getLogger(__name__)
+
+_CAPABILITY_CONTRACT: dict[str, JsonValue] = {
+    "schema_version": 1,
+    "implementation_key": "kubernetes",
+    "implementation_version": "0.1.0",
+    "protocol_version": _PROTOCOL_VERSION,
+    "core_lifecycle_operations": [
+        "start",
+        "stop",
+        "restart",
+        "reset",
+        "observe",
+        "terminal_delete",
+    ],
+    "optional_capabilities": [
+        "execution_policy_v1",
+        "runtime_network_policy",
+        "engine_storage_ephemeral",
+    ],
+    "persistence": {
+        "kind": "persistent",
+        "reset_destroys_workspace": True,
+        "terminal_delete_destroys_workspace": True,
+    },
+    "configuration_fields": [],
+}
 
 
 async def _main() -> None:
@@ -142,6 +169,7 @@ async def _run_control_loop(
         ),
         config_schema_version=_CONFIG_SCHEMA_VERSION,
         metadata={"workspace_path": settings.workspace_path},
+        capability_contract=_CAPABILITY_CONTRACT,
     )
     while not stop.is_set():
         _set_readiness(settings.readiness_file, ready=False)

--- a/python/apps/azents/specs/admin/openapi.json
+++ b/python/apps/azents/specs/admin/openapi.json
@@ -1427,6 +1427,121 @@
         }
       }
     },
+    "/runtime-provider/v1/providers/{provider_id}/contracts": {
+      "get": {
+        "tags": [
+          "Runtime Provider v1"
+        ],
+        "summary": "List Contracts",
+        "description": "List accepted and pending capability contract revisions.",
+        "operationId": "runtime_provider_v1_list_contracts",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeProviderContractListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/runtime-provider/v1/providers/{provider_id}/contracts/{revision_id}/accept": {
+      "post": {
+        "tags": [
+          "Runtime Provider v1"
+        ],
+        "summary": "Accept Contract",
+        "description": "Explicitly accept one valid Provider capability contract candidate.",
+        "operationId": "runtime_provider_v1_accept_contract",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "revision_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Revision Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeProviderContractAcceptRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeProviderContractResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/runtime-provider/v1/providers/{provider_id}/authentication-bindings": {
       "get": {
         "tags": [
@@ -6112,6 +6227,149 @@
         ],
         "title": "RuntimeProviderBindingState",
         "description": "Lifecycle state of a durable Provider authentication binding."
+      },
+      "RuntimeProviderContractAcceptRequest": {
+        "properties": {
+          "expected_admin_version": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Expected Admin Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "expected_admin_version"
+        ],
+        "title": "RuntimeProviderContractAcceptRequest",
+        "description": "Optimistic concurrency input for explicit contract acceptance."
+      },
+      "RuntimeProviderContractListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeProviderContractResponse"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "RuntimeProviderContractListResponse",
+        "description": "Provider contract revision history."
+      },
+      "RuntimeProviderContractResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
+          "implementation_version": {
+            "type": "string",
+            "title": "Implementation Version"
+          },
+          "protocol_version": {
+            "type": "string",
+            "title": "Protocol Version"
+          },
+          "contract": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Contract"
+          },
+          "compatibility": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Compatibility"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RuntimeProviderContractStatus"
+          },
+          "validation_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Validation Code"
+          },
+          "validation_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Validation Message"
+          },
+          "accepted_by_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accepted By User Id"
+          },
+          "accepted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Accepted At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "digest",
+          "implementation_version",
+          "protocol_version",
+          "contract",
+          "compatibility",
+          "status",
+          "validation_code",
+          "validation_message",
+          "accepted_by_user_id",
+          "accepted_at",
+          "created_at"
+        ],
+        "title": "RuntimeProviderContractResponse",
+        "description": "One immutable Provider capability contract revision."
+      },
+      "RuntimeProviderContractStatus": {
+        "type": "string",
+        "enum": [
+          "candidate",
+          "accepted",
+          "rejected",
+          "superseded"
+        ],
+        "title": "RuntimeProviderContractStatus",
+        "description": "Administrative state of an immutable Provider capability contract."
       },
       "RuntimeProviderLifecycleState": {
         "type": "string",

--- a/python/apps/azents/src/azents/api/admin/runtime_provider/v1/__init__.py
+++ b/python/apps/azents/src/azents/api/admin/runtime_provider/v1/__init__.py
@@ -14,6 +14,10 @@ from azents.services.runtime_provider_binding_admin.service import (
     RuntimeProviderBindingAdminService,
     RuntimeProviderBindingAdminUnavailable,
 )
+from azents.services.runtime_provider_contract.service import (
+    RuntimeProviderContractService,
+    RuntimeProviderContractUnavailable,
+)
 from azents.utils.fastapi.route import RouteMounter
 
 from .data import (
@@ -26,12 +30,53 @@ from .data import (
     RuntimeProviderAuthenticationBindingRotateRequest,
     RuntimeProviderAuthenticationBindingRotateResponse,
     RuntimeProviderAvailabilityRequest,
+    RuntimeProviderContractAcceptRequest,
+    RuntimeProviderContractListResponse,
+    RuntimeProviderContractResponse,
     RuntimeProviderListResponse,
     RuntimeProviderPolicyUpdateRequest,
     RuntimeProviderResponse,
 )
 
 router = APIRouter()
+
+
+@router.get("/providers/{provider_id}/contracts")
+async def list_contracts(
+    service: Annotated[RuntimeProviderContractService, Depends()],
+    *,
+    provider_id: str,
+) -> RuntimeProviderContractListResponse:
+    """List accepted and pending capability contract revisions."""
+    try:
+        contracts = await service.list_contracts(provider_id)
+    except RuntimeProviderContractUnavailable as error:
+        _raise_contract_unavailable(error)
+    return RuntimeProviderContractListResponse(
+        items=[RuntimeProviderContractResponse.convert_from(item) for item in contracts]
+    )
+
+
+@router.post("/providers/{provider_id}/contracts/{revision_id}/accept")
+async def accept_contract(
+    system_admin: Annotated[SystemAdmin, Depends(get_system_admin)],
+    service: Annotated[RuntimeProviderContractService, Depends()],
+    request_body: RuntimeProviderContractAcceptRequest,
+    *,
+    provider_id: str,
+    revision_id: str,
+) -> RuntimeProviderContractResponse:
+    """Explicitly accept one valid Provider capability contract candidate."""
+    try:
+        contract = await service.accept_contract(
+            provider_id,
+            revision_id,
+            expected_admin_version=request_body.expected_admin_version,
+            actor_user_id=system_admin.user_id,
+        )
+    except RuntimeProviderContractUnavailable as error:
+        _raise_contract_unavailable(error)
+    return RuntimeProviderContractResponse.convert_from(contract)
 
 
 @router.get("/providers/{provider_id}/authentication-bindings")
@@ -232,6 +277,29 @@ def _raise_unavailable(error: RuntimeProviderAdminUnavailable) -> NoReturn:
     raise HTTPException(
         status_code=status.HTTP_409_CONFLICT,
         detail="Runtime Provider operation is unavailable.",
+    ) from None
+
+
+def _raise_contract_unavailable(
+    error: RuntimeProviderContractUnavailable,
+) -> NoReturn:
+    """Convert contract lifecycle failures to bounded Admin API errors."""
+    if error.code == "provider_not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": error.code},
+        ) from None
+    if error.code == "contract_invalid":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={"code": error.code},
+        ) from None
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": error.code,
+            "current_admin_version": error.current_admin_version,
+        },
     ) from None
 
 

--- a/python/apps/azents/src/azents/api/admin/runtime_provider/v1/data.py
+++ b/python/apps/azents/src/azents/api/admin/runtime_provider/v1/data.py
@@ -11,11 +11,15 @@ from azents.core.enums import (
     RuntimeProviderBindingAuditEventType,
     RuntimeProviderBindingOwner,
     RuntimeProviderBindingState,
+    RuntimeProviderContractStatus,
     RuntimeProviderLifecycleState,
 )
 from azents.repos.runtime_provider.data import RuntimeProvider
 from azents.repos.runtime_provider_binding.data import (
     RuntimeProviderAuthBindingAuditEvent,
+)
+from azents.repos.runtime_provider_policy.data import (
+    RuntimeProviderContractRevision,
 )
 from azents.services.runtime_provider_binding_admin.service import (
     RuntimeProviderBindingAdminProjection,
@@ -70,6 +74,56 @@ class RuntimeProviderListResponse(BaseModel):
     """Provider inventory response."""
 
     items: list[RuntimeProviderResponse]
+
+
+class RuntimeProviderContractResponse(BaseModel):
+    """One immutable Provider capability contract revision."""
+
+    id: str
+    digest: str
+    implementation_version: str
+    protocol_version: str
+    contract: dict[str, Any]
+    compatibility: dict[str, Any]
+    status: RuntimeProviderContractStatus
+    validation_code: str | None
+    validation_message: str | None
+    accepted_by_user_id: str | None
+    accepted_at: datetime.datetime | None
+    created_at: datetime.datetime
+
+    @classmethod
+    def convert_from(
+        cls,
+        contract: RuntimeProviderContractRevision,
+    ) -> "RuntimeProviderContractResponse":
+        """Convert the repository contract to an Admin-safe response."""
+        return cls(
+            id=contract.id,
+            digest=contract.digest,
+            implementation_version=contract.implementation_version,
+            protocol_version=contract.protocol_version,
+            contract=contract.contract,
+            compatibility=contract.compatibility,
+            status=contract.status,
+            validation_code=contract.validation_code,
+            validation_message=contract.validation_message,
+            accepted_by_user_id=contract.accepted_by_user_id,
+            accepted_at=contract.accepted_at,
+            created_at=contract.created_at,
+        )
+
+
+class RuntimeProviderContractListResponse(BaseModel):
+    """Provider contract revision history."""
+
+    items: list[RuntimeProviderContractResponse]
+
+
+class RuntimeProviderContractAcceptRequest(BaseModel):
+    """Optimistic concurrency input for explicit contract acceptance."""
+
+    expected_admin_version: int = Field(ge=0)
 
 
 class RuntimeProviderPolicyUpdateRequest(BaseModel):

--- a/python/apps/azents/src/azents/api/admin/runtime_provider/v1/route_test.py
+++ b/python/apps/azents/src/azents/api/admin/runtime_provider/v1/route_test.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from azents.api.admin import mount as mount_admin
 from azents.api.admin.runtime_provider.v1 import (
+    accept_contract,
     get_auth_binding,
     mount,
     rotate_auth_binding,
@@ -17,19 +18,27 @@ from azents.api.admin.runtime_provider.v1 import (
 from azents.api.admin.runtime_provider.v1.data import (
     RuntimeProviderAuthenticationBindingResponse,
     RuntimeProviderAuthenticationBindingRotateRequest,
+    RuntimeProviderContractAcceptRequest,
 )
 from azents.core.auth.deps import SystemAdmin, get_system_admin
 from azents.core.enums import (
     RuntimeProviderAuthMethod,
     RuntimeProviderBindingOwner,
     RuntimeProviderBindingState,
+    RuntimeProviderContractStatus,
 )
 from azents.repos.runtime_provider_binding.data import RuntimeProviderAuthBinding
+from azents.repos.runtime_provider_policy.data import (
+    RuntimeProviderContractRevision,
+)
 from azents.services.runtime_provider_binding_admin.service import (
     RuntimeProviderBindingAdminProjection,
     RuntimeProviderBindingAdminService,
     RuntimeProviderBindingAdminUnavailable,
     RuntimeProviderBindingRotation,
+)
+from azents.services.runtime_provider_contract.service import (
+    RuntimeProviderContractService,
 )
 from azents.utils.fastapi.route import as_route_mounter
 
@@ -80,6 +89,11 @@ def test_mounts_runtime_provider_inventory_and_authentication_routes() -> None:
     assert "/runtime-provider/v1/providers/{provider_id}" in paths
     assert "/runtime-provider/v1/providers/{provider_id}/policy" in paths
     assert "/runtime-provider/v1/providers/{provider_id}/availability" in paths
+    assert "/runtime-provider/v1/providers/{provider_id}/contracts" in paths
+    assert (
+        "/runtime-provider/v1/providers/{provider_id}/contracts/{revision_id}/accept"
+        in paths
+    )
     assert (
         "/runtime-provider/v1/providers/{provider_id}/authentication-bindings" in paths
     )
@@ -155,6 +169,48 @@ def test_rotate_rejects_timezone_naive_expiry() -> None:
             expected_admin_version=1,
             expires_at=datetime.datetime(2026, 7, 23, 12),
         )
+
+
+@pytest.mark.asyncio
+async def test_accept_contract_uses_admin_identity_and_expected_version() -> None:
+    """Contract acceptance carries explicit Admin authority and concurrency."""
+    now = datetime.datetime(2026, 7, 27, tzinfo=datetime.UTC)
+    service = create_autospec(RuntimeProviderContractService, instance=True)
+    service.accept_contract = AsyncMock(
+        return_value=RuntimeProviderContractRevision(
+            id="contract-1",
+            provider_id="provider-row-1",
+            digest="a" * 64,
+            implementation_version="0.1.0",
+            protocol_version="provider-v1",
+            contract={"schema_version": 1},
+            compatibility={"compatible": True},
+            status=RuntimeProviderContractStatus.ACCEPTED,
+            validation_code=None,
+            validation_message=None,
+            accepted_by_user_id="admin-1",
+            accepted_at=now,
+            rejected_by_user_id=None,
+            rejected_at=None,
+            created_at=now,
+        )
+    )
+
+    response = await accept_contract(
+        system_admin=_system_admin(),
+        service=service,
+        request_body=RuntimeProviderContractAcceptRequest(expected_admin_version=0),
+        provider_id="system-kubernetes",
+        revision_id="contract-1",
+    )
+
+    assert response.status is RuntimeProviderContractStatus.ACCEPTED
+    service.accept_contract.assert_awaited_once_with(
+        "system-kubernetes",
+        "contract-1",
+        expected_admin_version=0,
+        actor_user_id="admin-1",
+    )
 
 
 @pytest.mark.parametrize(

--- a/python/apps/azents/src/azents/repos/agent_runtime/__init__.py
+++ b/python/apps/azents/src/azents/repos/agent_runtime/__init__.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from azents.core.enums import (
     RuntimeDesiredState,
     RuntimeLifecycleCommandType,
+    RuntimeProviderBindingOrigin,
     RuntimeProviderConnectionState,
     RuntimeProviderObservedState,
     RuntimeRunnerState,
@@ -134,6 +135,43 @@ class AgentRuntimeRepository:
         if rdb is None:
             return None
         return self._build(rdb)
+
+    async def attach_provider_binding(
+        self,
+        session: AsyncSession,
+        *,
+        runtime_id: str,
+        provider_logical_id: str,
+        provider_resource_id: str,
+        binding_origin: RuntimeProviderBindingOrigin,
+        binding_evidence: dict[str, object],
+    ) -> AgentRuntime | None:
+        """Attach or confirm one exact durable Provider binding."""
+        result = await session.execute(
+            sa.update(RDBAgentRuntime)
+            .where(
+                RDBAgentRuntime.id == runtime_id,
+                sa.or_(
+                    RDBAgentRuntime.runtime_provider_id.is_(None),
+                    RDBAgentRuntime.runtime_provider_id == provider_logical_id,
+                ),
+                sa.or_(
+                    RDBAgentRuntime.runtime_provider_resource_id.is_(None),
+                    RDBAgentRuntime.runtime_provider_resource_id
+                    == provider_resource_id,
+                ),
+            )
+            .values(
+                runtime_provider_id=provider_logical_id,
+                runtime_provider_resource_id=provider_resource_id,
+                provider_binding_origin=binding_origin,
+                provider_binding_evidence=binding_evidence,
+            )
+            .returning(RDBAgentRuntime)
+        )
+        rdb = result.scalar_one_or_none()
+        await session.flush()
+        return self._build(rdb) if rdb is not None else None
 
     async def provider_report_matches_binding(
         self,

--- a/python/apps/azents/src/azents/repos/agent_runtime/repository_test.py
+++ b/python/apps/azents/src/azents/repos/agent_runtime/repository_test.py
@@ -10,14 +10,22 @@ from azents.core.enums import (
     LLMProvider,
     RuntimeDesiredState,
     RuntimeLifecycleCommandType,
+    RuntimeProviderAvailabilityMode,
+    RuntimeProviderBindingOrigin,
     RuntimeProviderConnectionState,
+    RuntimeProviderKind,
+    RuntimeProviderLifecycleState,
     RuntimeProviderObservedState,
+    RuntimeProviderRegistrationMethod,
+    RuntimeProviderScope,
     RuntimeRunnerState,
 )
 from azents.rdb.models.agent import RDBAgent
 from azents.rdb.models.agent_runtime import RDBAgentRuntime
 from azents.rdb.models.llm_provider_integration import RDBLLMProviderIntegration
 from azents.repos.agent_runtime.data import AgentRuntimeFailurePatch
+from azents.repos.runtime_provider.data import RuntimeProviderCreate
+from azents.repos.runtime_provider.repository import RuntimeProviderRepository
 from azents.repos.workspace import WorkspaceRepository
 from azents.repos.workspace.data import WorkspaceCreate
 from azents.testing.model_selection import make_test_model_selection_dict
@@ -172,6 +180,66 @@ class TestAgentRuntimeRepository:
         )
 
         assert runtime.runtime_provider_id == "workspace-provider"
+
+    async def test_attach_provider_binding_upgrades_exact_legacy_runtime(
+        self, rdb_session: AsyncSession
+    ) -> None:
+        """Attach durable identity only when the historical logical ID matches."""
+        workspace_id = await _create_workspace(
+            rdb_session, "agent-runtime-attach-provider-ws"
+        )
+        agent_id = await _create_agent(
+            rdb_session,
+            workspace_id,
+            "agent-runtime-attach-provider",
+        )
+        repository = AgentRuntimeRepository()
+        runtime = await repository.ensure_for_agent(
+            rdb_session,
+            agent_id,
+            default_runtime_provider_id="system-kubernetes",
+        )
+        provider = await RuntimeProviderRepository().create(
+            rdb_session,
+            RuntimeProviderCreate(
+                provider_id="system-kubernetes",
+                scope=RuntimeProviderScope.SYSTEM,
+                workspace_id=None,
+                kind=RuntimeProviderKind.KUBERNETES,
+                display_name="Kubernetes",
+                registration_method=RuntimeProviderRegistrationMethod.ADMIN,
+                enabled=True,
+                lifecycle_state=RuntimeProviderLifecycleState.ACTIVE,
+                availability_mode=RuntimeProviderAvailabilityMode.PLATFORM_WIDE,
+                capabilities={},
+                config_schema=None,
+                metadata=None,
+            ),
+        )
+
+        bound = await repository.attach_provider_binding(
+            rdb_session,
+            runtime_id=runtime.id,
+            provider_logical_id=provider.provider_id,
+            provider_resource_id=provider.id,
+            binding_origin=RuntimeProviderBindingOrigin.MIGRATION,
+            binding_evidence={"origin": "migration"},
+        )
+
+        assert bound is not None
+        assert bound.runtime_provider_resource_id == provider.id
+        assert bound.provider_binding_origin is RuntimeProviderBindingOrigin.MIGRATION
+        assert bound.provider_binding_evidence == {"origin": "migration"}
+
+        conflicting = await repository.attach_provider_binding(
+            rdb_session,
+            runtime_id=runtime.id,
+            provider_logical_id="different-provider",
+            provider_resource_id=provider.id,
+            binding_origin=RuntimeProviderBindingOrigin.MIGRATION,
+            binding_evidence={"origin": "conflict"},
+        )
+        assert conflicting is None
 
     async def test_get_by_agent_id_returns_existing_runtime(
         self, rdb_session: AsyncSession

--- a/python/apps/azents/src/azents/repos/runtime_provider_policy/repository.py
+++ b/python/apps/azents/src/azents/repos/runtime_provider_policy/repository.py
@@ -88,6 +88,23 @@ class RuntimeProviderPolicyRepository:
         rdb = result.scalar_one_or_none()
         return self._build_contract(rdb) if rdb is not None else None
 
+    async def list_contracts(
+        self,
+        session: AsyncSession,
+        *,
+        provider_id: str,
+    ) -> list[RuntimeProviderContractRevision]:
+        """List Provider contract revisions from newest to oldest."""
+        result = await session.execute(
+            sa.select(RDBRuntimeProviderContractRevision)
+            .where(RDBRuntimeProviderContractRevision.provider_id == provider_id)
+            .order_by(
+                RDBRuntimeProviderContractRevision.created_at.desc(),
+                RDBRuntimeProviderContractRevision.id.desc(),
+            )
+        )
+        return [self._build_contract(rdb) for rdb in result.scalars()]
+
     async def create_contract(
         self,
         session: AsyncSession,
@@ -164,6 +181,7 @@ class RuntimeProviderPolicyRepository:
             .values(
                 accepted_contract_revision_id=contract_revision_id,
                 admin_version=RDBRuntimeProvider.admin_version + 1,
+                capabilities=accepted.contract,
             )
         )
         await session.flush()

--- a/python/apps/azents/src/azents/runtime/control_protocol/data.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/data.py
@@ -46,6 +46,7 @@ class RuntimeProviderRegistration:
     capabilities: RuntimeProtocolCapabilities
     config_schema_version: str
     metadata: dict[str, JsonValue]
+    capability_contract: dict[str, JsonValue]
     auth_credential_id: str | None
     connection_id: str
     owner_replica_id: str

--- a/python/apps/azents/src/azents/runtime/control_protocol/grpc/provider_server.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/grpc/provider_server.py
@@ -47,6 +47,9 @@ from azents.runtime.coordination.data import (
     RuntimeReplyEventType,
     RuntimeRequestEnvelope,
 )
+from azents.services.runtime_provider_contract.service import (
+    RuntimeProviderContractUnavailable,
+)
 from azents.services.runtime_provider_control.data import (
     RuntimeProviderCredentialAuthentication,
     RuntimeProviderCredentialUnavailable,
@@ -140,6 +143,21 @@ class RuntimeRunnerCredentialIssuer(Protocol):
         ...
 
 
+class RuntimeProviderContractProposer(Protocol):
+    """Persist capability contracts from authenticated Provider registrations."""
+
+    async def propose_contract(
+        self,
+        *,
+        provider_resource_id: str,
+        provider_type: str,
+        protocol_version: str,
+        contract_payload: dict[str, JsonValue],
+    ) -> object:
+        """Validate and persist one immutable Provider contract proposal."""
+        ...
+
+
 class RuntimeProviderControlGrpcServicer(
     runtime_provider_control_pb2_grpc.RuntimeProviderControlServicer
 ):
@@ -154,6 +172,7 @@ class RuntimeProviderControlGrpcServicer(
         consumer_id: str,
         credential_authenticator: RuntimeProviderCredentialAuthenticator,
         connection_tracker: RuntimeProviderConnectionTracker,
+        contract_proposer: RuntimeProviderContractProposer,
         runner_credential_issuer: RuntimeRunnerCredentialIssuer,
         command_block_ms: int = _DEFAULT_COMMAND_BLOCK_MS,
     ) -> None:
@@ -164,6 +183,7 @@ class RuntimeProviderControlGrpcServicer(
         self._consumer_id = consumer_id
         self._auth = RuntimeProviderCredentialGrpcAuth(credential_authenticator)
         self._connection_tracker = connection_tracker
+        self._contract_proposer = contract_proposer
         self._runner_credential_issuer = runner_credential_issuer
         self._command_block_ms = command_block_ms
 
@@ -186,6 +206,21 @@ class RuntimeProviderControlGrpcServicer(
         if identity_error is not None:
             await context.abort(grpc.StatusCode.PERMISSION_DENIED, identity_error)
             raise AssertionError("unreachable")
+        try:
+            await self._contract_proposer.propose_contract(
+                provider_resource_id=authentication.provider_resource_id,
+                provider_type=registration.provider_type,
+                protocol_version=registration.protocol_version,
+                contract_payload=registration.capability_contract,
+            )
+        except RuntimeProviderContractUnavailable as error:
+            status_code = (
+                grpc.StatusCode.PERMISSION_DENIED
+                if error.code in {"provider_not_found", "contract_identity_mismatch"}
+                else grpc.StatusCode.INVALID_ARGUMENT
+            )
+            await context.abort(status_code, error.message)
+            raise AssertionError("unreachable") from None
         bound_registration = dataclasses.replace(
             registration,
             provider_id=authentication.provider_id,
@@ -590,6 +625,7 @@ def add_runtime_provider_control_servicer(
     consumer_id: str,
     credential_authenticator: RuntimeProviderCredentialAuthenticator,
     connection_tracker: RuntimeProviderConnectionTracker,
+    contract_proposer: RuntimeProviderContractProposer,
     runner_credential_issuer: RuntimeRunnerCredentialIssuer,
     command_block_ms: int = _DEFAULT_COMMAND_BLOCK_MS,
 ) -> None:
@@ -602,6 +638,7 @@ def add_runtime_provider_control_servicer(
             consumer_id=consumer_id,
             credential_authenticator=credential_authenticator,
             connection_tracker=connection_tracker,
+            contract_proposer=contract_proposer,
             runner_credential_issuer=runner_credential_issuer,
             command_block_ms=command_block_ms,
         ),
@@ -710,6 +747,7 @@ def _registration(
         capabilities=RuntimeProtocolCapabilities(tuple(register.capabilities)),
         config_schema_version=register.config_schema_version,
         metadata=json_value_from_struct(register.metadata),
+        capability_contract=json_value_from_struct(register.capability_contract),
         auth_credential_id=register.auth_credential_id,
         connection_id=message.connection_id,
         owner_replica_id=owner_replica_id,

--- a/python/apps/azents/src/azents/runtime/control_protocol/grpc/provider_server_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/grpc/provider_server_test.py
@@ -140,6 +140,14 @@ class FakeRuntimeRunnerCredentialIssuer:
         )
 
 
+class FakeRuntimeProviderContractProposer:
+    """Accept test Provider contract proposals."""
+
+    async def propose_contract(self, **_: object) -> object:
+        """Accept one test proposal."""
+        return object()
+
+
 class QueueIterator:
     """Async iterator backed by a queue."""
 
@@ -528,6 +536,7 @@ def _servicer(
         consumer_id="provider-consumer-a",
         credential_authenticator=bridge,
         connection_tracker=bridge,
+        contract_proposer=FakeRuntimeProviderContractProposer(),
         runner_credential_issuer=FakeRuntimeRunnerCredentialIssuer(),
         command_block_ms=1,
     )
@@ -547,6 +556,7 @@ def _register_message(
             capabilities=("lifecycle", "observe"),
             config_schema_version="v1",
             auth_credential_id="credential-1",
+            capability_contract={"schema_version": 1},
         ),
     )
 

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
@@ -354,6 +354,7 @@ def _provider_registration() -> RuntimeProviderRegistration:
         capabilities=RuntimeProtocolCapabilities(("lifecycle",)),
         config_schema_version="v1",
         metadata={},
+        capability_contract={"schema_version": 1},
         auth_credential_id="provider:provider-1",
         connection_id="provider-connection-1",
         owner_replica_id="control-a",

--- a/python/apps/azents/src/azents/runtime/control_protocol/service_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/service_test.py
@@ -620,6 +620,7 @@ def _provider_registration() -> RuntimeProviderRegistration:
         capabilities=RuntimeProtocolCapabilities(("lifecycle",)),
         config_schema_version="v1",
         metadata={"region": "local"},
+        capability_contract={"schema_version": 1},
         auth_credential_id="credential-1",
         connection_id="provider-connection-1",
         owner_replica_id="control-a",

--- a/python/apps/azents/src/azents/runtime/control_server.py
+++ b/python/apps/azents/src/azents/runtime/control_server.py
@@ -63,6 +63,9 @@ from azents.runtime.coordination.redis import (
 from azents.services.runtime_execution_policy.application_service import (
     RuntimeExecutionPolicyApplicationService,
 )
+from azents.services.runtime_provider_contract.service import (
+    RuntimeProviderContractService,
+)
 from azents.services.runtime_provider_control.provider_auth import (
     KubernetesApiTokenReviewer,
 )
@@ -168,6 +171,11 @@ async def runtime_control_server_lifespan(
         kubernetes_token_reviewer=kubernetes_token_reviewer,
         auth_registry=None,
     )
+    contract_service = RuntimeProviderContractService(
+        session_manager=session_manager,
+        provider_repository=RuntimeProviderRepository(),
+        policy_repository=policy_repository,
+    )
     provider_sink = RuntimeProviderReportRepositorySink(
         runtime_repository=runtime_repository,
         policy_repository=policy_repository,
@@ -225,6 +233,7 @@ async def runtime_control_server_lifespan(
         consumer_id=f"{settings.runtime_control_instance_id}:provider",
         credential_authenticator=enrollment_service,
         connection_tracker=enrollment_service,
+        contract_proposer=contract_service,
         runner_credential_issuer=runner_credential_verifier,
     )
     add_runtime_runner_control_servicer(

--- a/python/apps/azents/src/azents/services/runtime_provider_contract/__init__.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_contract/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime Provider capability contract services."""

--- a/python/apps/azents/src/azents/services/runtime_provider_contract/service.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_contract/service.py
@@ -1,0 +1,191 @@
+"""Runtime Provider capability contract proposal and Admin acceptance."""
+
+import dataclasses
+from typing import Annotated, Any
+
+from azcommon.datetime import tznow
+from fastapi import Depends
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from azents.core.enums import RuntimeProviderContractStatus
+from azents.core.runtime_provider_contract import (
+    RuntimeProviderCapabilityContract,
+    canonicalize_runtime_provider_contract,
+)
+from azents.rdb.deps import get_session_manager
+from azents.rdb.session import SessionManager
+from azents.repos.runtime_provider.repository import RuntimeProviderRepository
+from azents.repos.runtime_provider_policy.data import (
+    RuntimeProviderContractRevision,
+    RuntimeProviderContractRevisionCreate,
+)
+from azents.repos.runtime_provider_policy.repository import (
+    RuntimeProviderPolicyRepository,
+)
+
+
+@dataclasses.dataclass
+class RuntimeProviderContractUnavailable(Exception):
+    """A Provider contract operation cannot be completed safely."""
+
+    code: str
+    message: str
+    current_admin_version: int | None
+
+    def __post_init__(self) -> None:
+        Exception.__init__(self, self.message)
+
+
+@dataclasses.dataclass
+class RuntimeProviderContractService:
+    """Persist Provider proposals and manage explicit Admin acceptance."""
+
+    session_manager: Annotated[
+        SessionManager[AsyncSession], Depends(get_session_manager)
+    ]
+    provider_repository: Annotated[
+        RuntimeProviderRepository, Depends(RuntimeProviderRepository)
+    ]
+    policy_repository: Annotated[
+        RuntimeProviderPolicyRepository, Depends(RuntimeProviderPolicyRepository)
+    ]
+
+    async def propose_contract(
+        self,
+        *,
+        provider_resource_id: str,
+        provider_type: str,
+        protocol_version: str,
+        contract_payload: dict[str, Any],
+    ) -> RuntimeProviderContractRevision:
+        """Create or find a contract proposed by an authenticated Provider."""
+        try:
+            contract = RuntimeProviderCapabilityContract.model_validate(
+                contract_payload
+            )
+        except ValidationError as error:
+            raise RuntimeProviderContractUnavailable(
+                code="contract_invalid",
+                message="Provider capability contract is invalid.",
+                current_admin_version=None,
+            ) from error
+        if (
+            contract.implementation_key != provider_type
+            or contract.protocol_version != protocol_version
+        ):
+            raise RuntimeProviderContractUnavailable(
+                code="contract_identity_mismatch",
+                message=(
+                    "Provider capability contract identity does not match registration."
+                ),
+                current_admin_version=None,
+            )
+        canonical = canonicalize_runtime_provider_contract(contract)
+        async with self.session_manager() as session:
+            provider = await self.provider_repository.get_by_id(
+                session,
+                provider_id=provider_resource_id,
+                for_update=True,
+            )
+            if provider is None:
+                raise RuntimeProviderContractUnavailable(
+                    code="provider_not_found",
+                    message="Runtime Provider was not found.",
+                    current_admin_version=None,
+                )
+            if provider.kind.value != provider_type:
+                raise RuntimeProviderContractUnavailable(
+                    code="contract_identity_mismatch",
+                    message=(
+                        "Provider capability contract identity does not match the "
+                        "durable Provider."
+                    ),
+                    current_admin_version=provider.admin_version,
+                )
+            existing = await self.policy_repository.get_contract_by_digest(
+                session,
+                provider_id=provider.id,
+                digest=canonical.digest,
+                for_update=False,
+            )
+            if existing is not None:
+                return existing
+            return await self.policy_repository.create_contract(
+                session,
+                create=RuntimeProviderContractRevisionCreate(
+                    provider_id=provider.id,
+                    digest=canonical.digest,
+                    implementation_version=contract.implementation_version,
+                    protocol_version=contract.protocol_version,
+                    contract=canonical.canonical_json,
+                    compatibility={"compatible": True},
+                    status=RuntimeProviderContractStatus.CANDIDATE,
+                    validation_code=None,
+                    validation_message=None,
+                ),
+            )
+
+    async def list_contracts(
+        self,
+        provider_logical_id: str,
+    ) -> list[RuntimeProviderContractRevision]:
+        """List accepted and candidate contracts for one logical Provider."""
+        async with self.session_manager() as session:
+            provider = await self.provider_repository.get_by_provider_id(
+                session,
+                provider_logical_id=provider_logical_id,
+                for_update=False,
+            )
+            if provider is None:
+                raise RuntimeProviderContractUnavailable(
+                    code="provider_not_found",
+                    message="Runtime Provider was not found.",
+                    current_admin_version=None,
+                )
+            return await self.policy_repository.list_contracts(
+                session,
+                provider_id=provider.id,
+            )
+
+    async def accept_contract(
+        self,
+        provider_logical_id: str,
+        contract_revision_id: str,
+        *,
+        expected_admin_version: int,
+        actor_user_id: str | None,
+    ) -> RuntimeProviderContractRevision:
+        """Accept one unchanged candidate using Provider optimistic concurrency."""
+        async with self.session_manager() as session:
+            provider = await self.provider_repository.get_by_provider_id(
+                session,
+                provider_logical_id=provider_logical_id,
+                for_update=True,
+            )
+            if provider is None:
+                raise RuntimeProviderContractUnavailable(
+                    code="provider_not_found",
+                    message="Runtime Provider was not found.",
+                    current_admin_version=None,
+                )
+            if provider.admin_version != expected_admin_version:
+                raise RuntimeProviderContractUnavailable(
+                    code="stale_provider_version",
+                    message="Runtime Provider changed before contract acceptance.",
+                    current_admin_version=provider.admin_version,
+                )
+            accepted = await self.policy_repository.accept_contract(
+                session,
+                provider_id=provider.id,
+                contract_revision_id=contract_revision_id,
+                accepted_by_user_id=actor_user_id,
+                accepted_at=tznow(),
+            )
+            if accepted is None:
+                raise RuntimeProviderContractUnavailable(
+                    code="contract_not_acceptable",
+                    message="Runtime Provider contract candidate cannot be accepted.",
+                    current_admin_version=provider.admin_version,
+                )
+            return accepted

--- a/python/apps/azents/src/azents/services/runtime_provider_contract/service_test.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_contract/service_test.py
@@ -1,0 +1,196 @@
+"""Runtime Provider capability contract lifecycle tests."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from azents.core.enums import (
+    RuntimeProviderAvailabilityMode,
+    RuntimeProviderContractStatus,
+    RuntimeProviderKind,
+    RuntimeProviderLifecycleState,
+    RuntimeProviderRegistrationMethod,
+    RuntimeProviderScope,
+)
+from azents.rdb.session import SessionManager
+from azents.repos.runtime_provider.data import RuntimeProviderCreate
+from azents.repos.runtime_provider.repository import RuntimeProviderRepository
+from azents.repos.runtime_provider_policy.repository import (
+    RuntimeProviderPolicyRepository,
+)
+from azents.repos.user import UserRepository
+from azents.repos.user.data import UserCreate
+
+from .service import (
+    RuntimeProviderContractService,
+    RuntimeProviderContractUnavailable,
+)
+
+_PROTOCOL_VERSION = "agent-runtime-provider-kubernetes-v1"
+
+
+def _contract_payload() -> dict[str, object]:
+    """Build the Kubernetes contract submitted by the production Provider."""
+    return {
+        "schema_version": 1,
+        "implementation_key": "kubernetes",
+        "implementation_version": "0.1.0",
+        "protocol_version": _PROTOCOL_VERSION,
+        "core_lifecycle_operations": [
+            "start",
+            "stop",
+            "restart",
+            "reset",
+            "observe",
+            "terminal_delete",
+        ],
+        "optional_capabilities": ["execution_policy_v1"],
+        "persistence": {
+            "kind": "persistent",
+            "reset_destroys_workspace": True,
+            "terminal_delete_destroys_workspace": True,
+        },
+        "configuration_fields": [],
+    }
+
+
+async def _create_provider_and_admin(
+    session_manager: SessionManager[AsyncSession],
+) -> tuple[str, str]:
+    """Create the durable Provider and Admin actor used by lifecycle tests."""
+    async with session_manager() as session:
+        provider = await RuntimeProviderRepository().create(
+            session,
+            RuntimeProviderCreate(
+                provider_id="system-kubernetes-contract-test",
+                scope=RuntimeProviderScope.SYSTEM,
+                workspace_id=None,
+                kind=RuntimeProviderKind.KUBERNETES,
+                display_name="Kubernetes",
+                registration_method=RuntimeProviderRegistrationMethod.ADMIN,
+                enabled=True,
+                lifecycle_state=RuntimeProviderLifecycleState.ACTIVE,
+                availability_mode=RuntimeProviderAvailabilityMode.PLATFORM_WIDE,
+                capabilities={},
+                config_schema=None,
+                metadata=None,
+            ),
+        )
+        user = await UserRepository().create(
+            session,
+            UserCreate(email="runtime-contract-admin@example.com"),
+        )
+    return provider.id, user.id
+
+
+def _service(
+    session_manager: SessionManager[AsyncSession],
+) -> RuntimeProviderContractService:
+    """Build the production contract service."""
+    return RuntimeProviderContractService(
+        session_manager=session_manager,
+        provider_repository=RuntimeProviderRepository(),
+        policy_repository=RuntimeProviderPolicyRepository(),
+    )
+
+
+async def test_provider_proposal_is_idempotent_and_admin_accepts_explicitly(
+    rdb_session_manager: SessionManager[AsyncSession],
+) -> None:
+    """Registration creates one candidate and acceptance advances the Provider."""
+    provider_resource_id, actor_user_id = await _create_provider_and_admin(
+        rdb_session_manager
+    )
+    service = _service(rdb_session_manager)
+
+    first = await service.propose_contract(
+        provider_resource_id=provider_resource_id,
+        provider_type="kubernetes",
+        protocol_version=_PROTOCOL_VERSION,
+        contract_payload=_contract_payload(),
+    )
+    repeated = await service.propose_contract(
+        provider_resource_id=provider_resource_id,
+        provider_type="kubernetes",
+        protocol_version=_PROTOCOL_VERSION,
+        contract_payload=_contract_payload(),
+    )
+
+    assert repeated.id == first.id
+    assert first.status is RuntimeProviderContractStatus.CANDIDATE
+    assert first.accepted_at is None
+    listed = await service.list_contracts("system-kubernetes-contract-test")
+    assert [contract.id for contract in listed] == [first.id]
+
+    accepted = await service.accept_contract(
+        "system-kubernetes-contract-test",
+        first.id,
+        expected_admin_version=0,
+        actor_user_id=actor_user_id,
+    )
+
+    assert accepted.status is RuntimeProviderContractStatus.ACCEPTED
+    assert accepted.accepted_by_user_id == actor_user_id
+    assert accepted.accepted_at is not None
+    async with rdb_session_manager() as session:
+        provider = await RuntimeProviderRepository().get_by_id(
+            session,
+            provider_id=provider_resource_id,
+            for_update=False,
+        )
+    assert provider is not None
+    assert provider.accepted_contract_revision_id == first.id
+    assert provider.admin_version == 1
+    assert provider.capabilities["optional_capabilities"] == ["execution_policy_v1"]
+
+
+async def test_accept_rejects_stale_provider_version(
+    rdb_session_manager: SessionManager[AsyncSession],
+) -> None:
+    """Contract acceptance cannot overwrite a concurrently changed Provider."""
+    provider_resource_id, actor_user_id = await _create_provider_and_admin(
+        rdb_session_manager
+    )
+    service = _service(rdb_session_manager)
+    candidate = await service.propose_contract(
+        provider_resource_id=provider_resource_id,
+        provider_type="kubernetes",
+        protocol_version=_PROTOCOL_VERSION,
+        contract_payload=_contract_payload(),
+    )
+
+    with pytest.raises(
+        RuntimeProviderContractUnavailable,
+        match="changed before contract acceptance",
+    ) as raised:
+        await service.accept_contract(
+            "system-kubernetes-contract-test",
+            candidate.id,
+            expected_admin_version=3,
+            actor_user_id=actor_user_id,
+        )
+
+    assert raised.value.code == "stale_provider_version"
+    assert raised.value.current_admin_version == 0
+
+
+async def test_proposal_rejects_registration_contract_identity_mismatch(
+    rdb_session_manager: SessionManager[AsyncSession],
+) -> None:
+    """Authenticated registration claims cannot substitute another implementation."""
+    provider_resource_id, _actor_user_id = await _create_provider_and_admin(
+        rdb_session_manager
+    )
+    service = _service(rdb_session_manager)
+
+    with pytest.raises(
+        RuntimeProviderContractUnavailable,
+        match="does not match registration",
+    ) as raised:
+        await service.propose_contract(
+            provider_resource_id=provider_resource_id,
+            provider_type="docker",
+            protocol_version=_PROTOCOL_VERSION,
+            contract_payload=_contract_payload(),
+        )
+
+    assert raised.value.code == "contract_identity_mismatch"

--- a/python/apps/azents/src/azents/services/runtime_provider_selection/data.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_selection/data.py
@@ -6,7 +6,7 @@ from azents.core.enums import RuntimeProviderBindingOrigin
 from azents.repos.agent_runtime.data import AgentRuntime
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class RuntimeProviderSelectionUnavailable(Exception):
     """The requested exact Provider candidate cannot provision a Runtime."""
 

--- a/python/apps/azents/src/azents/services/runtime_provider_selection/service.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_selection/service.py
@@ -25,7 +25,7 @@ from azents.rdb.deps import get_session_manager
 from azents.rdb.session import SessionManager
 from azents.repos.agent import AgentRepository
 from azents.repos.agent_runtime import AgentRuntimeRepository
-from azents.repos.agent_runtime.data import AgentRuntimeCreate
+from azents.repos.agent_runtime.data import AgentRuntime, AgentRuntimeCreate
 from azents.repos.runtime_provider.data import RuntimeProvider
 from azents.repos.runtime_provider.repository import RuntimeProviderRepository
 from azents.repos.runtime_provider_control.repository import (
@@ -100,6 +100,15 @@ class RuntimeProviderSelectionService:
                 agent_id,
             )
             if existing is not None:
+                if existing.runtime_policy_snapshot_id is None:
+                    existing = await self._upgrade_existing_runtime(
+                        session,
+                        runtime=existing,
+                        workspace_id=agent.workspace_id,
+                        agent_runtime_provider_id=agent.runtime_provider_id,
+                        requested_provider_id=requested_provider_id,
+                        required_capabilities=required_capabilities,
+                    )
                 return RuntimeProviderBindingResult(
                     runtime=existing,
                     created=False,
@@ -128,14 +137,13 @@ class RuntimeProviderSelectionService:
                 workspace_id=agent.workspace_id,
                 required_capabilities=required_capabilities,
             )
-            binding_evidence: dict[str, object] = {
-                "workspace_id": agent.workspace_id,
-                "origin": origin.value,
-                "provider_admin_version": provider.admin_version,
-                "contract_revision_id": contract.id,
-                "contract_digest": contract.digest,
-                "config_revision_id": active_config.id if active_config else None,
-            }
+            binding_evidence = _binding_evidence(
+                workspace_id=agent.workspace_id,
+                origin=origin,
+                provider=provider,
+                contract=contract,
+                active_config=active_config,
+            )
             created = await self.runtime_repository.ensure_with_create(
                 session,
                 create=AgentRuntimeCreate(
@@ -159,56 +167,12 @@ class RuntimeProviderSelectionService:
 
             snapshot = await self.policy_repository.create_snapshot(
                 session,
-                create=RuntimePolicySnapshotCreate(
-                    runtime_id=created.runtime.id,
-                    provider_id=provider.id,
-                    contract_revision_id=contract.id,
-                    config_revision_id=active_config.id if active_config else None,
-                    override_provider_id=None,
-                    override_version=None,
-                    execution_profile_id=None,
-                    execution_platform_version=None,
-                    execution_profile_version=None,
-                    execution_workspace_version=None,
-                    execution_agent_version=None,
-                    resolved_execution_policy=None,
-                    execution_source_trace=None,
-                    execution_provider_compatibility=None,
-                    execution_target_digest=None,
-                    execution_reported_digest=None,
-                    resolved_config=active_config.config if active_config else {},
-                    encrypted_secrets=(
-                        active_config.encrypted_secrets if active_config else None
-                    ),
-                    secret_metadata=(
-                        active_config.secret_metadata if active_config else {}
-                    ),
-                    source_trace={
-                        "contract": contract.digest,
-                        "configuration": (
-                            active_config.revision if active_config else None
-                        ),
-                        "binding": origin.value,
-                    },
-                    digest=_snapshot_digest(
-                        runtime_id=created.runtime.id,
-                        provider_id=provider.id,
-                        contract_digest=contract.digest,
-                        config_revision_id=active_config.id if active_config else None,
-                        config=active_config.config if active_config else {},
-                        encrypted_secrets=(
-                            active_config.encrypted_secrets if active_config else None
-                        ),
-                        secret_metadata=(
-                            active_config.secret_metadata if active_config else {}
-                        ),
-                        override_provider_id=None,
-                        override_version=None,
-                        target_desired_generation=created.runtime.desired_generation,
-                        origin=origin,
-                    ),
-                    target_desired_generation=created.runtime.desired_generation,
-                    application_state=RuntimePolicySnapshotApplicationState.PENDING,
+                create=_initial_snapshot_create(
+                    runtime=created.runtime,
+                    provider=provider,
+                    contract=contract,
+                    active_config=active_config,
+                    origin=origin,
                 ),
             )
             if snapshot is None:
@@ -229,6 +193,96 @@ class RuntimeProviderSelectionService:
                     binding_evidence=binding_evidence,
                 ),
             )
+
+    async def _upgrade_existing_runtime(
+        self,
+        session: AsyncSession,
+        *,
+        runtime: AgentRuntime,
+        workspace_id: str,
+        agent_runtime_provider_id: str | None,
+        requested_provider_id: str | None,
+        required_capabilities: set[str] | None,
+    ) -> AgentRuntime:
+        """Attach accepted policy evidence to a pre-contract Runtime."""
+        if runtime.runtime_provider_resource_id is not None:
+            provider = await self.provider_repository.get_by_id(
+                session,
+                provider_id=runtime.runtime_provider_resource_id,
+                for_update=True,
+            )
+            origin = runtime.provider_binding_origin or (
+                RuntimeProviderBindingOrigin.MIGRATION
+            )
+        else:
+            if runtime.runtime_provider_id is not None:
+                selected_id = runtime.runtime_provider_id
+                origin = RuntimeProviderBindingOrigin.MIGRATION
+            else:
+                selected_id, origin = await self.resolve_candidate_id(
+                    session,
+                    agent_runtime_provider_id=agent_runtime_provider_id,
+                    requested_provider_id=requested_provider_id,
+                )
+            provider = await self.provider_repository.get_by_provider_id_for_update(
+                session,
+                provider_logical_id=selected_id,
+            )
+        if provider is None:
+            raise RuntimeProviderSelectionUnavailable(
+                code="provider_not_found",
+                provider_id=runtime.runtime_provider_id,
+                message="The Runtime's bound Provider was not found.",
+            )
+        contract, active_config = await self.validate_provider_candidate(
+            session,
+            provider_logical_id=provider.provider_id,
+            provider=provider,
+            workspace_id=workspace_id,
+            required_capabilities=required_capabilities,
+        )
+        binding_evidence = _binding_evidence(
+            workspace_id=workspace_id,
+            origin=origin,
+            provider=provider,
+            contract=contract,
+            active_config=active_config,
+        )
+        bound = await self.runtime_repository.attach_provider_binding(
+            session,
+            runtime_id=runtime.id,
+            provider_logical_id=provider.provider_id,
+            provider_resource_id=provider.id,
+            binding_origin=origin,
+            binding_evidence=binding_evidence,
+        )
+        if bound is None:
+            raise RuntimeProviderSelectionUnavailable(
+                code="provider_binding_conflict",
+                provider_id=provider.provider_id,
+                message="The existing Runtime Provider binding conflicts.",
+            )
+        snapshot = await self.policy_repository.create_and_attach_target_snapshot(
+            session,
+            create=_initial_snapshot_create(
+                runtime=bound,
+                provider=provider,
+                contract=contract,
+                active_config=active_config,
+                origin=origin,
+            ),
+            expected_target_snapshot_id=None,
+        )
+        if snapshot is None:
+            raise RuntimeProviderSelectionUnavailable(
+                code="runtime_policy_binding_conflict",
+                provider_id=provider.provider_id,
+                message="The existing Runtime policy binding changed concurrently.",
+            )
+        upgraded = await self.runtime_repository.get_by_id(session, runtime.id)
+        if upgraded is None:
+            raise RuntimeError("Upgraded Agent Runtime could not be reloaded")
+        return upgraded
 
     async def resolve_candidate_id(
         self,
@@ -375,6 +429,80 @@ class RuntimeProviderSelectionService:
                 message="The selected Provider has no active configuration.",
             )
         return contract, active_config
+
+
+def _binding_evidence(
+    *,
+    workspace_id: str,
+    origin: RuntimeProviderBindingOrigin,
+    provider: RuntimeProvider,
+    contract: RuntimeProviderContractRevision,
+    active_config: RuntimeProviderConfigRevision | None,
+) -> dict[str, object]:
+    """Build sanitized immutable Runtime Provider binding evidence."""
+    return {
+        "workspace_id": workspace_id,
+        "origin": origin.value,
+        "provider_admin_version": provider.admin_version,
+        "contract_revision_id": contract.id,
+        "contract_digest": contract.digest,
+        "config_revision_id": active_config.id if active_config else None,
+    }
+
+
+def _initial_snapshot_create(
+    *,
+    runtime: AgentRuntime,
+    provider: RuntimeProvider,
+    contract: RuntimeProviderContractRevision,
+    active_config: RuntimeProviderConfigRevision | None,
+    origin: RuntimeProviderBindingOrigin,
+) -> RuntimePolicySnapshotCreate:
+    """Build the first immutable policy target for one exact Runtime binding."""
+    config = active_config.config if active_config else {}
+    encrypted_secrets = active_config.encrypted_secrets if active_config else None
+    secret_metadata = active_config.secret_metadata if active_config else {}
+    return RuntimePolicySnapshotCreate(
+        runtime_id=runtime.id,
+        provider_id=provider.id,
+        contract_revision_id=contract.id,
+        config_revision_id=active_config.id if active_config else None,
+        override_provider_id=None,
+        override_version=None,
+        execution_profile_id=None,
+        execution_platform_version=None,
+        execution_profile_version=None,
+        execution_workspace_version=None,
+        execution_agent_version=None,
+        resolved_execution_policy=None,
+        execution_source_trace=None,
+        execution_provider_compatibility=None,
+        execution_target_digest=None,
+        execution_reported_digest=None,
+        resolved_config=config,
+        encrypted_secrets=encrypted_secrets,
+        secret_metadata=secret_metadata,
+        source_trace={
+            "contract": contract.digest,
+            "configuration": active_config.revision if active_config else None,
+            "binding": origin.value,
+        },
+        digest=_snapshot_digest(
+            runtime_id=runtime.id,
+            provider_id=provider.id,
+            contract_digest=contract.digest,
+            config_revision_id=active_config.id if active_config else None,
+            config=config,
+            encrypted_secrets=encrypted_secrets,
+            secret_metadata=secret_metadata,
+            override_provider_id=None,
+            override_version=None,
+            target_desired_generation=runtime.desired_generation,
+            origin=origin,
+        ),
+        target_desired_generation=runtime.desired_generation,
+        application_state=RuntimePolicySnapshotApplicationState.PENDING,
+    )
 
 
 def _snapshot_digest(

--- a/python/apps/azents/src/azents/services/runtime_provider_selection/service_test.py
+++ b/python/apps/azents/src/azents/services/runtime_provider_selection/service_test.py
@@ -1,5 +1,7 @@
 """Runtime Provider selection service tests."""
 
+# pyright: reportPrivateUsage=false
+
 import datetime
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
@@ -19,6 +21,7 @@ from azents.core.enums import (
     RuntimeProviderScope,
 )
 from azents.rdb.session import SessionManager
+from azents.repos.agent_runtime.data import AgentRuntime
 from azents.repos.runtime_provider.data import RuntimeProvider
 from azents.repos.runtime_provider_policy.data import (
     RuntimeProviderConfigRevision,
@@ -108,6 +111,64 @@ def _service() -> RuntimeProviderSelectionService:
         policy_repository=cast(Any, Mock()),
         system_setting_repository=cast(Any, Mock()),
     )
+
+
+@pytest.mark.asyncio
+async def test_existing_runtime_receives_migration_binding_and_initial_snapshot() -> (
+    None
+):
+    """A pre-contract Runtime converges without replacing its logical identity."""
+    service = _service()
+    provider = _provider()
+    existing = AgentRuntime(
+        id="runtime-legacy",
+        workspace_id="workspace-1",
+        agent_id="agent-1",
+        runtime_provider_id=provider.provider_id,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    bound = existing.model_copy(
+        update={
+            "runtime_provider_resource_id": provider.id,
+            "provider_binding_origin": RuntimeProviderBindingOrigin.MIGRATION,
+            "provider_binding_evidence": {"origin": "migration"},
+        }
+    )
+    upgraded = bound.model_copy(update={"runtime_policy_snapshot_id": "snapshot-1"})
+    service.provider_repository.get_by_provider_id_for_update = AsyncMock(
+        return_value=provider
+    )
+    service.validate_provider_candidate = AsyncMock(return_value=(_contract(), None))
+    service.runtime_repository.attach_provider_binding = AsyncMock(return_value=bound)
+    service.policy_repository.create_and_attach_target_snapshot = AsyncMock(
+        return_value=object()
+    )
+    service.runtime_repository.get_by_id = AsyncMock(return_value=upgraded)
+
+    result = await service._upgrade_existing_runtime(
+        cast(AsyncSession, Mock()),
+        runtime=existing,
+        workspace_id="workspace-1",
+        agent_runtime_provider_id=None,
+        requested_provider_id=None,
+        required_capabilities=None,
+    )
+
+    assert result is upgraded
+    attach_call = service.runtime_repository.attach_provider_binding.await_args
+    assert attach_call is not None
+    assert attach_call.kwargs["runtime_id"] == existing.id
+    assert (
+        attach_call.kwargs["binding_origin"] is RuntimeProviderBindingOrigin.MIGRATION
+    )
+    snapshot_call = (
+        service.policy_repository.create_and_attach_target_snapshot.await_args
+    )
+    assert snapshot_call is not None
+    assert snapshot_call.kwargs["create"].runtime_id == existing.id
+    assert snapshot_call.kwargs["create"].provider_id == provider.id
+    assert snapshot_call.kwargs["expected_target_snapshot_id"] is None
 
 
 @pytest.mark.asyncio

--- a/python/libs/azents-runtime-control/src/azents_runtime_control/grpc_provider_client.py
+++ b/python/libs/azents-runtime-control/src/azents_runtime_control/grpc_provider_client.py
@@ -357,6 +357,7 @@ def _register_message(
             capabilities=list(registration.capabilities),
             config_schema_version=registration.config_schema_version,
             metadata=_struct(registration.metadata),
+            capability_contract=_struct(registration.capability_contract),
         ),
     )
 

--- a/python/libs/azents-runtime-control/src/azents_runtime_control/proto/runtime_provider_control_pb2.py
+++ b/python/libs/azents-runtime-control/src/azents_runtime_control/proto/runtime_provider_control_pb2.py
@@ -26,7 +26,7 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x1eruntime_provider_control.proto\x12\x19\x61zents.runtime_control.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xb2\x03\n\x0fProviderMessage\x12\x15\n\rconnection_id\x18\x01 \x01(\t\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x12\n\ngeneration\x18\x03 \x01(\x04\x12?\n\x08register\x18\n \x01(\x0b\x32+.azents.runtime_control.v1.ProviderRegisterH\x00\x12\x41\n\theartbeat\x18\x0b \x01(\x0b\x32,.azents.runtime_control.v1.ProviderHeartbeatH\x00\x12\x42\n\x06report\x18\x14 \x01(\x0b\x32\x30.azents.runtime_control.v1.RuntimeProviderReportH\x00\x12R\n\x12\x63ommand_completion\x18\x15 \x01(\x0b\x32\x34.azents.runtime_control.v1.ProviderCommandCompletionH\x00\x12\x39\n\x05\x65rror\x18( \x01(\x0b\x32(.azents.runtime_control.v1.ProviderErrorH\x00\x42\t\n\x07payload"\xce\x02\n\x0e\x43ontrolMessage\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12P\n\x11register_accepted\x18\n \x01(\x0b\x32\x33.azents.runtime_control.v1.ProviderRegisterAcceptedH\x00\x12H\n\rheartbeat_ack\x18\x0b \x01(\x0b\x32/.azents.runtime_control.v1.ProviderHeartbeatAckH\x00\x12\x46\n\x10provider_command\x18\x14 \x01(\x0b\x32*.azents.runtime_control.v1.ProviderCommandH\x00\x12\x39\n\x05\x65rror\x18( \x01(\x0b\x32(.azents.runtime_control.v1.ProviderErrorH\x00\x42\t\n\x07payload"\xf9\x01\n\x10ProviderRegister\x12\x13\n\x0bprovider_id\x18\x01 \x01(\t\x12\x15\n\rprovider_type\x18\x02 \x01(\t\x12\r\n\x05scope\x18\x03 \x01(\t\x12\x14\n\x0cworkspace_id\x18\x04 \x01(\t\x12\x18\n\x10protocol_version\x18\x05 \x01(\t\x12\x14\n\x0c\x63\x61pabilities\x18\x06 \x03(\t\x12\x1d\n\x15\x63onfig_schema_version\x18\x07 \x01(\t\x12)\n\x08metadata\x18\x08 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x1a\n\x12\x61uth_credential_id\x18\t \x01(\t"~\n\x18ProviderRegisterAccepted\x12\x13\n\x0bprovider_id\x18\x01 \x01(\t\x12\x15\n\rconnection_id\x18\x02 \x01(\t\x12\x12\n\ngeneration\x18\x03 \x01(\x04\x12"\n\x1aheartbeat_interval_seconds\x18\x04 \x01(\r"/\n\x11ProviderHeartbeat\x12\x1a\n\x12monotonic_sequence\x18\x01 \x01(\x04"2\n\x14ProviderHeartbeatAck\x12\x1a\n\x12monotonic_sequence\x18\x01 \x01(\x04"\xba\x03\n\x0fProviderCommand\x12\x12\n\nruntime_id\x18\x01 \x01(\t\x12\x10\n\x08\x61gent_id\x18\x02 \x01(\t\x12\x14\n\x0cworkspace_id\x18\x03 \x01(\t\x12\x1a\n\x12\x64\x65sired_generation\x18\x04 \x01(\x04\x12\x1b\n\x13provider_generation\x18\x05 \x01(\x04\x12\x14\n\x0c\x63ommand_type\x18\x06 \x01(\t\x12!\n\x19reset_final_desired_state\x18\x07 \x01(\t\x12\x14\n\x0crunner_image\x18\x08 \x01(\t\x12\x18\n\x10\x63ontrol_endpoint\x18\t \x01(\t\x12\x19\n\x11runner_auth_token\x18\n \x01(\t\x12(\n\x07payload\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12/\n\x0b\x64\x65\x61\x64line_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12S\n\x10\x65xecution_policy\x18\r \x01(\x0b\x32\x39.azents.runtime_control.v1.RuntimeExecutionPolicyEnvelope"\x94\x04\n\x15RuntimeProviderReport\x12\x12\n\nruntime_id\x18\x01 \x01(\t\x12\x13\n\x0bprovider_id\x18\x02 \x01(\t\x12\x1b\n\x13provider_generation\x18\x03 \x01(\x04\x12\x16\n\x0eobserved_state\x18\x04 \x01(\t\x12#\n\x1bobserved_desired_generation\x18\x05 \x01(\x04\x12\x1b\n\x13provider_runtime_id\x18\x06 \x01(\t\x12\x16\n\x0eworkspace_path\x18\x07 \x01(\t\x12\x0e\n\x06reason\x18\x08 \x01(\t\x12T\n\ndiagnostic\x18\t \x03(\x0b\x32@.azents.runtime_control.v1.RuntimeProviderReport.DiagnosticEntry\x12/\n\x0breported_at\x18\n \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12$\n\x1cterminal_delete_acknowledged\x18\x0b \x01(\x08\x12S\n\x10\x65xecution_policy\x18\x0c \x01(\x0b\x32\x39.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence\x1a\x31\n\x0f\x44iagnosticEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\x9f\x03\n\x1eRuntimeExecutionPolicyEvidence\x12\x13\n\x0bsnapshot_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64igest\x18\x02 \x01(\t\x12\x1a\n\x12\x64\x65sired_generation\x18\x03 \x01(\x04\x12\x66\n\x0fmodule_versions\x18\x04 \x03(\x0b\x32M.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence.ModuleVersionsEntry\x12\x66\n\x0fsource_versions\x18\x05 \x03(\x0b\x32M.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence.SourceVersionsEntry\x1a\x35\n\x13ModuleVersionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a\x35\n\x13SourceVersionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x04:\x02\x38\x01"\xa0\x01\n\x1eRuntimeExecutionPolicyEnvelope\x12K\n\x08\x65vidence\x18\x01 \x01(\x0b\x32\x39.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence\x12\x31\n\x10\x65\x66\x66\x65\x63tive_policy\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct"\x87\x02\n\x19ProviderCommandCompletion\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x12\n\nruntime_id\x18\x02 \x01(\t\x12\x12\n\ngeneration\x18\x03 \x01(\x04\x12\x0f\n\x07success\x18\x04 \x01(\x08\x12@\n\x06report\x18\x05 \x01(\x0b\x32\x30.azents.runtime_control.v1.RuntimeProviderReport\x12\x12\n\nerror_code\x18\x06 \x01(\t\x12\x15\n\rerror_message\x18\x07 \x01(\t\x12\x30\n\x0c\x63ompleted_at\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp".\n\rProviderError\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t2\x86\x01\n\x16RuntimeProviderControl\x12l\n\x0f\x43onnectProvider\x12*.azents.runtime_control.v1.ProviderMessage\x1a).azents.runtime_control.v1.ControlMessage(\x01\x30\x01\x62\x06proto3'
+    b'\n\x1eruntime_provider_control.proto\x12\x19\x61zents.runtime_control.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto"\xb2\x03\n\x0fProviderMessage\x12\x15\n\rconnection_id\x18\x01 \x01(\t\x12\x12\n\nrequest_id\x18\x02 \x01(\t\x12\x12\n\ngeneration\x18\x03 \x01(\x04\x12?\n\x08register\x18\n \x01(\x0b\x32+.azents.runtime_control.v1.ProviderRegisterH\x00\x12\x41\n\theartbeat\x18\x0b \x01(\x0b\x32,.azents.runtime_control.v1.ProviderHeartbeatH\x00\x12\x42\n\x06report\x18\x14 \x01(\x0b\x32\x30.azents.runtime_control.v1.RuntimeProviderReportH\x00\x12R\n\x12\x63ommand_completion\x18\x15 \x01(\x0b\x32\x34.azents.runtime_control.v1.ProviderCommandCompletionH\x00\x12\x39\n\x05\x65rror\x18( \x01(\x0b\x32(.azents.runtime_control.v1.ProviderErrorH\x00\x42\t\n\x07payload"\xce\x02\n\x0e\x43ontrolMessage\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12P\n\x11register_accepted\x18\n \x01(\x0b\x32\x33.azents.runtime_control.v1.ProviderRegisterAcceptedH\x00\x12H\n\rheartbeat_ack\x18\x0b \x01(\x0b\x32/.azents.runtime_control.v1.ProviderHeartbeatAckH\x00\x12\x46\n\x10provider_command\x18\x14 \x01(\x0b\x32*.azents.runtime_control.v1.ProviderCommandH\x00\x12\x39\n\x05\x65rror\x18( \x01(\x0b\x32(.azents.runtime_control.v1.ProviderErrorH\x00\x42\t\n\x07payload"\xaf\x02\n\x10ProviderRegister\x12\x13\n\x0bprovider_id\x18\x01 \x01(\t\x12\x15\n\rprovider_type\x18\x02 \x01(\t\x12\r\n\x05scope\x18\x03 \x01(\t\x12\x14\n\x0cworkspace_id\x18\x04 \x01(\t\x12\x18\n\x10protocol_version\x18\x05 \x01(\t\x12\x14\n\x0c\x63\x61pabilities\x18\x06 \x03(\t\x12\x1d\n\x15\x63onfig_schema_version\x18\x07 \x01(\t\x12)\n\x08metadata\x18\x08 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x1a\n\x12\x61uth_credential_id\x18\t \x01(\t\x12\x34\n\x13\x63\x61pability_contract\x18\n \x01(\x0b\x32\x17.google.protobuf.Struct"~\n\x18ProviderRegisterAccepted\x12\x13\n\x0bprovider_id\x18\x01 \x01(\t\x12\x15\n\rconnection_id\x18\x02 \x01(\t\x12\x12\n\ngeneration\x18\x03 \x01(\x04\x12"\n\x1aheartbeat_interval_seconds\x18\x04 \x01(\r"/\n\x11ProviderHeartbeat\x12\x1a\n\x12monotonic_sequence\x18\x01 \x01(\x04"2\n\x14ProviderHeartbeatAck\x12\x1a\n\x12monotonic_sequence\x18\x01 \x01(\x04"\xba\x03\n\x0fProviderCommand\x12\x12\n\nruntime_id\x18\x01 \x01(\t\x12\x10\n\x08\x61gent_id\x18\x02 \x01(\t\x12\x14\n\x0cworkspace_id\x18\x03 \x01(\t\x12\x1a\n\x12\x64\x65sired_generation\x18\x04 \x01(\x04\x12\x1b\n\x13provider_generation\x18\x05 \x01(\x04\x12\x14\n\x0c\x63ommand_type\x18\x06 \x01(\t\x12!\n\x19reset_final_desired_state\x18\x07 \x01(\t\x12\x14\n\x0crunner_image\x18\x08 \x01(\t\x12\x18\n\x10\x63ontrol_endpoint\x18\t \x01(\t\x12\x19\n\x11runner_auth_token\x18\n \x01(\t\x12(\n\x07payload\x18\x0b \x01(\x0b\x32\x17.google.protobuf.Struct\x12/\n\x0b\x64\x65\x61\x64line_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12S\n\x10\x65xecution_policy\x18\r \x01(\x0b\x32\x39.azents.runtime_control.v1.RuntimeExecutionPolicyEnvelope"\x94\x04\n\x15RuntimeProviderReport\x12\x12\n\nruntime_id\x18\x01 \x01(\t\x12\x13\n\x0bprovider_id\x18\x02 \x01(\t\x12\x1b\n\x13provider_generation\x18\x03 \x01(\x04\x12\x16\n\x0eobserved_state\x18\x04 \x01(\t\x12#\n\x1bobserved_desired_generation\x18\x05 \x01(\x04\x12\x1b\n\x13provider_runtime_id\x18\x06 \x01(\t\x12\x16\n\x0eworkspace_path\x18\x07 \x01(\t\x12\x0e\n\x06reason\x18\x08 \x01(\t\x12T\n\ndiagnostic\x18\t \x03(\x0b\x32@.azents.runtime_control.v1.RuntimeProviderReport.DiagnosticEntry\x12/\n\x0breported_at\x18\n \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12$\n\x1cterminal_delete_acknowledged\x18\x0b \x01(\x08\x12S\n\x10\x65xecution_policy\x18\x0c \x01(\x0b\x32\x39.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence\x1a\x31\n\x0f\x44iagnosticEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"\x9f\x03\n\x1eRuntimeExecutionPolicyEvidence\x12\x13\n\x0bsnapshot_id\x18\x01 \x01(\t\x12\x0e\n\x06\x64igest\x18\x02 \x01(\t\x12\x1a\n\x12\x64\x65sired_generation\x18\x03 \x01(\x04\x12\x66\n\x0fmodule_versions\x18\x04 \x03(\x0b\x32M.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence.ModuleVersionsEntry\x12\x66\n\x0fsource_versions\x18\x05 \x03(\x0b\x32M.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence.SourceVersionsEntry\x1a\x35\n\x13ModuleVersionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\r:\x02\x38\x01\x1a\x35\n\x13SourceVersionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x04:\x02\x38\x01"\xa0\x01\n\x1eRuntimeExecutionPolicyEnvelope\x12K\n\x08\x65vidence\x18\x01 \x01(\x0b\x32\x39.azents.runtime_control.v1.RuntimeExecutionPolicyEvidence\x12\x31\n\x10\x65\x66\x66\x65\x63tive_policy\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct"\x87\x02\n\x19ProviderCommandCompletion\x12\x12\n\nrequest_id\x18\x01 \x01(\t\x12\x12\n\nruntime_id\x18\x02 \x01(\t\x12\x12\n\ngeneration\x18\x03 \x01(\x04\x12\x0f\n\x07success\x18\x04 \x01(\x08\x12@\n\x06report\x18\x05 \x01(\x0b\x32\x30.azents.runtime_control.v1.RuntimeProviderReport\x12\x12\n\nerror_code\x18\x06 \x01(\t\x12\x15\n\rerror_message\x18\x07 \x01(\t\x12\x30\n\x0c\x63ompleted_at\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp".\n\rProviderError\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0f\n\x07message\x18\x02 \x01(\t2\x86\x01\n\x16RuntimeProviderControl\x12l\n\x0f\x43onnectProvider\x12*.azents.runtime_control.v1.ProviderMessage\x1a).azents.runtime_control.v1.ControlMessage(\x01\x30\x01\x62\x06proto3'
 )
 
 _globals = globals()
@@ -55,39 +55,39 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_CONTROLMESSAGE"]._serialized_start = 562
     _globals["_CONTROLMESSAGE"]._serialized_end = 896
     _globals["_PROVIDERREGISTER"]._serialized_start = 899
-    _globals["_PROVIDERREGISTER"]._serialized_end = 1148
-    _globals["_PROVIDERREGISTERACCEPTED"]._serialized_start = 1150
-    _globals["_PROVIDERREGISTERACCEPTED"]._serialized_end = 1276
-    _globals["_PROVIDERHEARTBEAT"]._serialized_start = 1278
-    _globals["_PROVIDERHEARTBEAT"]._serialized_end = 1325
-    _globals["_PROVIDERHEARTBEATACK"]._serialized_start = 1327
-    _globals["_PROVIDERHEARTBEATACK"]._serialized_end = 1377
-    _globals["_PROVIDERCOMMAND"]._serialized_start = 1380
-    _globals["_PROVIDERCOMMAND"]._serialized_end = 1822
-    _globals["_RUNTIMEPROVIDERREPORT"]._serialized_start = 1825
-    _globals["_RUNTIMEPROVIDERREPORT"]._serialized_end = 2357
-    _globals["_RUNTIMEPROVIDERREPORT_DIAGNOSTICENTRY"]._serialized_start = 2308
-    _globals["_RUNTIMEPROVIDERREPORT_DIAGNOSTICENTRY"]._serialized_end = 2357
-    _globals["_RUNTIMEEXECUTIONPOLICYEVIDENCE"]._serialized_start = 2360
-    _globals["_RUNTIMEEXECUTIONPOLICYEVIDENCE"]._serialized_end = 2775
+    _globals["_PROVIDERREGISTER"]._serialized_end = 1202
+    _globals["_PROVIDERREGISTERACCEPTED"]._serialized_start = 1204
+    _globals["_PROVIDERREGISTERACCEPTED"]._serialized_end = 1330
+    _globals["_PROVIDERHEARTBEAT"]._serialized_start = 1332
+    _globals["_PROVIDERHEARTBEAT"]._serialized_end = 1379
+    _globals["_PROVIDERHEARTBEATACK"]._serialized_start = 1381
+    _globals["_PROVIDERHEARTBEATACK"]._serialized_end = 1431
+    _globals["_PROVIDERCOMMAND"]._serialized_start = 1434
+    _globals["_PROVIDERCOMMAND"]._serialized_end = 1876
+    _globals["_RUNTIMEPROVIDERREPORT"]._serialized_start = 1879
+    _globals["_RUNTIMEPROVIDERREPORT"]._serialized_end = 2411
+    _globals["_RUNTIMEPROVIDERREPORT_DIAGNOSTICENTRY"]._serialized_start = 2362
+    _globals["_RUNTIMEPROVIDERREPORT_DIAGNOSTICENTRY"]._serialized_end = 2411
+    _globals["_RUNTIMEEXECUTIONPOLICYEVIDENCE"]._serialized_start = 2414
+    _globals["_RUNTIMEEXECUTIONPOLICYEVIDENCE"]._serialized_end = 2829
     _globals[
         "_RUNTIMEEXECUTIONPOLICYEVIDENCE_MODULEVERSIONSENTRY"
-    ]._serialized_start = 2667
+    ]._serialized_start = 2721
     _globals[
         "_RUNTIMEEXECUTIONPOLICYEVIDENCE_MODULEVERSIONSENTRY"
-    ]._serialized_end = 2720
+    ]._serialized_end = 2774
     _globals[
         "_RUNTIMEEXECUTIONPOLICYEVIDENCE_SOURCEVERSIONSENTRY"
-    ]._serialized_start = 2722
+    ]._serialized_start = 2776
     _globals[
         "_RUNTIMEEXECUTIONPOLICYEVIDENCE_SOURCEVERSIONSENTRY"
-    ]._serialized_end = 2775
-    _globals["_RUNTIMEEXECUTIONPOLICYENVELOPE"]._serialized_start = 2778
-    _globals["_RUNTIMEEXECUTIONPOLICYENVELOPE"]._serialized_end = 2938
-    _globals["_PROVIDERCOMMANDCOMPLETION"]._serialized_start = 2941
-    _globals["_PROVIDERCOMMANDCOMPLETION"]._serialized_end = 3204
-    _globals["_PROVIDERERROR"]._serialized_start = 3206
-    _globals["_PROVIDERERROR"]._serialized_end = 3252
-    _globals["_RUNTIMEPROVIDERCONTROL"]._serialized_start = 3255
-    _globals["_RUNTIMEPROVIDERCONTROL"]._serialized_end = 3389
+    ]._serialized_end = 2829
+    _globals["_RUNTIMEEXECUTIONPOLICYENVELOPE"]._serialized_start = 2832
+    _globals["_RUNTIMEEXECUTIONPOLICYENVELOPE"]._serialized_end = 2992
+    _globals["_PROVIDERCOMMANDCOMPLETION"]._serialized_start = 2995
+    _globals["_PROVIDERCOMMANDCOMPLETION"]._serialized_end = 3258
+    _globals["_PROVIDERERROR"]._serialized_start = 3260
+    _globals["_PROVIDERERROR"]._serialized_end = 3306
+    _globals["_RUNTIMEPROVIDERCONTROL"]._serialized_start = 3309
+    _globals["_RUNTIMEPROVIDERCONTROL"]._serialized_end = 3443
 # @@protoc_insertion_point(module_scope)

--- a/python/libs/azents-runtime-control/src/azents_runtime_control/provider.py
+++ b/python/libs/azents-runtime-control/src/azents_runtime_control/provider.py
@@ -123,6 +123,7 @@ class ProviderRegistration:
     capabilities: Sequence[str]
     config_schema_version: str
     metadata: Mapping[str, JsonValue]
+    capability_contract: Mapping[str, JsonValue]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/python/libs/azents-runtime-control/tests/grpc_provider_client_test.py
+++ b/python/libs/azents-runtime-control/tests/grpc_provider_client_test.py
@@ -111,6 +111,7 @@ async def test_grpc_client_registers_heartbeats_claims_and_completes() -> None:
     )
 
     assert accepted.generation == 3
+    assert sent[0].register.capability_contract["schema_version"] == 1
     assert command is not None
     assert command.command.identity.runtime_id == "runtime-1"
     assert command.command.auth.control_endpoint == "runtime-control:8020"
@@ -238,6 +239,7 @@ def _registration() -> ProviderRegistration:
         capabilities=("lifecycle", "observe"),
         config_schema_version="v1",
         metadata={"workspace_path_source": "provider"},
+        capability_contract={"schema_version": 1},
     )
 
 

--- a/python/libs/azents-runtime-control/tests/provider_test.py
+++ b/python/libs/azents-runtime-control/tests/provider_test.py
@@ -313,6 +313,7 @@ def _loop(
             capabilities=("lifecycle", "observe"),
             config_schema_version="v1",
             metadata={"workspace_path_source": "provider"},
+            capability_contract={"schema_version": 1},
         ),
         connection_id="connection-1",
         consumer_id="consumer-1",

--- a/typescript/apps/azents-admin-web/src/features/runtime-providers/components/RuntimeProvidersPageContent.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-providers/components/RuntimeProvidersPageContent.tsx
@@ -19,6 +19,8 @@ import type {
   RuntimeProviderAuthAuditState,
   RuntimeProviderAuthBindingItem,
   RuntimeProviderAuthBindingState,
+  RuntimeProviderContractItem,
+  RuntimeProviderContractState,
   RuntimeProviderItem,
   RuntimeProvidersPageContentProps,
 } from "../containers/useRuntimeProvidersPageContainer";
@@ -195,6 +197,92 @@ function AuthenticationSection({
   );
 }
 
+function ContractSection({
+  provider,
+  state,
+  accepting,
+  onAccept,
+}: {
+  provider: RuntimeProviderItem;
+  state: RuntimeProviderContractState;
+  accepting: boolean;
+  onAccept: (contract: RuntimeProviderContractItem) => void;
+}): React.ReactElement {
+  return (
+    <Stack gap="sm">
+      <Text size="sm" fw={600}>
+        Contract and configuration
+      </Text>
+      <Group gap="xs">
+        {provider.accepted_contract_revision_id ? (
+          <IconCircleCheck size={16} color="var(--mantine-color-green-6)" />
+        ) : (
+          <IconCircleX size={16} color="var(--mantine-color-yellow-6)" />
+        )}
+        <Text size="sm">
+          {provider.accepted_contract_revision_id
+            ? "Capability contract accepted"
+            : "Capability contract requires Admin acceptance"}
+        </Text>
+      </Group>
+      {state.type === "IDLE" && (
+        <Text size="sm" c="dimmed">
+          Select a Provider to inspect capability contracts.
+        </Text>
+      )}
+      {state.type === "LOADING" && <Loader size="sm" />}
+      {state.type === "ERROR" && <Alert color="red">{state.message}</Alert>}
+      {state.type === "LOADED" && state.items.length === 0 && (
+        <Alert color="yellow">
+          The connected Provider has not submitted a capability contract yet.
+        </Alert>
+      )}
+      {state.type === "LOADED" &&
+        state.items.map((contract) => (
+          <Paper key={contract.id} withBorder p="sm" radius="sm">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Stack gap={2}>
+                <Group gap="xs">
+                  <Badge
+                    color={contract.status === "accepted" ? "green" : "yellow"}
+                    variant="light"
+                  >
+                    {contract.status}
+                  </Badge>
+                  <Text size="xs">
+                    Implementation {contract.implementation_version} · Protocol{" "}
+                    {contract.protocol_version}
+                  </Text>
+                </Group>
+                <Text size="xs" c="dimmed" ff="monospace">
+                  {contract.digest}
+                </Text>
+                {contract.validation_message && (
+                  <Text size="xs" c="red">
+                    {contract.validation_message}
+                  </Text>
+                )}
+              </Stack>
+              {contract.status === "candidate" &&
+                contract.validation_code === null && (
+                  <Button
+                    size="xs"
+                    loading={accepting}
+                    onClick={() => onAccept(contract)}
+                  >
+                    Accept contract
+                  </Button>
+                )}
+            </Group>
+          </Paper>
+        ))}
+      <Text size="sm" c="dimmed" ff="monospace">
+        Config revision: {provider.active_config_revision_id ?? "None"}
+      </Text>
+    </Stack>
+  );
+}
+
 function AuthenticationAudit({
   state,
 }: {
@@ -245,20 +333,26 @@ function AuthenticationAudit({
 
 function ProviderDetail({
   provider,
+  contractState,
   authBindingState,
   authMutating,
   updating,
+  acceptingContract,
   onToggleEnabled,
+  onAcceptContract,
   onCreateAuthBinding,
   onRotateAuthBinding,
   onRevokeAuthBinding,
   onOpenAuthAudit,
 }: {
   provider: RuntimeProviderItem;
+  contractState: RuntimeProviderContractState;
   authBindingState: RuntimeProviderAuthBindingState;
   authMutating: boolean;
   updating: boolean;
+  acceptingContract: boolean;
   onToggleEnabled: () => void;
+  onAcceptContract: (contract: RuntimeProviderContractItem) => void;
   onCreateAuthBinding: () => void;
   onRotateAuthBinding: (binding: RuntimeProviderAuthBindingItem) => void;
   onRevokeAuthBinding: (binding: RuntimeProviderAuthBindingItem) => void;
@@ -319,28 +413,12 @@ function ProviderDetail({
         </Group>
       </Stack>
 
-      <Stack gap="sm">
-        <Text size="sm" fw={600}>
-          Contract and configuration
-        </Text>
-        <Stack gap={4}>
-          <Group gap="xs">
-            {provider.accepted_contract_revision_id ? (
-              <IconCircleCheck size={16} color="var(--mantine-color-green-6)" />
-            ) : (
-              <IconCircleX size={16} color="var(--mantine-color-yellow-6)" />
-            )}
-            <Text size="sm">
-              {provider.accepted_contract_revision_id
-                ? "Capability contract accepted"
-                : "Capability contract requires Admin acceptance"}
-            </Text>
-          </Group>
-          <Text size="sm" c="dimmed" ff="monospace">
-            Config revision: {provider.active_config_revision_id ?? "None"}
-          </Text>
-        </Stack>
-      </Stack>
+      <ContractSection
+        provider={provider}
+        state={contractState}
+        accepting={acceptingContract}
+        onAccept={onAcceptContract}
+      />
 
       <Divider />
       <AuthenticationSection
@@ -358,14 +436,17 @@ function ProviderDetail({
 export function RuntimeProvidersPageContent({
   state,
   selectedProvider,
+  contractState,
   authBindingState,
   authAuditState,
   authMutating,
   oneTimeSecret,
   updating,
+  acceptingContract,
   errorMessage,
   onSelectProvider,
   onToggleEnabled,
+  onAcceptContract,
   onCreateAuthBinding,
   onRotateAuthBinding,
   onRevokeAuthBinding,
@@ -435,10 +516,13 @@ export function RuntimeProvidersPageContent({
               {selectedProvider ? (
                 <ProviderDetail
                   provider={selectedProvider}
+                  contractState={contractState}
                   authBindingState={authBindingState}
                   authMutating={authMutating}
                   updating={updating}
+                  acceptingContract={acceptingContract}
                   onToggleEnabled={() => onToggleEnabled(selectedProvider)}
+                  onAcceptContract={onAcceptContract}
                   onCreateAuthBinding={onCreateAuthBinding}
                   onRotateAuthBinding={onRotateAuthBinding}
                   onRevokeAuthBinding={onRevokeAuthBinding}

--- a/typescript/apps/azents-admin-web/src/features/runtime-providers/containers/useRuntimeProvidersPageContainer.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-providers/containers/useRuntimeProvidersPageContainer.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeProviderAuthenticationBindingAuditEventResponse,
   RuntimeProviderAuthenticationBindingResponse,
   RuntimeProviderAuthenticationBindingRotateResponse,
+  RuntimeProviderContractResponse,
   RuntimeProviderResponse,
 } from "@azents/admin-client";
 
@@ -14,6 +15,7 @@ export type RuntimeProviderAuthBindingItem =
   RuntimeProviderAuthenticationBindingResponse;
 export type RuntimeProviderAuthAuditEvent =
   RuntimeProviderAuthenticationBindingAuditEventResponse;
+export type RuntimeProviderContractItem = RuntimeProviderContractResponse;
 
 export type RuntimeProviderListState =
   | { type: "LOADING" }
@@ -25,6 +27,12 @@ export type RuntimeProviderAuthBindingState =
   | { type: "LOADING" }
   | { type: "ERROR"; message: string }
   | { type: "LOADED"; items: RuntimeProviderAuthBindingItem[] };
+
+export type RuntimeProviderContractState =
+  | { type: "IDLE" }
+  | { type: "LOADING" }
+  | { type: "ERROR"; message: string }
+  | { type: "LOADED"; items: RuntimeProviderContractItem[] };
 
 export type RuntimeProviderAuthAuditState =
   | { type: "IDLE" }
@@ -40,14 +48,17 @@ export interface RuntimeProvidersPageContentProps {
   state: RuntimeProviderListState;
   selectedProviderId: string | null;
   selectedProvider: RuntimeProviderItem | null;
+  contractState: RuntimeProviderContractState;
   authBindingState: RuntimeProviderAuthBindingState;
   authAuditState: RuntimeProviderAuthAuditState;
   authMutating: boolean;
   oneTimeSecret: RuntimeProviderAuthenticationBindingRotateResponse | null;
   updating: boolean;
+  acceptingContract: boolean;
   errorMessage: string | null;
   onSelectProvider: (providerId: string) => void;
   onToggleEnabled: (provider: RuntimeProviderItem) => void;
+  onAcceptContract: (contract: RuntimeProviderContractItem) => void;
   onCreateAuthBinding: () => void;
   onRotateAuthBinding: (binding: RuntimeProviderAuthBindingItem) => void;
   onRevokeAuthBinding: (binding: RuntimeProviderAuthBindingItem) => void;
@@ -87,6 +98,20 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
     { providerId: effectiveSelectedProviderId ?? "" },
     { enabled: effectiveSelectedProviderId !== null },
   );
+  const contractsQuery = trpc.runtimeProvider.listContracts.useQuery(
+    { providerId: effectiveSelectedProviderId ?? "" },
+    { enabled: effectiveSelectedProviderId !== null },
+  );
+  const acceptContract = trpc.runtimeProvider.acceptContract.useMutation({
+    onSuccess: async () => {
+      await utils.runtimeProvider.list.invalidate();
+      if (effectiveSelectedProviderId !== null) {
+        await utils.runtimeProvider.listContracts.invalidate({
+          providerId: effectiveSelectedProviderId,
+        });
+      }
+    },
+  });
   const [oneTimeSecret, setOneTimeSecret] =
     useState<RuntimeProviderAuthenticationBindingRotateResponse | null>(null);
   const [auditBinding, setAuditBinding] =
@@ -137,6 +162,14 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
         : authBindingsQuery.isError
           ? { type: "ERROR", message: authBindingsQuery.error.message }
           : { type: "LOADED", items: authBindingsQuery.data?.items ?? [] };
+  const contractState: RuntimeProviderContractState =
+    effectiveSelectedProviderId === null
+      ? { type: "IDLE" }
+      : contractsQuery.isLoading
+        ? { type: "LOADING" }
+        : contractsQuery.isError
+          ? { type: "ERROR", message: contractsQuery.error.message }
+          : { type: "LOADED", items: contractsQuery.data?.items ?? [] };
   const authAuditState: RuntimeProviderAuthAuditState =
     auditBinding === null
       ? { type: "IDLE" }
@@ -175,6 +208,22 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
       subject: `provider:${effectiveSelectedProviderId}:admin`,
     });
   }, [createAuthBinding, effectiveSelectedProviderId]);
+  const handleAcceptContract = useCallback(
+    (contract: RuntimeProviderContractItem): void => {
+      if (selectedProvider === null) {
+        return;
+      }
+      if (!window.confirm("Accept this Provider capability contract?")) {
+        return;
+      }
+      acceptContract.mutate({
+        providerId: selectedProvider.provider_id,
+        revisionId: contract.id,
+        expectedAdminVersion: selectedProvider.admin_version,
+      });
+    },
+    [acceptContract, selectedProvider],
+  );
   const handleRotateAuthBinding = useCallback(
     (binding: RuntimeProviderAuthBindingItem): void => {
       const rotate = async (): Promise<void> => {
@@ -229,6 +278,7 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
     state,
     selectedProviderId: effectiveSelectedProviderId,
     selectedProvider,
+    contractState,
     authBindingState,
     authAuditState,
     authMutating:
@@ -237,14 +287,17 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
       revokeAuthBinding.isPending,
     oneTimeSecret,
     updating: updatePolicy.isPending,
+    acceptingContract: acceptContract.isPending,
     errorMessage:
       updatePolicy.error?.message ??
+      acceptContract.error?.message ??
       createAuthBinding.error?.message ??
       rotateError ??
       revokeAuthBinding.error?.message ??
       null,
     onSelectProvider: handleSelectProvider,
     onToggleEnabled: handleToggleEnabled,
+    onAcceptContract: handleAcceptContract,
     onCreateAuthBinding: handleCreateAuthBinding,
     onRotateAuthBinding: handleRotateAuthBinding,
     onRevokeAuthBinding: handleRevokeAuthBinding,

--- a/typescript/apps/azents-admin-web/src/trpc/routers/runtimeProvider.ts
+++ b/typescript/apps/azents-admin-web/src/trpc/routers/runtimeProvider.ts
@@ -1,8 +1,10 @@
 import {
+  runtimeProviderV1AcceptContract,
   runtimeProviderV1CreateAuthBinding,
   runtimeProviderV1GetRuntimeProvider,
   runtimeProviderV1ListAuthBindingAuditEvents,
   runtimeProviderV1ListAuthBindings,
+  runtimeProviderV1ListContracts,
   runtimeProviderV1ListRuntimeProviders,
   runtimeProviderV1ReplaceRuntimeProviderAvailability,
   runtimeProviderV1RevokeAuthBinding,
@@ -22,6 +24,50 @@ const lifecycleStateSchema = z.enum([
 const availabilityModeSchema = z.enum(["platform_wide", "selected_workspaces"]);
 
 export const runtimeProviderRouter = router({
+  listContracts: protectedProcedure
+    .input(z.object({ providerId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const { data } = await runtimeProviderV1ListContracts({
+          client: ctx.adminApiClient,
+          path: { provider_id: input.providerId },
+          throwOnError: true,
+        });
+        return data;
+      } catch (error) {
+        throw mapExpectedError(error, { 404: "NOT_FOUND" });
+      }
+    }),
+
+  acceptContract: protectedProcedure
+    .input(
+      z.object({
+        providerId: z.string().min(1),
+        revisionId: z.string().min(1),
+        expectedAdminVersion: z.number().int().nonnegative(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { data } = await runtimeProviderV1AcceptContract({
+          client: ctx.adminApiClient,
+          path: {
+            provider_id: input.providerId,
+            revision_id: input.revisionId,
+          },
+          body: { expected_admin_version: input.expectedAdminVersion },
+          throwOnError: true,
+        });
+        return data;
+      } catch (error) {
+        throw mapExpectedError(error, {
+          404: "NOT_FOUND",
+          409: "CONFLICT",
+          422: "BAD_REQUEST",
+        });
+      }
+    }),
+
   listAuthBindings: protectedProcedure
     .input(z.object({ providerId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

- make Runtime Providers submit a validated capability contract during control-plane registration
- add explicit Admin contract listing and acceptance APIs/UI
- migrate pre-contract Runtime records onto exact Provider resources and immutable policy snapshots without replacing Runtime identity or PVCs
- document the contract and legacy Runtime convergence flow

## Root cause

The Kubernetes Provider could authenticate and connect, but it never proposed a capability contract. Admin therefore had nothing to accept, while Runtime startup already required accepted execution-policy evidence. Existing Runtime rows also predated durable Provider resource and policy snapshot bindings.

## Verification

- Azents backend: 3,367 tests passed
- Runtime Control shared library: 55 tests passed
- Kubernetes Provider: 68 tests passed
- Docker Provider: 22 tests passed
- Admin Web: typecheck, lint, 8 tests, production build passed
- full pre-commit suite passed (docs/OpenAPI generation, Ruff, Pyright, TypeScript checks)