### PR TITLE
feat(runtime): enable accepted Kubernetes engine capabilities

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -21,7 +21,7 @@ Design documents are accumulated records and are not listed individually in this
 | [Goal Domain Spec](spec/domain/goal.md) | goal | - | 2026-07-26 | 12 |
 | [Memory](spec/domain/memory.md) | memory | @Hardtack | 2026-07-24 | 6 |
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-07-21 | 17 |
-| [Runtime Provider](spec/domain/runtime-provider.md) | runtime-provider | - | 2026-07-27 | 5 |
+| [Runtime Provider](spec/domain/runtime-provider.md) | runtime-provider | - | 2026-07-27 | 6 |
 | [System Settings](spec/domain/system-settings.md) | system-settings | @Hardtack | 2026-07-23 | 4 |
 | [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-07-26 | 75 |
 | [User & Authentication](spec/domain/user-auth.md) | user-auth | @Hardtack | 2026-07-20 | 8 |
@@ -33,7 +33,7 @@ Design documents are accumulated records and are not listed individually in this
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-26 | 134 |
 | [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-26 | 31 |
-| [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 7 |
+| [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 8 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |
 | [Context Compaction](spec/flow/context-compaction.md) | @Hardtack | 2026-07-22 | 31 |
@@ -48,7 +48,7 @@ Design documents are accumulated records and are not listed individually in this
 | [Periodic Execution Flow Spec](spec/flow/periodic-execution.md) | - | 2026-07-26 | 11 |
 | [Run Resume](spec/flow/run-resume.md) | @Hardtack | 2026-07-24 | 25 |
 | [Session Context Inspector](spec/flow/session-context-inspector.md) | @Hardtack | 2026-07-21 | 18 |
-| [E2E Primary Test Strategy](spec/flow/test-strategy-e2e-primary.md) | @Hardtack | 2026-07-26 | 11 |
+| [E2E Primary Test Strategy](spec/flow/test-strategy-e2e-primary.md) | @Hardtack | 2026-07-27 | 12 |
 | [xAI API Key Provider Flow](spec/flow/xai-api-key.md) | @Hardtack | 2026-07-18 | 3 |
 | [xAI OAuth Flow](spec/flow/xai-oauth.md) | @Hardtack | 2026-07-19 | 6 |
 

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -18,7 +18,7 @@ Details of all living specs. Synchronized from frontmatter.
 | goal | [Goal Domain Spec](domain/goal.md) | - | 2026-07-26 | 12 |
 | memory | [Memory](domain/memory.md) | @Hardtack | 2026-07-24 | 6 |
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-07-21 | 17 |
-| runtime-provider | [Runtime Provider](domain/runtime-provider.md) | - | 2026-07-27 | 5 |
+| runtime-provider | [Runtime Provider](domain/runtime-provider.md) | - | 2026-07-27 | 6 |
 | system-settings | [System Settings](domain/system-settings.md) | @Hardtack | 2026-07-23 | 4 |
 | toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-07-26 | 75 |
 | user-auth | [User & Authentication](domain/user-auth.md) | @Hardtack | 2026-07-20 | 8 |
@@ -30,7 +30,7 @@ Details of all living specs. Synchronized from frontmatter.
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-26 | 134 |
 | [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-26 | 31 |
-| [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 7 |
+| [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 8 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |
 | [Context Compaction](flow/context-compaction.md) | @Hardtack | 2026-07-22 | 31 |
@@ -45,6 +45,6 @@ Details of all living specs. Synchronized from frontmatter.
 | [Periodic Execution Flow Spec](flow/periodic-execution.md) | - | 2026-07-26 | 11 |
 | [Run Resume](flow/run-resume.md) | @Hardtack | 2026-07-24 | 25 |
 | [Session Context Inspector](flow/session-context-inspector.md) | @Hardtack | 2026-07-21 | 18 |
-| [E2E Primary Test Strategy](flow/test-strategy-e2e-primary.md) | @Hardtack | 2026-07-26 | 11 |
+| [E2E Primary Test Strategy](flow/test-strategy-e2e-primary.md) | @Hardtack | 2026-07-27 | 12 |
 | [xAI API Key Provider Flow](flow/xai-api-key.md) | @Hardtack | 2026-07-18 | 3 |
 | [xAI OAuth Flow](flow/xai-oauth.md) | @Hardtack | 2026-07-19 | 6 |

--- a/docs/azents/spec/domain/runtime-provider.md
+++ b/docs/azents/spec/domain/runtime-provider.md
@@ -42,7 +42,7 @@ code_paths:
   - typescript/apps/azents-admin-web/src/features/runtime-providers/**
   - typescript/apps/azents-admin-web/src/trpc/routers/runtimeProvider.ts
 last_verified_at: 2026-07-27
-spec_version: 5
+spec_version: 6
 ---
 
 # Runtime Provider
@@ -97,6 +97,13 @@ replacement.
 Raw Provider registration metadata is not product capability authority. The server-owned
 management/status gate is authoritative: the resolver marks an unsatisfied Profile unavailable and
 provisioning fails closed rather than dropping an unsupported module or selecting a weaker Runtime.
+The immutable contract may include a typed `execution_policy` section declaring exact module
+versions, privileged-engine implementation support, storage modes, network modes, and optional
+resource maxima. Runtime resolution uses only the bound Provider's current accepted contract;
+missing, candidate, rejected, malformed, or superseded declarations cannot grant authority. A new
+target snapshot records and references that accepted contract revision even when the previous
+snapshot used an older revision. A stale non-null Provider configuration remains unavailable until
+it is validated against the newly accepted contract.
 
 Agent intent is independent from a physical Runtime. Saving Agent Profile/override intent does not
 advance Runtime desired generation. Explicit Apply attaches an immutable target snapshot and
@@ -105,10 +112,14 @@ second Agent Apply; it preserves Agent Workspace storage and does not invoke res
 delete. Audit and public projections contain only bounded policy metadata, reason codes, source
 layers, digests, and generations.
 
-The current server capability gate keeps `privileged_engine` unavailable and exposes storage/network
-mode `none`. Kubernetes Provider registration metadata such as `engine_storage_ephemeral` is not
-yet translated into product availability. Image build, container run, Compose, ephemeral or
-persistent engine storage, and qualified nested-workload enablement are therefore not advertised.
+The installation management gate exposes image build, container run, Compose, `none` or
+`ephemeral` engine storage, and `none` or `direct` network egress. The Kubernetes Provider declares
+those exact capabilities in its Admin-accepted typed contract and enforces them with the fixed
+Runner, policy-gateway, and engine topology plus a generation-fenced Runtime NetworkPolicy.
+Persistent engine storage, proxy-required egress, and restricted-destination egress remain
+unavailable because this Provider contract does not advertise them. A legacy accepted contract
+without the typed section remains usable for the non-engine baseline but cannot grant nested-engine
+authority.
 Admin/Public surfaces must not expose Provider credentials, socket paths, raw manifests, Kubernetes
 resource names, or generic privileged controls.
 

--- a/docs/azents/spec/flow/agent-runtime-persistence.md
+++ b/docs/azents/spec/flow/agent-runtime-persistence.md
@@ -18,7 +18,7 @@ code_paths:
   - infra/charts/azents/**
   - infra/argocd/azents-runtime-provider-kubernetes/**
 last_verified_at: 2026-07-27
-spec_version: 7
+spec_version: 8
 ---
 
 # Agent Runtime Persistence
@@ -132,9 +132,13 @@ input. A Runtime may contain the Runner, policy gateway, and fixed engine compon
 Runner and nested workloads do not receive the Provider ServiceAccount, Provider credentials,
 Runtime Control credentials other than their Runtime-bound path, host sockets, or generic
 privileged controls. Agent Workspace PVC storage remains distinct from nested-engine storage.
-The current server capability gate exposes engine storage mode `none`; raw Provider registration
-metadata does not itself enable ephemeral storage. Persistent nested-engine storage also remains
-unavailable until a Provider advertises and qualifies bounded capacity.
+The Kubernetes Provider's typed Admin-accepted contract advertises image build, nested container
+run, Compose, ephemeral engine storage, and direct or disabled egress. Runtime policy resolution and
+the next immutable target snapshot use the Provider's current accepted contract rather than raw
+registration metadata or a prior snapshot's contract revision. The Provider adds the fixed gateway
+and privileged engine only when the effective policy requires them, keeps engine state in a bounded
+engine-only `emptyDir`, and applies a Runtime-specific NetworkPolicy. Persistent nested-engine
+storage remains unavailable until a Provider advertises and qualifies bounded persistent capacity.
 
 ## Docker Provider v1
 

--- a/docs/azents/spec/flow/test-strategy-e2e-primary.md
+++ b/docs/azents/spec/flow/test-strategy-e2e-primary.md
@@ -24,8 +24,8 @@ code_paths:
   - python/apps/azents-runtime-provider-docker/**
   - python/apps/azents-runtime-provider-kubernetes/**
   - python/apps/azents-runtime-runner/**
-last_verified_at: 2026-07-26
-spec_version: 11
+last_verified_at: 2026-07-27
+spec_version: 12
 ---
 
 # E2E Primary Test Strategy
@@ -135,11 +135,12 @@ Live workflow runs `live_external` E2E marker. If credential is missing in live 
 Agent Runtime Provider E2E follows the same policy. The focused required lane creates its System Docker Provider declaration through the trusted bootstrap source, enrolls it through the Admin and Public HTTP APIs, and passes only the issued credential to the Provider process. In required live Runtime Provider runs, missing or stale external provider prerequisites are treated as failures. Optional or nightly runs can report prerequisite-not-ready as a skip summary.
 
 Runtime Execution Profile E2E creates policy state through Admin/Public APIs only. It verifies
-typed unknown-field rejection, fail-closed unavailable capability, hierarchy reductions and
+typed unknown-field rejection, qualified engine-policy acceptance, hierarchy reductions and
 expansion rejection, save versus explicit Apply, idempotent Apply, automatic restrictive
-convergence, bounded audit/status projections, and response redaction. A Web Surface journey first
-uses an actual server projection and may use server-shaped response fixtures only for bounded
-presentation branches.
+convergence, bounded audit/status projections, and response redaction. Bound Runtime application
+still fails closed unless that Runtime's Provider has the required typed accepted contract. A Web
+Surface journey first uses an actual server projection and may use server-shaped response fixtures
+only for bounded presentation branches.
 
 Qualified Kubernetes execution-policy coverage is live evidence. Its prerequisite contract must
 distinguish unadvertised capability from advertised-but-unenforced privileged engine, CNI,

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/main.py
@@ -78,6 +78,21 @@ _CAPABILITY_CONTRACT: dict[str, JsonValue] = {
         "terminal_delete_destroys_workspace": True,
     },
     "configuration_fields": [],
+    "execution_policy": {
+        "schema_version": 1,
+        "supported_modules": [
+            {"module_id": "container.image_build", "version": 1},
+            {"module_id": "container.run", "version": 1},
+            {"module_id": "container.compose", "version": 1},
+            {"module_id": "container.resources", "version": 1},
+            {"module_id": "engine.storage", "version": 1},
+            {"module_id": "network.egress", "version": 1},
+        ],
+        "privileged_engine": True,
+        "storage_modes": ["none", "ephemeral"],
+        "network_modes": ["none", "direct"],
+        "resource_maxima": None,
+    },
 }
 
 

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_main_settings.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_main_settings.py
@@ -1,5 +1,7 @@
 """Runtime Provider settings tests."""
 
+# pyright: reportPrivateUsage=false
+
 import asyncio
 import dataclasses
 from datetime import datetime
@@ -309,3 +311,29 @@ def test_provider_settings_accepts_pod_image_pull_secrets(
     assert settings.image_pull_secrets == (
         LocalObjectReference(name="ecr-pull-secret"),
     )
+
+
+def test_capability_contract_declares_qualified_execution_support() -> None:
+    """Registration carries the exact execution authority Admin must accept."""
+    execution_policy = provider_main._CAPABILITY_CONTRACT["execution_policy"]
+
+    assert isinstance(execution_policy, dict)
+    assert execution_policy["privileged_engine"] is True
+    assert execution_policy["storage_modes"] == ["none", "ephemeral"]
+    assert execution_policy["network_modes"] == ["none", "direct"]
+    supported_modules = execution_policy["supported_modules"]
+    assert isinstance(supported_modules, list)
+    module_ids: list[str] = []
+    for module in supported_modules:
+        assert isinstance(module, dict)
+        module_id = module["module_id"]
+        assert isinstance(module_id, str)
+        module_ids.append(module_id)
+    assert set(module_ids) == {
+        "container.image_build",
+        "container.run",
+        "container.compose",
+        "container.resources",
+        "engine.storage",
+        "network.egress",
+    }

--- a/python/apps/azents/src/azents/core/runtime_provider_contract.py
+++ b/python/apps/azents/src/azents/core/runtime_provider_contract.py
@@ -8,6 +8,14 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from azents.core.runtime_execution_policy import (
+    RuntimeExecutionModuleSupport,
+    RuntimeExecutionNetworkMode,
+    RuntimeExecutionProviderCapabilities,
+    RuntimeExecutionResourceModule,
+    RuntimeExecutionStorageMode,
+)
+
 
 class RuntimeProviderPolicyScope(enum.StrEnum):
     """Policy layer at which a Provider contract accepts values."""
@@ -156,6 +164,19 @@ RuntimeProviderConfigField = Annotated[
 ]
 
 
+class RuntimeProviderExecutionPolicyContract(BaseModel):
+    """Typed execution-policy support declared by one Provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1]
+    supported_modules: set[RuntimeExecutionModuleSupport]
+    privileged_engine: bool
+    storage_modes: set[RuntimeExecutionStorageMode]
+    network_modes: set[RuntimeExecutionNetworkMode]
+    resource_maxima: RuntimeExecutionResourceModule | None
+
+
 class RuntimeProviderCapabilityContract(BaseModel):
     """Complete immutable capability proposal from one authenticated Provider."""
 
@@ -174,6 +195,7 @@ class RuntimeProviderCapabilityContract(BaseModel):
         default_factory=list,
         max_length=100,
     )
+    execution_policy: RuntimeProviderExecutionPolicyContract | None = None
 
     @model_validator(mode="after")
     def validate_contract(self) -> "RuntimeProviderCapabilityContract":
@@ -216,6 +238,21 @@ def canonicalize_runtime_provider_contract(
     canonical_json["optional_capabilities"] = sorted(
         canonical_json["optional_capabilities"]
     )
+    execution_policy = canonical_json.get("execution_policy")
+    if execution_policy is None:
+        # Preserve existing contract digests when this backwards-compatible
+        # capability section is absent.
+        del canonical_json["execution_policy"]
+    elif isinstance(execution_policy, dict):
+        supported_modules = execution_policy["supported_modules"]
+        if not isinstance(supported_modules, list):
+            raise AssertionError("Execution-policy module support must be a list.")
+        execution_policy["supported_modules"] = sorted(
+            supported_modules,
+            key=lambda item: (item["module_id"], item["version"]),
+        )
+        execution_policy["storage_modes"] = sorted(execution_policy["storage_modes"])
+        execution_policy["network_modes"] = sorted(execution_policy["network_modes"])
     encoded = json.dumps(
         canonical_json,
         sort_keys=True,
@@ -226,4 +263,26 @@ def canonicalize_runtime_provider_contract(
         contract=contract,
         canonical_json=canonical_json,
         digest=hashlib.sha256(encoded).hexdigest(),
+    )
+
+
+def runtime_execution_capabilities_from_provider_contract(
+    contract: RuntimeProviderCapabilityContract,
+) -> RuntimeExecutionProviderCapabilities:
+    """Project accepted Provider declarations into resolver capabilities."""
+    execution_policy = contract.execution_policy
+    if execution_policy is None:
+        return RuntimeExecutionProviderCapabilities(
+            supported_modules=frozenset(),
+            privileged_engine=False,
+            storage_modes=frozenset({RuntimeExecutionStorageMode.NONE}),
+            network_modes=frozenset({RuntimeExecutionNetworkMode.NONE}),
+            resource_maxima=None,
+        )
+    return RuntimeExecutionProviderCapabilities(
+        supported_modules=frozenset(execution_policy.supported_modules),
+        privileged_engine=execution_policy.privileged_engine,
+        storage_modes=frozenset(execution_policy.storage_modes),
+        network_modes=frozenset(execution_policy.network_modes),
+        resource_maxima=execution_policy.resource_maxima,
     )

--- a/python/apps/azents/src/azents/core/runtime_provider_contract_test.py
+++ b/python/apps/azents/src/azents/core/runtime_provider_contract_test.py
@@ -3,16 +3,23 @@
 import pytest
 from pydantic import ValidationError
 
+from azents.core.runtime_execution_policy import (
+    RuntimeExecutionModuleId,
+    RuntimeExecutionNetworkMode,
+    RuntimeExecutionStorageMode,
+)
 from azents.core.runtime_provider_contract import (
     RuntimeProviderApplicationImpact,
     RuntimeProviderCapabilityContract,
     RuntimeProviderConfigField,
+    RuntimeProviderExecutionPolicyContract,
     RuntimeProviderLifecycleOperation,
     RuntimeProviderPersistenceContract,
     RuntimeProviderPersistenceKind,
     RuntimeProviderPolicyScope,
     RuntimeProviderStringConfigField,
     canonicalize_runtime_provider_contract,
+    runtime_execution_capabilities_from_provider_contract,
 )
 
 _REQUIRED_OPERATIONS = set(RuntimeProviderLifecycleOperation)
@@ -82,3 +89,51 @@ def test_contract_canonicalization_produces_stable_digest() -> None:
     assert first.canonical_json == second.canonical_json
     assert first.digest == second.digest
     assert len(first.digest) == 64
+    assert "execution_policy" not in first.canonical_json
+
+
+def test_execution_policy_capabilities_are_typed_and_canonical() -> None:
+    """Execution support is stable contract authority rather than metadata."""
+    contract = _contract().model_copy(
+        update={
+            "execution_policy": RuntimeProviderExecutionPolicyContract.model_validate(
+                {
+                    "schema_version": 1,
+                    "supported_modules": [
+                        {"module_id": "container.run", "version": 1},
+                        {"module_id": "container.image_build", "version": 1},
+                    ],
+                    "privileged_engine": True,
+                    "storage_modes": ["ephemeral", "none"],
+                    "network_modes": ["none"],
+                    "resource_maxima": None,
+                }
+            )
+        }
+    )
+
+    canonical = canonicalize_runtime_provider_contract(contract)
+    capabilities = runtime_execution_capabilities_from_provider_contract(contract)
+
+    execution_policy = canonical.canonical_json["execution_policy"]
+    assert isinstance(execution_policy, dict)
+    assert execution_policy["supported_modules"] == [
+        {"module_id": "container.image_build", "version": 1},
+        {"module_id": "container.run", "version": 1},
+    ]
+    assert execution_policy["storage_modes"] == ["ephemeral", "none"]
+    assert capabilities.privileged_engine
+    assert {support.module_id for support in capabilities.supported_modules} == {
+        RuntimeExecutionModuleId.IMAGE_BUILD,
+        RuntimeExecutionModuleId.CONTAINER_RUN,
+    }
+
+
+def test_missing_execution_policy_contract_fails_closed() -> None:
+    """Legacy accepted contracts cannot grant nested-engine authority."""
+    capabilities = runtime_execution_capabilities_from_provider_contract(_contract())
+
+    assert not capabilities.privileged_engine
+    assert not capabilities.supported_modules
+    assert capabilities.storage_modes == {RuntimeExecutionStorageMode.NONE}
+    assert capabilities.network_modes == {RuntimeExecutionNetworkMode.NONE}

--- a/python/apps/azents/src/azents/runtime/control_server.py
+++ b/python/apps/azents/src/azents/runtime/control_server.py
@@ -152,6 +152,7 @@ async def runtime_control_server_lifespan(
         policy_repository=execution_policy_repository,
         snapshot_repository=policy_repository,
         runtime_repository=runtime_repository,
+        provider_repository=RuntimeProviderRepository(),
         agent_admin_repository=AgentAdminRepository(),
     )
     kubernetes_api_client: ApiClient | None = None

--- a/python/apps/azents/src/azents/services/runtime_execution_policy/application_service.py
+++ b/python/apps/azents/src/azents/services/runtime_execution_policy/application_service.py
@@ -6,12 +6,14 @@ import json
 from typing import Annotated
 
 from fastapi import Depends
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from azents.core.enums import (
     RuntimeDesiredState,
     RuntimeLifecycleCommandType,
     RuntimePolicySnapshotApplicationState,
+    RuntimeProviderContractStatus,
     WorkspaceUserRole,
 )
 from azents.core.runtime_execution_policy import (
@@ -23,7 +25,6 @@ from azents.core.runtime_execution_policy import (
     RuntimeExecutionChangeSummary,
     RuntimeExecutionManagementLayer,
     RuntimeExecutionModuleId,
-    RuntimeExecutionModuleSupport,
     RuntimeExecutionNetworkMode,
     RuntimeExecutionPolicyDocument,
     RuntimeExecutionPolicyLayer,
@@ -39,6 +40,10 @@ from azents.core.runtime_execution_policy import (
     empty_runtime_execution_restriction,
     resolve_runtime_execution_policy,
 )
+from azents.core.runtime_provider_contract import (
+    RuntimeProviderCapabilityContract,
+    runtime_execution_capabilities_from_provider_contract,
+)
 from azents.rdb.deps import get_session_manager
 from azents.rdb.session import SessionManager
 from azents.repos.agent_admin import AgentAdminRepository
@@ -50,6 +55,7 @@ from azents.repos.runtime_execution_policy.data import (
 from azents.repos.runtime_execution_policy.repository import (
     RuntimeExecutionPolicyRepository,
 )
+from azents.repos.runtime_provider.repository import RuntimeProviderRepository
 from azents.repos.runtime_provider_policy.data import (
     RuntimePolicySnapshot,
     RuntimePolicySnapshotCreate,
@@ -140,6 +146,8 @@ class _ResolvedRuntimePolicy:
     runtime: AgentRuntime
     target_snapshot: RuntimePolicySnapshot
     applied_snapshot: RuntimePolicySnapshot | None
+    accepted_contract_revision_id: str
+    provider_compatibility: dict[str, JsonValue]
     profile_id: str
     resolution: RuntimeExecutionResolution
 
@@ -171,6 +179,10 @@ class RuntimeExecutionPolicyApplicationService:
     runtime_repository: Annotated[
         AgentRuntimeRepository,
         Depends(AgentRuntimeRepository),
+    ]
+    provider_repository: Annotated[
+        RuntimeProviderRepository,
+        Depends(RuntimeProviderRepository),
     ]
     agent_admin_repository: Annotated[
         AgentAdminRepository,
@@ -339,15 +351,11 @@ class RuntimeExecutionPolicyApplicationService:
                     for reduction in resolved.resolution.reductions
                 ],
             }
-            provider_compatibility = {
-                "mode": "standard_only",
-                "authority_bearing_policy_supported": False,
-            }
         else:
             source_versions = _snapshot_source_versions(target)
             profile_id = target.execution_profile_id
             execution_source_trace = target.execution_source_trace
-            provider_compatibility = target.execution_provider_compatibility
+        provider_compatibility = resolved.provider_compatibility
 
         next_generation = resolved.runtime.desired_generation + 1
         canonical_policy = canonical_runtime_execution_policy(effective_policy)
@@ -359,7 +367,7 @@ class RuntimeExecutionPolicyApplicationService:
             create=RuntimePolicySnapshotCreate(
                 runtime_id=resolved.runtime.id,
                 provider_id=target.provider_id,
-                contract_revision_id=target.contract_revision_id,
+                contract_revision_id=resolved.accepted_contract_revision_id,
                 config_revision_id=target.config_revision_id,
                 override_provider_id=target.override_provider_id,
                 override_version=target.override_version,
@@ -544,6 +552,42 @@ class RuntimeExecutionPolicyApplicationService:
                 "runtime_provider_binding_missing",
                 agent_id,
             )
+        provider = await self.provider_repository.get_by_id(
+            session,
+            provider_id=runtime.runtime_provider_resource_id,
+            for_update=for_update,
+        )
+        if provider is None or provider.accepted_contract_revision_id is None:
+            raise RuntimeExecutionPolicyApplicationUnavailable(
+                "runtime_provider_contract_unaccepted",
+                runtime.runtime_provider_resource_id,
+            )
+        contract_revision = await self.snapshot_repository.get_contract_by_id(
+            session,
+            contract_revision_id=provider.accepted_contract_revision_id,
+            for_update=False,
+        )
+        if (
+            contract_revision is None
+            or contract_revision.provider_id != provider.id
+            or contract_revision.status is not RuntimeProviderContractStatus.ACCEPTED
+        ):
+            raise RuntimeExecutionPolicyApplicationUnavailable(
+                "runtime_provider_contract_unaccepted",
+                provider.id,
+            )
+        try:
+            provider_contract = RuntimeProviderCapabilityContract.model_validate(
+                contract_revision.contract
+            )
+        except ValidationError as error:
+            raise RuntimeExecutionPolicyApplicationUnavailable(
+                "runtime_provider_contract_invalid",
+                provider.id,
+            ) from error
+        provider_capabilities = runtime_execution_capabilities_from_provider_contract(
+            provider_contract
+        )
         platform = await self.policy_repository.get_platform(
             session,
             for_update=for_update,
@@ -588,6 +632,14 @@ class RuntimeExecutionPolicyApplicationService:
                 "runtime_policy_target_missing",
                 runtime.id,
             )
+        if (
+            target_snapshot.contract_revision_id != contract_revision.id
+            and target_snapshot.config_revision_id is not None
+        ):
+            raise RuntimeExecutionPolicyApplicationUnavailable(
+                "runtime_provider_configuration_contract_stale",
+                provider.id,
+            )
         applied_snapshot = None
         if runtime.applied_runtime_policy_snapshot_id is not None:
             applied_snapshot = await self.snapshot_repository.get_snapshot(
@@ -616,7 +668,7 @@ class RuntimeExecutionPolicyApplicationService:
                 workspace=workspace.version if workspace is not None else 1,
                 agent=setting.version,
             ),
-            provider_capabilities=_phase_three_provider_capabilities(),
+            provider_capabilities=provider_capabilities,
             profile_active=(
                 profile.lifecycle is RuntimeExecutionProfileLifecycle.ACTIVE
             ),
@@ -627,6 +679,12 @@ class RuntimeExecutionPolicyApplicationService:
             runtime=runtime,
             target_snapshot=target_snapshot,
             applied_snapshot=applied_snapshot,
+            accepted_contract_revision_id=contract_revision.id,
+            provider_compatibility=_provider_compatibility(
+                contract_revision_id=contract_revision.id,
+                contract_digest=contract_revision.digest,
+                capabilities=provider_capabilities,
+            ),
             profile_id=profile.id,
             resolution=resolution,
         )
@@ -648,6 +706,7 @@ class RuntimeExecutionPolicyApplicationService:
         execution_digest = digest_runtime_execution_policy(effective_policy)
         if _snapshot_matches_target(
             resolved.target_snapshot,
+            contract_revision_id=resolved.accepted_contract_revision_id,
             execution_digest=execution_digest,
             source_versions=source_versions,
             desired_generation=runtime.desired_generation,
@@ -670,7 +729,7 @@ class RuntimeExecutionPolicyApplicationService:
             create=RuntimePolicySnapshotCreate(
                 runtime_id=runtime.id,
                 provider_id=resolved.target_snapshot.provider_id,
-                contract_revision_id=resolved.target_snapshot.contract_revision_id,
+                contract_revision_id=resolved.accepted_contract_revision_id,
                 config_revision_id=resolved.target_snapshot.config_revision_id,
                 override_provider_id=resolved.target_snapshot.override_provider_id,
                 override_version=resolved.target_snapshot.override_version,
@@ -690,10 +749,7 @@ class RuntimeExecutionPolicyApplicationService:
                         for reduction in resolved.resolution.reductions
                     ],
                 },
-                execution_provider_compatibility={
-                    "mode": "standard_only",
-                    "authority_bearing_policy_supported": False,
-                },
+                execution_provider_compatibility=resolved.provider_compatibility,
                 execution_target_digest=execution_digest,
                 execution_reported_digest=None,
                 resolved_config=resolved.target_snapshot.resolved_config,
@@ -788,20 +844,6 @@ class RuntimeExecutionPolicyApplicationService:
         )
 
 
-def _phase_three_provider_capabilities() -> RuntimeExecutionProviderCapabilities:
-    """Expose only support that cannot grant Runtime authority in Phase 3."""
-    return RuntimeExecutionProviderCapabilities(
-        supported_modules=frozenset(
-            RuntimeExecutionModuleSupport(module_id=module_id, version=1)
-            for module_id in RuntimeExecutionModuleId
-        ),
-        privileged_engine=False,
-        storage_modes=frozenset({RuntimeExecutionStorageMode.NONE}),
-        network_modes=frozenset({RuntimeExecutionNetworkMode.NONE}),
-        resource_maxima=None,
-    )
-
-
 def _build_status_projection(
     resolved: _ResolvedRuntimePolicy,
 ) -> RuntimeExecutionPolicyStatusProjection:
@@ -847,6 +889,7 @@ def _build_status_projection(
 
     configured_matches_target = _snapshot_matches_target(
         resolved.target_snapshot,
+        contract_revision_id=resolved.accepted_contract_revision_id,
         execution_digest=resolution.digest,
         source_versions=resolution.source_versions,
         desired_generation=runtime.desired_generation,
@@ -1033,18 +1076,54 @@ def _snapshot_source_versions(
 def _snapshot_matches_target(
     snapshot: RuntimePolicySnapshot,
     *,
+    contract_revision_id: str,
     execution_digest: str,
     source_versions: RuntimeExecutionSourceVersions,
     desired_generation: int,
 ) -> bool:
     return (
-        snapshot.execution_target_digest == execution_digest
+        snapshot.contract_revision_id == contract_revision_id
+        and snapshot.execution_target_digest == execution_digest
         and snapshot.target_desired_generation == desired_generation
         and snapshot.execution_platform_version == source_versions.platform
         and snapshot.execution_profile_version == source_versions.profile
         and snapshot.execution_workspace_version == source_versions.workspace
         and snapshot.execution_agent_version == source_versions.agent
     )
+
+
+def _provider_compatibility(
+    *,
+    contract_revision_id: str,
+    contract_digest: str,
+    capabilities: RuntimeExecutionProviderCapabilities,
+) -> dict[str, JsonValue]:
+    """Build the safe accepted-contract evidence stored with a snapshot."""
+    supported_modules: list[JsonValue] = [
+        {
+            "module_id": support.module_id.value,
+            "version": support.version,
+        }
+        for support in sorted(
+            capabilities.supported_modules,
+            key=lambda item: (item.module_id.value, item.version),
+        )
+    ]
+    storage_modes: list[JsonValue] = [
+        mode.value for mode in sorted(capabilities.storage_modes)
+    ]
+    network_modes: list[JsonValue] = [
+        mode.value for mode in sorted(capabilities.network_modes)
+    ]
+    return {
+        "mode": "accepted_contract",
+        "contract_revision_id": contract_revision_id,
+        "contract_digest": contract_digest,
+        "authority_bearing_policy_supported": capabilities.privileged_engine,
+        "supported_modules": supported_modules,
+        "storage_modes": storage_modes,
+        "network_modes": network_modes,
+    }
 
 
 def _automatic_convergence_source_allowed(

--- a/python/apps/azents/src/azents/services/runtime_execution_policy/application_service_test.py
+++ b/python/apps/azents/src/azents/services/runtime_execution_policy/application_service_test.py
@@ -14,15 +14,19 @@ from azents.core.enums import (
     RuntimeDesiredState,
     RuntimeLifecycleCommandType,
     RuntimePolicySnapshotApplicationState,
+    RuntimeProviderContractStatus,
     WorkspaceUserRole,
 )
 from azents.core.runtime_execution_policy import (
     RuntimeExecutionBooleanModule,
     RuntimeExecutionChangeDirection,
     RuntimeExecutionModuleId,
+    RuntimeExecutionModuleSupport,
     RuntimeExecutionNetworkMode,
     RuntimeExecutionNetworkModule,
     RuntimeExecutionPolicyStatus,
+    RuntimeExecutionProfileLifecycle,
+    RuntimeExecutionProviderCapabilities,
     RuntimeExecutionRequiredAction,
     RuntimeExecutionSourceVersions,
     RuntimeExecutionStorageMode,
@@ -33,6 +37,11 @@ from azents.core.runtime_execution_policy import (
     standard_runtime_execution_policy,
 )
 from azents.repos.agent_runtime.data import AgentRuntime
+from azents.repos.runtime_execution_policy.data import (
+    AgentRuntimeExecutionSetting,
+    RuntimeExecutionPlatformPolicy,
+    RuntimeExecutionProfile,
+)
 from azents.repos.runtime_provider_policy.data import RuntimePolicySnapshot
 
 from .application_service import (
@@ -40,12 +49,25 @@ from .application_service import (
     RuntimeExecutionPolicyApplicationUnavailable,
     _automatic_convergence_source_allowed,
     _build_status_projection,
-    _phase_three_provider_capabilities,
     _ResolvedRuntimePolicy,
     _restrictive_projection,
 )
 
 _NOW = datetime.datetime.now(datetime.timezone.utc)
+
+
+def _legacy_provider_capabilities() -> RuntimeExecutionProviderCapabilities:
+    """Model the accepted pre-engine Provider boundary used by legacy tests."""
+    return RuntimeExecutionProviderCapabilities(
+        supported_modules=frozenset(
+            RuntimeExecutionModuleSupport(module_id=module_id, version=1)
+            for module_id in RuntimeExecutionModuleId
+        ),
+        privileged_engine=False,
+        storage_modes=frozenset({RuntimeExecutionStorageMode.NONE}),
+        network_modes=frozenset({RuntimeExecutionNetworkMode.NONE}),
+        resource_maxima=None,
+    )
 
 
 @asynccontextmanager
@@ -113,7 +135,7 @@ def _resolved() -> _ResolvedRuntimePolicy:
             workspace=3,
             agent=4,
         ),
-        provider_capabilities=_phase_three_provider_capabilities(),
+        provider_capabilities=_legacy_provider_capabilities(),
         profile_active=True,
         profile_allowed=True,
         applied_policy=None,
@@ -123,6 +145,11 @@ def _resolved() -> _ResolvedRuntimePolicy:
         runtime=_runtime(),
         target_snapshot=_snapshot(),
         applied_snapshot=None,
+        accepted_contract_revision_id="contract-1",
+        provider_compatibility={
+            "mode": "accepted_contract",
+            "contract_revision_id": "contract-1",
+        },
         profile_id="system-standard",
         resolution=resolution,
     )
@@ -141,7 +168,7 @@ def _unavailable_resolved() -> _ResolvedRuntimePolicy:
             workspace=3,
             agent=4,
         ),
-        provider_capabilities=_phase_three_provider_capabilities(),
+        provider_capabilities=_legacy_provider_capabilities(),
         profile_active=False,
         profile_allowed=True,
         applied_policy=policy,
@@ -238,7 +265,7 @@ def _upper_layer_change_resolved(
         workspace_restriction=empty_runtime_execution_restriction(),
         agent_restriction=empty_runtime_execution_restriction(),
         source_versions=source_versions,
-        provider_capabilities=_phase_three_provider_capabilities(),
+        provider_capabilities=_legacy_provider_capabilities(),
         profile_active=True,
         profile_allowed=True,
         applied_policy=baseline,
@@ -265,6 +292,11 @@ def _upper_layer_change_resolved(
         runtime=runtime,
         target_snapshot=target,
         applied_snapshot=target,
+        accepted_contract_revision_id="contract-1",
+        provider_compatibility={
+            "mode": "accepted_contract",
+            "contract_revision_id": "contract-1",
+        },
         profile_id="system-standard",
         resolution=resolution,
     )
@@ -409,6 +441,136 @@ def test_status_projection_marks_snapshot_divergence() -> None:
     assert status.reason_codes == ("target_divergent",)
 
 
+async def test_resolve_uses_current_accepted_contract_engine_capabilities() -> None:
+    """Runtime resolution consumes typed authority from the accepted contract."""
+    base = standard_runtime_execution_policy()
+    engine_policy = base.model_copy(
+        update={
+            "image_build": base.image_build.model_copy(update={"enabled": True}),
+            "container_run": base.container_run.model_copy(update={"enabled": True}),
+            "resources": base.resources.model_copy(
+                update={
+                    "cpu_millicores": 1_000,
+                    "memory_bytes": 1_073_741_824,
+                    "pids": 256,
+                    "container_count": 8,
+                    "ephemeral_storage_bytes": 8_589_934_592,
+                }
+            ),
+            "engine_storage": base.engine_storage.model_copy(
+                update={
+                    "mode": RuntimeExecutionStorageMode.EPHEMERAL,
+                    "capacity_bytes": 8_589_934_592,
+                }
+            ),
+        }
+    )
+    platform = RuntimeExecutionPlatformPolicy(
+        id="platform",
+        version=1,
+        policy=engine_policy,
+        digest=digest_runtime_execution_policy(engine_policy),
+        updated_by_user_id=None,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    profile = RuntimeExecutionProfile(
+        id="nested-engine",
+        display_name="Nested engine",
+        description="Qualified engine profile",
+        lifecycle=RuntimeExecutionProfileLifecycle.ACTIVE,
+        version=1,
+        policy=engine_policy,
+        digest=digest_runtime_execution_policy(engine_policy),
+        reserved=False,
+        system_key=None,
+        updated_by_user_id=None,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    setting = AgentRuntimeExecutionSetting(
+        agent_id="agent-1",
+        profile_id=profile.id,
+        version=1,
+        restriction=empty_runtime_execution_restriction(),
+        digest=digest_runtime_execution_policy(empty_runtime_execution_restriction()),
+        updated_by_workspace_user_id=None,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    provider = Mock()
+    provider.id = "provider-1"
+    provider.accepted_contract_revision_id = "contract-2"
+    contract_revision = Mock()
+    contract_revision.id = "contract-2"
+    contract_revision.provider_id = "provider-1"
+    contract_revision.digest = "c" * 64
+    contract_revision.status = RuntimeProviderContractStatus.ACCEPTED
+    contract_revision.contract = {
+        "schema_version": 1,
+        "implementation_key": "kubernetes",
+        "implementation_version": "0.1.0",
+        "protocol_version": "agent-runtime-provider-kubernetes-v1",
+        "core_lifecycle_operations": [
+            "start",
+            "stop",
+            "restart",
+            "reset",
+            "observe",
+            "terminal_delete",
+        ],
+        "optional_capabilities": ["execution_policy_v1"],
+        "persistence": {
+            "kind": "persistent",
+            "reset_destroys_workspace": True,
+            "terminal_delete_destroys_workspace": True,
+        },
+        "configuration_fields": [],
+        "execution_policy": {
+            "schema_version": 1,
+            "supported_modules": [
+                {"module_id": module_id.value, "version": 1}
+                for module_id in RuntimeExecutionModuleId
+            ],
+            "privileged_engine": True,
+            "storage_modes": ["none", "ephemeral"],
+            "network_modes": ["none", "direct"],
+            "resource_maxima": None,
+        },
+    }
+    policy_repository = Mock()
+    workspace = Mock()
+    workspace.restriction = empty_runtime_execution_restriction()
+    workspace.allowed_profile_ids = frozenset({profile.id})
+    workspace.version = 1
+    policy_repository.get_platform = AsyncMock(return_value=platform)
+    policy_repository.get_agent_setting = AsyncMock(return_value=setting)
+    policy_repository.get_workspace = AsyncMock(return_value=workspace)
+    policy_repository.get_profile = AsyncMock(return_value=profile)
+    snapshot_repository = Mock()
+    snapshot_repository.get_contract_by_id = AsyncMock(return_value=contract_revision)
+    snapshot_repository.get_snapshot = AsyncMock(return_value=_snapshot())
+    runtime_repository = Mock()
+    runtime_repository.get_by_agent_id = AsyncMock(return_value=_runtime())
+    provider_repository = Mock()
+    provider_repository.get_by_id = AsyncMock(return_value=provider)
+    service = RuntimeExecutionPolicyApplicationService(
+        session_manager=_session_manager,
+        policy_repository=policy_repository,
+        snapshot_repository=snapshot_repository,
+        runtime_repository=runtime_repository,
+        provider_repository=provider_repository,
+        agent_admin_repository=Mock(),
+    )
+
+    resolved = await service._resolve_read(Mock(), agent_id="agent-1")
+
+    assert resolved.resolution.available
+    assert resolved.accepted_contract_revision_id == "contract-2"
+    assert resolved.provider_compatibility["authority_bearing_policy_supported"]
+    assert resolved.provider_compatibility["network_modes"] == ["direct", "none"]
+
+
 async def test_status_read_uses_read_resolver_without_target_mutation() -> None:
     """Status reads never call target creation or convergence paths."""
     snapshot_repository = Mock()
@@ -420,6 +582,7 @@ async def test_status_read_uses_read_resolver_without_target_mutation() -> None:
         policy_repository=policy_repository,
         snapshot_repository=snapshot_repository,
         runtime_repository=Mock(),
+        provider_repository=Mock(),
         agent_admin_repository=Mock(),
     )
     service._resolve_read = AsyncMock(return_value=_resolved())
@@ -442,6 +605,7 @@ async def test_apply_requires_existing_agent_management_authority() -> None:
         policy_repository=policy_repository,
         snapshot_repository=Mock(),
         runtime_repository=Mock(),
+        provider_repository=Mock(),
         agent_admin_repository=agent_admin_repository,
     )
 
@@ -478,9 +642,17 @@ async def test_explicit_apply_creates_next_generation_target_atomically() -> Non
         policy_repository=policy_repository,
         snapshot_repository=snapshot_repository,
         runtime_repository=Mock(),
+        provider_repository=Mock(),
         agent_admin_repository=Mock(),
     )
-    resolved = _resolved()
+    resolved = dataclasses.replace(
+        _resolved(),
+        accepted_contract_revision_id="contract-2",
+        provider_compatibility={
+            "mode": "accepted_contract",
+            "contract_revision_id": "contract-2",
+        },
+    )
 
     result = await service._target_resolution(
         Mock(),
@@ -496,6 +668,10 @@ async def test_explicit_apply_creates_next_generation_target_atomically() -> Non
     assert result.created
     call = snapshot_repository.create_and_advance_target_snapshot.await_args
     assert call.kwargs["create"].target_desired_generation == 3
+    assert call.kwargs["create"].contract_revision_id == "contract-2"
+    assert call.kwargs["create"].execution_provider_compatibility == (
+        resolved.provider_compatibility
+    )
     assert call.kwargs["expected_target_snapshot_id"] == "snapshot-1"
     assert call.kwargs["lifecycle_command"] is RuntimeLifecycleCommandType.RESTART
     policy_repository.append_audit_event.assert_awaited_once()
@@ -528,6 +704,7 @@ async def test_terminal_delete_targets_next_generation_with_bound_snapshot() -> 
         policy_repository=Mock(),
         snapshot_repository=snapshot_repository,
         runtime_repository=runtime_repository,
+        provider_repository=Mock(),
         agent_admin_repository=Mock(),
     )
     service._resolve_locked = AsyncMock(return_value=resolved)
@@ -572,6 +749,7 @@ async def test_terminal_delete_retry_reuses_current_generation() -> None:
         policy_repository=Mock(),
         snapshot_repository=snapshot_repository,
         runtime_repository=Mock(),
+        provider_repository=Mock(),
         agent_admin_repository=Mock(),
     )
     service._resolve_locked = AsyncMock(return_value=resolved)
@@ -655,6 +833,7 @@ async def test_incompatible_convergence_stops_with_a_new_exact_target() -> None:
         policy_repository=policy_repository,
         snapshot_repository=snapshot_repository,
         runtime_repository=runtime_repository,
+        provider_repository=Mock(),
         agent_admin_repository=Mock(),
     )
     service._resolve_locked = AsyncMock(return_value=resolved)
@@ -694,6 +873,7 @@ async def test_unavailable_agent_intent_change_remains_pending_apply() -> None:
         policy_repository=policy_repository,
         snapshot_repository=snapshot_repository,
         runtime_repository=runtime_repository,
+        provider_repository=Mock(),
         agent_admin_repository=Mock(),
     )
     service._resolve_locked = AsyncMock(return_value=resolved)
@@ -737,8 +917,8 @@ def test_mixed_convergence_copies_only_restrictive_fields() -> None:
     assert projected.network_egress.mode is RuntimeExecutionNetworkMode.NONE
 
 
-def test_phase_three_capabilities_cannot_grant_engine_or_network_authority() -> None:
-    capabilities = _phase_three_provider_capabilities()
+def test_legacy_capabilities_cannot_grant_engine_or_network_authority() -> None:
+    capabilities = _legacy_provider_capabilities()
 
     assert not capabilities.privileged_engine
     assert capabilities.storage_modes == {RuntimeExecutionStorageMode.NONE}

--- a/python/apps/azents/src/azents/services/runtime_execution_policy/service.py
+++ b/python/apps/azents/src/azents/services/runtime_execution_policy/service.py
@@ -1257,15 +1257,25 @@ def _string_set(value: JsonValue) -> set[str]:
 
 
 def _validation_provider_capabilities() -> RuntimeExecutionProviderCapabilities:
-    """Return only capability support backed by the current implementation."""
+    """Return the installation capability ceiling backed by qualified Providers."""
     return RuntimeExecutionProviderCapabilities(
         supported_modules=frozenset(
             RuntimeExecutionModuleSupport(module_id=module_id, version=1)
             for module_id in RuntimeExecutionModuleId
         ),
-        privileged_engine=False,
-        storage_modes=frozenset({RuntimeExecutionStorageMode.NONE}),
-        network_modes=frozenset({RuntimeExecutionNetworkMode.NONE}),
+        privileged_engine=True,
+        storage_modes=frozenset(
+            {
+                RuntimeExecutionStorageMode.NONE,
+                RuntimeExecutionStorageMode.EPHEMERAL,
+            }
+        ),
+        network_modes=frozenset(
+            {
+                RuntimeExecutionNetworkMode.NONE,
+                RuntimeExecutionNetworkMode.DIRECT,
+            }
+        ),
         resource_maxima=None,
     )
 

--- a/python/apps/azents/src/azents/services/runtime_execution_policy/service_test.py
+++ b/python/apps/azents/src/azents/services/runtime_execution_policy/service_test.py
@@ -13,12 +13,12 @@ from azents.core.enums import WorkspaceUserRole
 from azents.core.runtime_execution_policy import (
     RUNTIME_EXECUTION_PLATFORM_POLICY_ID,
     SYSTEM_STANDARD_PROFILE_ID,
-    RuntimeExecutionAvailabilityReason,
     RuntimeExecutionBooleanModule,
     RuntimeExecutionBooleanRestriction,
     RuntimeExecutionChangeDirection,
     RuntimeExecutionManagementLayer,
     RuntimeExecutionModuleId,
+    RuntimeExecutionNetworkMode,
     RuntimeExecutionPolicyDocument,
     RuntimeExecutionPolicyRestriction,
     RuntimeExecutionProfileLifecycle,
@@ -337,8 +337,8 @@ async def test_agent_cannot_newly_select_workspace_disallowed_profile() -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_cannot_newly_select_capability_unavailable_profile() -> None:
-    """An unsupported Profile cannot become a new Agent selection."""
+async def test_agent_can_select_qualified_nested_engine_profile() -> None:
+    """A qualified nested-engine Profile can become a new Agent selection."""
     restriction = empty_runtime_execution_restriction()
     current = AgentRuntimeExecutionSetting(
         agent_id="agent-1",
@@ -350,16 +350,16 @@ async def test_agent_cannot_newly_select_capability_unavailable_profile() -> Non
         created_at=_NOW,
         updated_at=_NOW,
     )
-    unsupported_policy = _expanded_standard()
-    unsupported = dataclasses.replace(
+    supported_policy = _expanded_standard()
+    supported = dataclasses.replace(
         _profile(reserved=False, profile_id="nested-engine"),
-        policy=unsupported_policy,
-        digest=digest_runtime_execution_policy(unsupported_policy),
+        policy=supported_policy,
+        digest=digest_runtime_execution_policy(supported_policy),
     )
     repository = Mock(spec=RuntimeExecutionPolicyRepository)
     repository.get_agent_setting = AsyncMock(return_value=current)
     repository.get_agent_workspace_id = AsyncMock(return_value="workspace-1")
-    repository.get_profile = AsyncMock(return_value=unsupported)
+    repository.get_profile = AsyncMock(return_value=supported)
     repository.get_platform = AsyncMock(return_value=_platform())
     repository.get_workspace = AsyncMock(
         return_value=_workspace(
@@ -373,20 +373,19 @@ async def test_agent_cannot_newly_select_capability_unavailable_profile() -> Non
     repository.append_audit_event = AsyncMock()
     service = _service(repository)
 
-    with pytest.raises(RuntimeExecutionPolicyUnavailable, match="profile_unavailable"):
-        await service.replace_agent_setting(
-            "agent-1",
-            AgentRuntimeExecutionSettingMutation(
-                expected_version=1,
-                profile_id="nested-engine",
-                restriction=restriction,
-                actor_workspace_user_id="workspace-user-1",
-                correlation_id="correlation-1",
-            ),
-        )
+    await service.replace_agent_setting(
+        "agent-1",
+        AgentRuntimeExecutionSettingMutation(
+            expected_version=1,
+            profile_id="nested-engine",
+            restriction=restriction,
+            actor_workspace_user_id="workspace-user-1",
+            correlation_id="correlation-1",
+        ),
+    )
 
-    repository.replace_agent_setting.assert_not_awaited()
-    repository.append_audit_event.assert_not_awaited()
+    repository.replace_agent_setting.assert_awaited_once()
+    repository.append_audit_event.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -684,7 +683,7 @@ async def test_agent_policy_read_rejects_non_admin_workspace_manager() -> None:
 
 @pytest.mark.asyncio
 async def test_agent_admin_receives_current_server_capability_evaluation() -> None:
-    """Agent administrators receive the current conservative compatibility gate."""
+    """Agent administrators receive the qualified installation capability gate."""
     restriction = empty_runtime_execution_restriction()
     setting = AgentRuntimeExecutionSetting(
         agent_id="agent-1",
@@ -716,109 +715,120 @@ async def test_agent_admin_receives_current_server_capability_evaluation() -> No
     assert policy.setting == setting
     assert policy.resolution.available
     assert policy.provider_compatibility_evaluated is True
-    assert not policy.capabilities.image_build
-    assert not policy.capabilities.container_run
-    assert not policy.capabilities.compose
-    assert policy.capabilities.storage_modes == (RuntimeExecutionStorageMode.NONE,)
+    assert policy.capabilities.image_build
+    assert policy.capabilities.container_run
+    assert policy.capabilities.compose
+    assert policy.capabilities.storage_modes == (
+        RuntimeExecutionStorageMode.EPHEMERAL,
+        RuntimeExecutionStorageMode.NONE,
+    )
+    assert policy.capabilities.network_modes == (
+        RuntimeExecutionNetworkMode.DIRECT,
+        RuntimeExecutionNetworkMode.NONE,
+    )
 
 
 @pytest.mark.asyncio
-async def test_platform_write_rejects_unavailable_engine_authority() -> None:
-    """Platform policy cannot store authority without compatible enforcement."""
+async def test_platform_write_accepts_qualified_engine_authority() -> None:
+    """Platform policy can store authority backed by qualified enforcement."""
     repository = Mock(spec=RuntimeExecutionPolicyRepository)
-    repository.get_platform = AsyncMock()
-    repository.replace_platform = AsyncMock()
+    current = _platform()
+    updated = dataclasses.replace(
+        current,
+        version=2,
+        policy=_expanded_standard(),
+        digest=digest_runtime_execution_policy(_expanded_standard()),
+    )
+    repository.get_platform = AsyncMock(return_value=current)
+    repository.replace_platform = AsyncMock(return_value=updated)
     repository.append_audit_event = AsyncMock()
     service = _service(repository)
 
-    with pytest.raises(
-        RuntimeExecutionPolicyUnavailable,
-        match="provider_engine_unsupported",
-    ):
-        await service.replace_platform(
-            RuntimeExecutionPlatformMutation(
-                expected_version=1,
-                policy=_expanded_standard(),
-                actor_user_id="user-1",
-                correlation_id="correlation-1",
-            )
-        )
-
-    repository.get_platform.assert_not_awaited()
-    repository.replace_platform.assert_not_awaited()
-    repository.append_audit_event.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_profile_create_rejects_unavailable_engine_authority() -> None:
-    """Profiles cannot store authority without compatible enforcement."""
-    repository = Mock(spec=RuntimeExecutionPolicyRepository)
-    repository.create_profile = AsyncMock()
-    repository.append_audit_event = AsyncMock()
-    service = _service(repository)
-
-    with pytest.raises(
-        RuntimeExecutionPolicyUnavailable,
-        match="provider_engine_unsupported",
-    ):
-        await service.create_profile(
-            profile_id="nested-engine",
-            display_name="Nested engine",
-            description="Unavailable authority",
+    result = await service.replace_platform(
+        RuntimeExecutionPlatformMutation(
+            expected_version=1,
             policy=_expanded_standard(),
             actor_user_id="user-1",
             correlation_id="correlation-1",
         )
+    )
 
-    repository.create_profile.assert_not_awaited()
-    repository.append_audit_event.assert_not_awaited()
+    assert result is updated
+    repository.replace_platform.assert_awaited_once()
+    repository.append_audit_event.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_workspace_cannot_save_unavailable_profile_allowance() -> None:
-    """Workspace policy cannot newly allow an unsupported Profile."""
+async def test_profile_create_accepts_qualified_engine_authority() -> None:
+    """Profiles can store authority backed by qualified enforcement."""
+    repository = Mock(spec=RuntimeExecutionPolicyRepository)
+    created = dataclasses.replace(
+        _profile(reserved=False, profile_id="nested-engine"),
+        policy=_expanded_standard(),
+        digest=digest_runtime_execution_policy(_expanded_standard()),
+    )
+    repository.create_profile = AsyncMock(return_value=created)
+    repository.append_audit_event = AsyncMock()
+    service = _service(repository)
+
+    result = await service.create_profile(
+        profile_id="nested-engine",
+        display_name="Nested engine",
+        description="Qualified authority",
+        policy=_expanded_standard(),
+        actor_user_id="user-1",
+        correlation_id="correlation-1",
+    )
+
+    assert result is created
+    repository.create_profile.assert_awaited_once()
+    repository.append_audit_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_workspace_can_allow_qualified_engine_profile() -> None:
+    """Workspace policy can allow a qualified engine Profile."""
     restriction = empty_runtime_execution_restriction()
     allowed = frozenset({SYSTEM_STANDARD_PROFILE_ID, "nested-engine"})
-    unsupported_policy = _expanded_standard()
-    unsupported = dataclasses.replace(
+    supported_policy = _expanded_standard()
+    supported = dataclasses.replace(
         _profile(reserved=False, profile_id="nested-engine"),
-        policy=unsupported_policy,
-        digest=digest_runtime_execution_policy(unsupported_policy),
+        policy=supported_policy,
+        digest=digest_runtime_execution_policy(supported_policy),
     )
     repository = Mock(spec=RuntimeExecutionPolicyRepository)
     repository.get_workspace = AsyncMock(return_value=None)
     repository.get_platform = AsyncMock(return_value=_platform())
     repository.list_profiles = AsyncMock(
-        return_value=[_profile(reserved=True), unsupported]
+        return_value=[_profile(reserved=True), supported]
     )
     repository.replace_workspace = AsyncMock()
     repository.append_audit_event = AsyncMock()
     service = _service(repository)
 
-    with pytest.raises(RuntimeExecutionPolicyUnavailable, match="profile_unavailable"):
-        await service.replace_workspace(
-            "workspace-1",
-            WorkspaceRuntimeExecutionPolicyMutation(
-                expected_version=0,
-                restriction=restriction,
-                allowed_profile_ids=allowed,
-                actor_workspace_user_id="workspace-user-1",
-                correlation_id="correlation-1",
-            ),
-        )
+    await service.replace_workspace(
+        "workspace-1",
+        WorkspaceRuntimeExecutionPolicyMutation(
+            expected_version=0,
+            restriction=restriction,
+            allowed_profile_ids=allowed,
+            actor_workspace_user_id="workspace-user-1",
+            correlation_id="correlation-1",
+        ),
+    )
 
-    repository.replace_workspace.assert_not_awaited()
-    repository.append_audit_event.assert_not_awaited()
+    repository.replace_workspace.assert_awaited_once()
+    repository.append_audit_event.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_workspace_profile_list_marks_unsupported_authority_unavailable() -> None:
-    """Workspace availability is derived from the server capability gate."""
-    unsupported_policy = _expanded_standard()
-    unsupported = dataclasses.replace(
+async def test_workspace_profile_list_marks_qualified_authority_available() -> None:
+    """Workspace availability is derived from the qualified capability gate."""
+    supported_policy = _expanded_standard()
+    supported = dataclasses.replace(
         _profile(reserved=False, profile_id="nested-engine"),
-        policy=unsupported_policy,
-        digest=digest_runtime_execution_policy(unsupported_policy),
+        policy=supported_policy,
+        digest=digest_runtime_execution_policy(supported_policy),
     )
     repository = Mock(spec=RuntimeExecutionPolicyRepository)
     repository.get_workspace = AsyncMock(
@@ -827,7 +837,7 @@ async def test_workspace_profile_list_marks_unsupported_authority_unavailable() 
             restriction=empty_runtime_execution_restriction(),
         )
     )
-    repository.list_profiles = AsyncMock(return_value=[unsupported])
+    repository.list_profiles = AsyncMock(return_value=[supported])
     service = _service(repository)
 
     profiles = await service.list_workspace_profiles(
@@ -838,8 +848,5 @@ async def test_workspace_profile_list_marks_unsupported_authority_unavailable() 
     )
 
     assert len(profiles) == 1
-    assert not profiles[0].available
-    assert (
-        profiles[0].reason
-        is RuntimeExecutionAvailabilityReason.PROVIDER_ENGINE_UNSUPPORTED
-    )
+    assert profiles[0].available
+    assert profiles[0].reason is None

--- a/testenv/azents/e2e/src/tests/azents/public/test_runtime_execution_policy.py
+++ b/testenv/azents/e2e/src/tests/azents/public/test_runtime_execution_policy.py
@@ -245,11 +245,11 @@ def _create_standard_profile(
     return profile_id
 
 
-def test_capability_gate_and_typed_policy_fail_closed(
+def test_capability_gate_accepts_qualified_typed_policy(
     azents_admin_server_url: str,
     system_bootstrap_evidence: SystemBootstrapEvidence,
 ) -> None:
-    """Reject unknown and authority-bearing policy without weaker fallback."""
+    """Reject unknown fields and accept qualified typed engine authority."""
     token = system_bootstrap_evidence.access_token
     platform = _request_object(
         "GET",
@@ -263,11 +263,11 @@ def test_capability_gate_and_typed_policy_fail_closed(
         known_sensitive_values=_known_sensitive_values(token),
     )
     assert capabilities == {
-        "image_build": False,
-        "container_run": False,
-        "compose": False,
-        "storage_modes": ["none"],
-        "network_modes": ["none"],
+        "image_build": True,
+        "container_run": True,
+        "compose": True,
+        "storage_modes": ["ephemeral", "none"],
+        "network_modes": ["direct", "none"],
     }
     standard_policy = _JSON_OBJECT.validate_python(platform["policy"])
 
@@ -306,11 +306,11 @@ def test_capability_gate_and_typed_policy_fail_closed(
         "mode": "ephemeral",
         "capacity_bytes": 1073741824,
     }
-    rejected = _request_object(
+    created = _request_object(
         "POST",
         f"{azents_admin_server_url}/runtime-execution/v1/profiles",
         token=token,
-        expected_status=409,
+        expected_status=201,
         body={
             "profile_id": f"authority-{unique()}",
             "display_name": "Authority request",
@@ -319,10 +319,10 @@ def test_capability_gate_and_typed_policy_fail_closed(
         },
     )
     _assert_safe_projection(
-        rejected,
+        created,
         known_sensitive_values=_known_sensitive_values(token),
     )
-    assert rejected == {"detail": {"code": "provider_engine_unsupported"}}
+    assert created["policy"] == authority_policy
 
 
 @pytest.mark.runtime_provider


### PR DESCRIPTION
## What changed

- add a typed execution-policy capability section to immutable Runtime Provider contracts
- resolve Runtime policy against the bound Provider current accepted contract and carry that revision into new snapshots
- advertise the qualified Kubernetes gateway plus DinD engine topology for image build, nested container run, Compose, ephemeral engine storage, and direct or disabled egress
- enable the Admin management capability gate while preserving fail-closed behavior for legacy or unaccepted contracts
- update deterministic tests, E2E expectations, and living specs

## Why

The Kubernetes Provider already implemented the fixed policy gateway and engine sidecars, but product capability validation was hardcoded off and Runtime application reused the previous snapshot contract. As a result, Admin controls remained disabled and no accepted contract could authorize the implementation.

This change makes the accepted immutable contract the authority boundary. Legacy contracts remain baseline-only, and a changed contract requires explicit Admin acceptance and explicit Agent Apply before authority expands.

## Validation

- backend full pytest, Ruff, and Pyright
- Kubernetes Provider: 71 tests, Ruff, and Pyright
- container policy gateway: 136 tests with TMPDIR=/tmp, Ruff, and Pyright
- Runtime execution E2E Ruff, Pyright, and collection
- pre-commit hooks

## Rollout

This is stage 1. After all CI checks pass, merge manually and deploy, then accept the new Kubernetes Provider contract. A follow-up stage changes the installation default network mode to direct so existing installations never become incompatible before the capability contract is accepted.
