### PR TITLE
fix(runtime): reuse Pods with Kubernetes default ServiceAccount

### DIFF
--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -579,7 +579,7 @@ class KubernetesRuntimeProvider:
             return False
         if pod.spec.security_context != expected.spec.security_context:
             return False
-        if pod.spec.service_account_name is not None:
+        if pod.spec.service_account_name not in {None, "default"}:
             return False
         if pod.spec.automount_service_account_token:
             return False

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -506,6 +506,52 @@ async def test_start_reuses_pod_with_kubernetes_default_tolerations() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_reuses_pod_with_kubernetes_default_service_account() -> None:
+    """The API-server default is safe when token automount remains disabled."""
+    api = FakeKubernetesApi()
+    provider = _provider(api)
+    command = _command(RuntimeLifecycleCommandType.START)
+    await provider.start(command)
+    pod_key = ("azents-runtime", "azents-runtime-runtime-1")
+    pod = api.pods[pod_key]
+    api.pods[pod_key] = dataclasses.replace(
+        pod,
+        spec=dataclasses.replace(
+            pod.spec,
+            service_account_name="default",
+        ),
+    )
+
+    await provider.start(command)
+
+    assert api.deleted_pods == []
+    assert api.pods[pod_key].spec.service_account_name == "default"
+    assert api.pods[pod_key].spec.automount_service_account_token is False
+
+
+@pytest.mark.asyncio
+async def test_start_replaces_pod_with_non_default_service_account() -> None:
+    api = FakeKubernetesApi()
+    provider = _provider(api)
+    command = _command(RuntimeLifecycleCommandType.START)
+    await provider.start(command)
+    pod_key = ("azents-runtime", "azents-runtime-runtime-1")
+    pod = api.pods[pod_key]
+    api.pods[pod_key] = dataclasses.replace(
+        pod,
+        spec=dataclasses.replace(
+            pod.spec,
+            service_account_name="privileged-runtime",
+        ),
+    )
+
+    await provider.start(command)
+
+    assert api.deleted_pods == ["azents-runtime-runtime-1"]
+    assert api.pods[pod_key].spec.service_account_name is None
+
+
+@pytest.mark.asyncio
 async def test_start_reuses_pod_with_canonicalized_kubernetes_quantities() -> None:
     api = FakeKubernetesApi()
     provider = _provider(api)


### PR DESCRIPTION
## Summary
- treat the API-server default ServiceAccount name as equivalent to an omitted name when token automount is disabled
- keep rejecting Pods that use any non-default ServiceAccount
- prevent the lifecycle reconciler from replacing a healthy Runtime Pod every retry interval

## Root cause
Kubernetes defaults an omitted `serviceAccountName` to `default`. The Provider expected only `None`, so otherwise identical Pods were classified as stale and replaced on every repeated start reconciliation.

## Validation
- `uv run --project python/apps/azents-runtime-provider-kubernetes pytest python/apps/azents-runtime-provider-kubernetes/tests` (70 passed)
- `uv run --project python/apps/azents-runtime-provider-kubernetes ruff check python/apps/azents-runtime-provider-kubernetes`
- `uv run --project python/apps/azents-runtime-provider-kubernetes pyright python/apps/azents-runtime-provider-kubernetes`
- focused pre-commit hooks