### PR TITLE
fix(runtime): preserve execution policy integers over gRPC

### DIFF
--- a/python/libs/azents-runtime-control/src/azents_runtime_control/grpc_provider_client.py
+++ b/python/libs/azents-runtime-control/src/azents_runtime_control/grpc_provider_client.py
@@ -508,7 +508,7 @@ def _execution_policy_envelope(
 ) -> RuntimeExecutionPolicyEnvelope:
     return RuntimeExecutionPolicyEnvelope(
         evidence=_execution_policy_evidence(message.evidence),
-        effective_policy=json_value_from_struct(message.effective_policy),
+        effective_policy=_execution_policy_from_struct(message.effective_policy),
     )
 
 
@@ -544,6 +544,26 @@ def _struct(metadata: object) -> struct_pb2.Struct:
 
 def json_value_from_struct(struct: struct_pb2.Struct) -> dict[str, JsonValue]:
     return cast(dict[str, JsonValue], json_format.MessageToDict(struct))
+
+
+def _execution_policy_from_struct(
+    struct: struct_pb2.Struct,
+) -> dict[str, JsonValue]:
+    """Restore JSON integers erased by protobuf Struct's double representation."""
+    value = _restore_integral_numbers(json_value_from_struct(struct))
+    if not isinstance(value, dict):
+        raise AssertionError("Runtime execution policy must be a JSON object.")
+    return value
+
+
+def _restore_integral_numbers(value: JsonValue) -> JsonValue:
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, list):
+        return [_restore_integral_numbers(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _restore_integral_numbers(item) for key, item in value.items()}
+    return value
 
 
 def _timestamp(value: datetime) -> timestamp_pb2.Timestamp:

--- a/python/libs/azents-runtime-control/tests/grpc_provider_client_test.py
+++ b/python/libs/azents-runtime-control/tests/grpc_provider_client_test.py
@@ -10,7 +10,12 @@ from datetime import UTC, datetime
 import pytest
 from google.protobuf import struct_pb2
 
-from azents_runtime_control.execution_policy import RuntimeExecutionPolicyEvidence
+from azents_runtime_control.execution_policy import (
+    JsonValue,
+    RuntimeExecutionPolicyEvidence,
+    digest_effective_policy,
+    validate_standard_execution_policy_envelope,
+)
 from azents_runtime_control.grpc_provider_client import (
     PROVIDER_AUTH_METHOD_AZENTS_ISSUED_TOKEN,
     PROVIDER_AUTH_METHOD_KUBERNETES_SERVICE_ACCOUNT,
@@ -52,6 +57,9 @@ async def test_grpc_client_registers_heartbeats_claims_and_completes() -> None:
         command_payload.update(
             {"auth": {"runner_auth_credential_id": "runner-credential-1"}}
         )
+        execution_policy = _execution_policy_document()
+        execution_policy_struct = struct_pb2.Struct()
+        execution_policy_struct.update(execution_policy)
         yield runtime_provider_control_pb2.ControlMessage(
             request_id="req-1",
             provider_command=runtime_provider_control_pb2.ProviderCommand(
@@ -68,9 +76,16 @@ async def test_grpc_client_registers_heartbeats_claims_and_completes() -> None:
                 execution_policy=runtime_provider_control_pb2.RuntimeExecutionPolicyEnvelope(
                     evidence=runtime_provider_control_pb2.RuntimeExecutionPolicyEvidence(
                         snapshot_id="snapshot-1",
-                        digest="d" * 64,
+                        digest=digest_effective_policy(execution_policy),
                         desired_generation=5,
-                        module_versions={"container.run": 1},
+                        module_versions={
+                            "container.image_build": 1,
+                            "container.run": 1,
+                            "container.compose": 1,
+                            "container.resources": 1,
+                            "engine.storage": 1,
+                            "network.egress": 1,
+                        },
                         source_versions={
                             "platform": 1,
                             "profile": 1,
@@ -78,7 +93,7 @@ async def test_grpc_client_registers_heartbeats_claims_and_completes() -> None:
                             "agent": 1,
                         },
                     ),
-                    effective_policy=struct_pb2.Struct(),
+                    effective_policy=execution_policy_struct,
                 ),
             ),
         )
@@ -117,6 +132,10 @@ async def test_grpc_client_registers_heartbeats_claims_and_completes() -> None:
     assert command.command.auth.control_endpoint == "runtime-control:8020"
     assert command.command.auth.runner_auth_token == "runner-token"
     assert command.command.auth.runner_auth_credential_id == "runner-credential-1"
+    validate_standard_execution_policy_envelope(
+        command.command.execution_policy,
+        desired_generation=5,
+    )
     assert await client.heartbeat_provider(
         provider_id="provider-1",
         generation=accepted.generation,
@@ -268,6 +287,49 @@ def _execution_policy_evidence() -> RuntimeExecutionPolicyEvidence:
         module_versions={"container.run": 1},
         source_versions={"platform": 1, "profile": 1, "workspace": 1, "agent": 1},
     )
+
+
+def _execution_policy_document() -> dict[str, JsonValue]:
+    return {
+        "schema_version": 1,
+        "image_build": {
+            "module_id": "container.image_build",
+            "version": 1,
+            "enabled": False,
+        },
+        "container_run": {
+            "module_id": "container.run",
+            "version": 1,
+            "enabled": False,
+        },
+        "compose": {
+            "module_id": "container.compose",
+            "version": 1,
+            "enabled": False,
+        },
+        "resources": {
+            "module_id": "container.resources",
+            "version": 1,
+            "cpu_millicores": None,
+            "memory_bytes": None,
+            "pids": None,
+            "container_count": None,
+            "ephemeral_storage_bytes": None,
+        },
+        "engine_storage": {
+            "module_id": "engine.storage",
+            "version": 1,
+            "mode": "none",
+            "capacity_bytes": None,
+        },
+        "network_egress": {
+            "module_id": "network.egress",
+            "version": 1,
+            "mode": "none",
+            "allowed_destinations": [],
+            "denied_destinations": [],
+        },
+    }
 
 
 def _now() -> datetime:


### PR DESCRIPTION
## Summary
- restore integral JSON numbers after execution policies cross protobuf `Struct`
- keep digest and strict integer schema validation stable at the Provider boundary
- cover the full gRPC command round trip with Standard policy validation

## Root cause
`google.protobuf.Struct` represents every JSON number as a double. Runtime Control hashed integer-valued policy documents, but Providers received values such as `1.0`, causing the evidence digest check to reject lifecycle commands before restart.

## Validation
- `uv run --project python/libs/azents-runtime-control pytest python/libs/azents-runtime-control/tests` (55 passed)
- `uv run --project python/apps/azents-runtime-provider-kubernetes pytest python/apps/azents-runtime-provider-kubernetes/tests` (68 passed)
- `uv run --project python/apps/azents-runtime-provider-docker pytest python/apps/azents-runtime-provider-docker/tests` (22 passed)
- `uv run --project python/libs/azents-runtime-control ruff check python/libs/azents-runtime-control`
- `uv run --project python/libs/azents-runtime-control pyright python/libs/azents-runtime-control`
- `pre-commit run --all-files`