### PR TITLE
fix(admin): standardize responsive master-detail layouts

### DIFF
--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPageContent.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPageContent.tsx
@@ -3,9 +3,9 @@
 import {
   Alert,
   Badge,
+  Box,
   Button,
   Code,
-  Divider,
   Group,
   Loader,
   Modal,
@@ -18,6 +18,7 @@ import {
   TextInput,
   Title,
 } from "@mantine/core";
+import { MasterDetailLayout } from "@/shared/components/MasterDetailLayout";
 import { isRuntimeExecutionPolicySupported } from "../runtimeExecutionPresentation";
 import { RuntimeExecutionPolicyEditor } from "./RuntimeExecutionPolicyEditor";
 import type {
@@ -143,6 +144,7 @@ export function RuntimeExecutionPageContent({
   platformDraft,
   profileDraft,
   selectedProfileId,
+  profileDetailOpen,
   profileModalOpened,
   savingPlatform,
   savingProfile,
@@ -151,6 +153,7 @@ export function RuntimeExecutionPageContent({
   onPlatformDraftChange,
   onSavePlatform,
   onSelectProfile,
+  onProfileDetailClose,
   onProfileDraftChange,
   onOpenCreateProfile,
   onCloseProfileModal,
@@ -160,7 +163,7 @@ export function RuntimeExecutionPageContent({
   const capabilities =
     state.type === "LOADED" ? state.platform.capabilities : null;
   return (
-    <Stack gap="lg" p="md">
+    <Box h="100%" display="flex" style={{ flexDirection: "column" }}>
       <Modal
         opened={profileModalOpened}
         onClose={onCloseProfileModal}
@@ -181,22 +184,34 @@ export function RuntimeExecutionPageContent({
         )}
       </Modal>
 
-      <Stack gap={4}>
+      <Stack gap={4} p="md">
         <Title order={2}>Runtime Execution</Title>
         <Text c="dimmed">
           Manage installation limits, reusable Profiles, and safe policy audit
           history.
         </Text>
       </Stack>
-      {actionError && (
-        <Alert color="red" title="Action failed">
-          {actionError}
-        </Alert>
-      )}
-      {state.type === "LOADING" && <Loader />}
-      {state.type === "ERROR" && <Alert color="red">{state.message}</Alert>}
+      <Stack gap="sm" px="md">
+        {actionError && (
+          <Alert color="red" title="Action failed">
+            {actionError}
+          </Alert>
+        )}
+        {state.type === "LOADING" && <Loader />}
+        {state.type === "ERROR" && <Alert color="red">{state.message}</Alert>}
+      </Stack>
       {state.type === "LOADED" && (
-        <Tabs defaultValue="platform">
+        <Tabs
+          defaultValue={profileDetailOpen ? "profiles" : "platform"}
+          px="md"
+          pb="md"
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
           <Tabs.List>
             <Tabs.Tab value="platform">Platform limits</Tabs.Tab>
             <Tabs.Tab value="profiles">
@@ -207,7 +222,11 @@ export function RuntimeExecutionPageContent({
             </Tabs.Tab>
           </Tabs.List>
 
-          <Tabs.Panel value="platform" pt="lg">
+          <Tabs.Panel
+            value="platform"
+            pt="lg"
+            style={{ flex: 1, minHeight: 0, overflow: "auto" }}
+          >
             <Stack gap="md">
               <Group justify="space-between" align="flex-start">
                 <Stack gap={2}>
@@ -241,70 +260,86 @@ export function RuntimeExecutionPageContent({
             </Stack>
           </Tabs.Panel>
 
-          <Tabs.Panel value="profiles" pt="lg">
-            <Group align="stretch" gap={0} wrap="nowrap">
-              <ScrollArea w={{ base: 240, sm: 320 }} type="auto">
-                <Stack gap="xs" pr="md">
-                  <Button variant="light" onClick={onOpenCreateProfile}>
-                    Create Profile
-                  </Button>
-                  {state.profiles.map((profile) => (
-                    <Paper
-                      key={profile.id}
-                      withBorder
-                      p="sm"
-                      radius="sm"
-                      bg={
-                        profile.id === selectedProfileId
-                          ? "var(--mantine-color-blue-light)"
-                          : "transparent"
-                      }
-                      style={{ cursor: "pointer" }}
-                      onClick={() => onSelectProfile(profile.id)}
-                    >
-                      <Stack gap={3}>
-                        <Group justify="space-between" wrap="nowrap">
-                          <Text fw={600} truncate>
-                            {profile.display_name}
+          <Tabs.Panel
+            value="profiles"
+            pt="lg"
+            style={{ flex: 1, minHeight: 0 }}
+          >
+            <MasterDetailLayout
+              columns="1fr 2fr"
+              master={
+                <ScrollArea h="100%" p="sm" type="auto">
+                  <Stack gap="xs">
+                    <Button variant="light" onClick={onOpenCreateProfile}>
+                      Create Profile
+                    </Button>
+                    {state.profiles.map((profile) => (
+                      <Paper
+                        key={profile.id}
+                        withBorder
+                        p="sm"
+                        radius="sm"
+                        bg={
+                          profile.id === selectedProfileId
+                            ? "var(--mantine-color-blue-light)"
+                            : "transparent"
+                        }
+                        style={{ cursor: "pointer" }}
+                        onClick={() => onSelectProfile(profile.id)}
+                      >
+                        <Stack gap={3}>
+                          <Group justify="space-between" wrap="nowrap">
+                            <Text fw={600} truncate>
+                              {profile.display_name}
+                            </Text>
+                            <Badge
+                              color={
+                                profile.lifecycle === "active"
+                                  ? "green"
+                                  : "gray"
+                              }
+                              variant="light"
+                            >
+                              {profile.lifecycle}
+                            </Badge>
+                          </Group>
+                          <Text size="xs" c="dimmed">
+                            v{profile.version} · {profile.id}
                           </Text>
-                          <Badge
-                            color={
-                              profile.lifecycle === "active" ? "green" : "gray"
-                            }
-                            variant="light"
-                          >
-                            {profile.lifecycle}
-                          </Badge>
-                        </Group>
-                        <Text size="xs" c="dimmed">
-                          v{profile.version} · {profile.id}
-                        </Text>
-                      </Stack>
-                    </Paper>
-                  ))}
+                        </Stack>
+                      </Paper>
+                    ))}
+                  </Stack>
+                </ScrollArea>
+              }
+              detail={
+                <Stack p={{ base: "md", sm: "xl" }}>
+                  {profileDraft ? (
+                    <ProfileEditor
+                      draft={profileDraft}
+                      creating={false}
+                      saving={savingProfile}
+                      retiring={retiringProfile}
+                      capabilities={state.platform.capabilities}
+                      onChange={onProfileDraftChange}
+                      onSave={onSaveProfile}
+                      onRetire={onRetireProfile}
+                    />
+                  ) : (
+                    <Alert color="yellow">No Profiles are available.</Alert>
+                  )}
                 </Stack>
-              </ScrollArea>
-              <Divider orientation="vertical" />
-              <Stack pl="xl" style={{ flex: 1, minWidth: 0 }}>
-                {profileDraft ? (
-                  <ProfileEditor
-                    draft={profileDraft}
-                    creating={false}
-                    saving={savingProfile}
-                    retiring={retiringProfile}
-                    capabilities={state.platform.capabilities}
-                    onChange={onProfileDraftChange}
-                    onSave={onSaveProfile}
-                    onRetire={onRetireProfile}
-                  />
-                ) : (
-                  <Alert color="yellow">No Profiles are available.</Alert>
-                )}
-              </Stack>
-            </Group>
+              }
+              detailOpen={profileDetailOpen}
+              onDetailClose={onProfileDetailClose}
+            />
           </Tabs.Panel>
 
-          <Tabs.Panel value="audit" pt="lg">
+          <Tabs.Panel
+            value="audit"
+            pt="lg"
+            style={{ flex: 1, minHeight: 0, overflow: "auto" }}
+          >
             <Stack gap="sm">
               {state.auditEvents.length === 0 && (
                 <Alert color="yellow">No Runtime Execution audit events.</Alert>
@@ -335,6 +370,6 @@ export function RuntimeExecutionPageContent({
           </Tabs.Panel>
         </Tabs>
       )}
-    </Stack>
+    </Box>
   );
 }

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/containers/useRuntimeExecutionContainer.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/containers/useRuntimeExecutionContainer.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { serializers, useQueryState } from "@/hooks/use-query-state";
 import { trpc } from "@/trpc/client";
 import { isRuntimeExecutionPolicySupported } from "../runtimeExecutionPresentation";
 import type {
@@ -13,9 +14,9 @@ export function useRuntimeExecutionContainer(): RuntimeExecutionPageContentProps
   const platformQuery = trpc.runtimeExecution.getPlatformPolicy.useQuery();
   const profilesQuery = trpc.runtimeExecution.listProfiles.useQuery();
   const auditQuery = trpc.runtimeExecution.listAuditEvents.useQuery();
-  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(
-    null,
-  );
+  const [selectedProfileId, setSelectedProfileId] = useQueryState("profileId", {
+    serializer: serializers.stringOrNull(),
+  });
   const [platformDraft, setPlatformDraft] = useState(
     platformQuery.data?.policy ?? null,
   );
@@ -112,6 +113,7 @@ export function useRuntimeExecutionContainer(): RuntimeExecutionPageContentProps
     platformDraft,
     profileDraft,
     selectedProfileId: effectiveProfileId,
+    profileDetailOpen: selectedProfileId !== null,
     profileModalOpened,
     savingPlatform: replacePlatform.isPending,
     savingProfile: createProfile.isPending || replaceProfile.isPending,
@@ -139,6 +141,7 @@ export function useRuntimeExecutionContainer(): RuntimeExecutionPageContentProps
       setSelectedProfileId(profileId);
       setActionError(null);
     },
+    onProfileDetailClose: () => setSelectedProfileId(null),
     onProfileDraftChange: setProfileDraft,
     onOpenCreateProfile: () => {
       if (!platformQuery.data) {

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/types.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/types.ts
@@ -29,6 +29,7 @@ export interface RuntimeExecutionPageContentProps {
   platformDraft: RuntimeExecutionPolicyDocument | null;
   profileDraft: RuntimeExecutionProfileDraft | null;
   selectedProfileId: string | null;
+  profileDetailOpen: boolean;
   profileModalOpened: boolean;
   savingPlatform: boolean;
   savingProfile: boolean;
@@ -37,6 +38,7 @@ export interface RuntimeExecutionPageContentProps {
   onPlatformDraftChange: (policy: RuntimeExecutionPolicyDocument) => void;
   onSavePlatform: () => void;
   onSelectProfile: (profileId: string) => void;
+  onProfileDetailClose: () => void;
   onProfileDraftChange: (draft: RuntimeExecutionProfileDraft) => void;
   onOpenCreateProfile: () => void;
   onCloseProfileModal: () => void;

--- a/typescript/apps/azents-admin-web/src/features/runtime-providers/components/RuntimeProvidersPageContent.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-providers/components/RuntimeProvidersPageContent.tsx
@@ -3,6 +3,7 @@
 import {
   Alert,
   Badge,
+  Box,
   Button,
   Divider,
   Group,
@@ -15,6 +16,7 @@ import {
   Title,
 } from "@mantine/core";
 import { IconCircleCheck, IconCircleX, IconServer } from "@tabler/icons-react";
+import { MasterDetailLayout } from "@/shared/components/MasterDetailLayout";
 import type {
   RuntimeProviderAuthAuditState,
   RuntimeProviderAuthBindingItem,
@@ -66,9 +68,14 @@ function ProviderListItem({
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Group gap="sm" wrap="nowrap">
           <IconServer size={18} />
-          <Stack gap={2}>
+          <Stack gap={2} style={{ minWidth: 0 }}>
             <Text fw={600}>{provider.display_name}</Text>
-            <Text size="xs" c="dimmed" ff="monospace">
+            <Text
+              size="xs"
+              c="dimmed"
+              ff="monospace"
+              style={{ overflowWrap: "anywhere" }}
+            >
               {provider.provider_id}
             </Text>
           </Stack>
@@ -126,8 +133,8 @@ function AuthenticationSection({
         state.items.map((binding) => (
           <Paper key={binding.id} withBorder p="sm" radius="sm">
             <Stack gap="xs">
-              <Group justify="space-between" align="flex-start" wrap="nowrap">
-                <Stack gap={2}>
+              <Group justify="space-between" align="flex-start" wrap="wrap">
+                <Stack gap={2} style={{ minWidth: 0 }}>
                   <Group gap="xs">
                     <Badge variant="light">{binding.auth_method}</Badge>
                     <Badge
@@ -143,7 +150,11 @@ function AuthenticationSection({
                       {binding.connected ? "Connected" : "Disconnected"}
                     </Badge>
                   </Group>
-                  <Text size="sm" ff="monospace">
+                  <Text
+                    size="sm"
+                    ff="monospace"
+                    style={{ overflowWrap: "anywhere" }}
+                  >
                     {binding.subject}
                   </Text>
                   <Text size="xs" c="dimmed">
@@ -240,8 +251,8 @@ function ContractSection({
       {state.type === "LOADED" &&
         state.items.map((contract) => (
           <Paper key={contract.id} withBorder p="sm" radius="sm">
-            <Group justify="space-between" align="flex-start" wrap="nowrap">
-              <Stack gap={2}>
+            <Group justify="space-between" align="flex-start" wrap="wrap">
+              <Stack gap={2} style={{ minWidth: 0 }}>
                 <Group gap="xs">
                   <Badge
                     color={contract.status === "accepted" ? "green" : "yellow"}
@@ -254,7 +265,12 @@ function ContractSection({
                     {contract.protocol_version}
                   </Text>
                 </Group>
-                <Text size="xs" c="dimmed" ff="monospace">
+                <Text
+                  size="xs"
+                  c="dimmed"
+                  ff="monospace"
+                  style={{ overflowWrap: "anywhere" }}
+                >
                   {contract.digest}
                 </Text>
                 {contract.validation_message && (
@@ -363,7 +379,12 @@ function ProviderDetail({
       <Group justify="space-between" align="flex-start">
         <Stack gap={3}>
           <Title order={3}>{provider.display_name}</Title>
-          <Text size="sm" c="dimmed" ff="monospace">
+          <Text
+            size="sm"
+            c="dimmed"
+            ff="monospace"
+            style={{ overflowWrap: "anywhere" }}
+          >
             {provider.provider_id}
           </Text>
         </Stack>
@@ -436,6 +457,7 @@ function ProviderDetail({
 export function RuntimeProvidersPageContent({
   state,
   selectedProvider,
+  detailOpen,
   contractState,
   authBindingState,
   authAuditState,
@@ -445,6 +467,7 @@ export function RuntimeProvidersPageContent({
   acceptingContract,
   errorMessage,
   onSelectProvider,
+  onDetailClose,
   onToggleEnabled,
   onAcceptContract,
   onCreateAuthBinding,
@@ -454,8 +477,46 @@ export function RuntimeProvidersPageContent({
   onCloseAuthAudit,
   onClearOneTimeSecret,
 }: RuntimeProvidersPageContentProps): React.ReactElement {
+  const master = (
+    <ScrollArea h="100%" p="sm" type="auto">
+      <Stack gap="xs">
+        {state.type === "LOADED" &&
+          state.items.map((provider) => (
+            <ProviderListItem
+              key={provider.provider_id}
+              provider={provider}
+              selected={provider.provider_id === selectedProvider?.provider_id}
+              onSelect={() => onSelectProvider(provider.provider_id)}
+            />
+          ))}
+      </Stack>
+    </ScrollArea>
+  );
+  const detail = (
+    <Stack p={{ base: "md", sm: "xl" }}>
+      {selectedProvider ? (
+        <ProviderDetail
+          provider={selectedProvider}
+          contractState={contractState}
+          authBindingState={authBindingState}
+          authMutating={authMutating}
+          updating={updating}
+          acceptingContract={acceptingContract}
+          onToggleEnabled={() => onToggleEnabled(selectedProvider)}
+          onAcceptContract={onAcceptContract}
+          onCreateAuthBinding={onCreateAuthBinding}
+          onRotateAuthBinding={onRotateAuthBinding}
+          onRevokeAuthBinding={onRevokeAuthBinding}
+          onOpenAuthAudit={onOpenAuthAudit}
+        />
+      ) : (
+        <Text c="dimmed">Select a Provider to inspect its state.</Text>
+      )}
+    </Stack>
+  );
+
   return (
-    <Stack gap="lg" p="md">
+    <Box h="100%" display="flex" style={{ flexDirection: "column" }}>
       <Modal
         opened={oneTimeSecret !== null}
         onClose={onClearOneTimeSecret}
@@ -479,62 +540,34 @@ export function RuntimeProvidersPageContent({
         <AuthenticationAudit state={authAuditState} />
       </Modal>
 
-      <Stack gap={4}>
+      <Stack gap={4} p="md">
         <Title order={2}>Runtime Providers</Title>
         <Text c="dimmed">
           Inspect Provider readiness, contract state, and administrative policy.
         </Text>
       </Stack>
 
-      {errorMessage && <Alert color="red">{errorMessage}</Alert>}
-      {state.type === "LOADING" && <Loader />}
-      {state.type === "ERROR" && <Alert color="red">{state.message}</Alert>}
-      {state.type === "LOADED" && state.items.length === 0 && (
-        <Alert color="yellow" title="No Runtime Providers">
-          Bootstrap or register a Provider before creating new Runtimes.
-        </Alert>
-      )}
+      <Stack gap="sm" px="md">
+        {errorMessage && <Alert color="red">{errorMessage}</Alert>}
+        {state.type === "LOADING" && <Loader />}
+        {state.type === "ERROR" && <Alert color="red">{state.message}</Alert>}
+        {state.type === "LOADED" && state.items.length === 0 && (
+          <Alert color="yellow" title="No Runtime Providers">
+            Bootstrap or register a Provider before creating new Runtimes.
+          </Alert>
+        )}
+      </Stack>
       {state.type === "LOADED" && state.items.length > 0 && (
-        <Paper withBorder radius="md" p={0} style={{ overflow: "hidden" }}>
-          <Group align="stretch" gap={0} wrap="nowrap">
-            <ScrollArea w={{ base: 260, sm: 340 }} p="sm" type="auto">
-              <Stack gap="xs">
-                {state.items.map((provider) => (
-                  <ProviderListItem
-                    key={provider.provider_id}
-                    provider={provider}
-                    selected={
-                      provider.provider_id === selectedProvider?.provider_id
-                    }
-                    onSelect={() => onSelectProvider(provider.provider_id)}
-                  />
-                ))}
-              </Stack>
-            </ScrollArea>
-            <Divider orientation="vertical" />
-            <Stack p="xl" style={{ flex: 1, minWidth: 0 }}>
-              {selectedProvider ? (
-                <ProviderDetail
-                  provider={selectedProvider}
-                  contractState={contractState}
-                  authBindingState={authBindingState}
-                  authMutating={authMutating}
-                  updating={updating}
-                  acceptingContract={acceptingContract}
-                  onToggleEnabled={() => onToggleEnabled(selectedProvider)}
-                  onAcceptContract={onAcceptContract}
-                  onCreateAuthBinding={onCreateAuthBinding}
-                  onRotateAuthBinding={onRotateAuthBinding}
-                  onRevokeAuthBinding={onRevokeAuthBinding}
-                  onOpenAuthAudit={onOpenAuthAudit}
-                />
-              ) : (
-                <Text c="dimmed">Select a Provider to inspect its state.</Text>
-              )}
-            </Stack>
-          </Group>
-        </Paper>
+        <Box px="md" pb="md" style={{ flex: 1, minHeight: 0 }}>
+          <MasterDetailLayout
+            columns="1fr 2fr"
+            master={master}
+            detail={detail}
+            detailOpen={detailOpen}
+            onDetailClose={onDetailClose}
+          />
+        </Box>
       )}
-    </Stack>
+    </Box>
   );
 }

--- a/typescript/apps/azents-admin-web/src/features/runtime-providers/containers/useRuntimeProvidersPageContainer.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-providers/containers/useRuntimeProvidersPageContainer.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { serializers, useQueryState } from "@/hooks/use-query-state";
 import { trpc } from "@/trpc/client";
 import type {
   RuntimeProviderAuthenticationBindingAuditEventResponse,
@@ -48,6 +49,7 @@ export interface RuntimeProvidersPageContentProps {
   state: RuntimeProviderListState;
   selectedProviderId: string | null;
   selectedProvider: RuntimeProviderItem | null;
+  detailOpen: boolean;
   contractState: RuntimeProviderContractState;
   authBindingState: RuntimeProviderAuthBindingState;
   authAuditState: RuntimeProviderAuthAuditState;
@@ -57,6 +59,7 @@ export interface RuntimeProvidersPageContentProps {
   acceptingContract: boolean;
   errorMessage: string | null;
   onSelectProvider: (providerId: string) => void;
+  onDetailClose: () => void;
   onToggleEnabled: (provider: RuntimeProviderItem) => void;
   onAcceptContract: (contract: RuntimeProviderContractItem) => void;
   onCreateAuthBinding: () => void;
@@ -76,8 +79,9 @@ function messageFromUnknown(error: unknown): string {
 export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentProps {
   const utils = trpc.useUtils();
   const providersQuery = trpc.runtimeProvider.list.useQuery();
-  const [selectedProviderId, setSelectedProviderId] = useState<string | null>(
-    null,
+  const [selectedProviderId, setSelectedProviderId] = useQueryState(
+    "providerId",
+    { serializer: serializers.stringOrNull() },
   );
   const updatePolicy = trpc.runtimeProvider.updatePolicy.useMutation({
     onSuccess: async () => {
@@ -194,11 +198,14 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
     },
     [updatePolicy],
   );
-  const handleSelectProvider = useCallback((providerId: string): void => {
-    setSelectedProviderId(providerId);
-    setAuditBinding(null);
-    setRotateError(null);
-  }, []);
+  const handleSelectProvider = useCallback(
+    (providerId: string): void => {
+      setSelectedProviderId(providerId);
+      setAuditBinding(null);
+      setRotateError(null);
+    },
+    [setSelectedProviderId],
+  );
   const handleCreateAuthBinding = useCallback((): void => {
     if (effectiveSelectedProviderId === null) {
       return;
@@ -278,6 +285,7 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
     state,
     selectedProviderId: effectiveSelectedProviderId,
     selectedProvider,
+    detailOpen: selectedProviderId !== null,
     contractState,
     authBindingState,
     authAuditState,
@@ -296,6 +304,7 @@ export function useRuntimeProvidersPageContainer(): RuntimeProvidersPageContentP
       revokeAuthBinding.error?.message ??
       null,
     onSelectProvider: handleSelectProvider,
+    onDetailClose: () => setSelectedProviderId(null),
     onToggleEnabled: handleToggleEnabled,
     onAcceptContract: handleAcceptContract,
     onCreateAuthBinding: handleCreateAuthBinding,

--- a/typescript/apps/azents-admin-web/src/features/workspaces/containers/useWorkspacesPageContainer.ts
+++ b/typescript/apps/azents-admin-web/src/features/workspaces/containers/useWorkspacesPageContainer.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { serializers, useQueryState } from "@/hooks/use-query-state";
+import { useCallback } from "react";
+import { serializers, useQueryStates } from "@/hooks/use-query-state";
 import type { WorkspaceResponse } from "../types";
+
+const MODES = ["view", "create"] as const;
 
 export interface WorkspacesPageContentProps {
   selectedWorkspaceHandle: string | null;
@@ -14,50 +16,40 @@ export interface WorkspacesPageContentProps {
   onDetailClose: () => void;
 }
 
-/**
- * Workspaces 페이지 컨테이너 훅
- *
- * URL 쿼리 상태로 선택된 workspace handle과 생성 모드를 관리합니다.
- */
+/** Manage the selected Workspace and creation mode in URL query state. */
 export function useWorkspacesPageContainer(): WorkspacesPageContentProps {
-  const [selectedWorkspaceHandle, setSelectedWorkspaceHandle] = useQueryState(
-    "workspace",
-    {
-      serializer: serializers.stringOrNull(),
-    },
-  );
-
-  const [isCreateMode, setIsCreateMode] = useState(false);
+  const [state, setState] = useQueryStates({
+    workspace: serializers.stringOrNull(),
+    mode: serializers.literal(MODES, "view"),
+  });
+  const selectedWorkspaceHandle = state.workspace;
+  const isCreateMode = state.mode === "create";
 
   const handleWorkspaceSelect = useCallback(
     (workspace: WorkspaceResponse): void => {
-      setSelectedWorkspaceHandle(workspace.handle);
-      setIsCreateMode(false);
+      setState({ workspace: workspace.handle, mode: "view" });
     },
-    [setSelectedWorkspaceHandle],
+    [setState],
   );
 
   const handleCreateNew = useCallback((): void => {
-    setSelectedWorkspaceHandle(null);
-    setIsCreateMode(true);
-  }, [setSelectedWorkspaceHandle]);
+    setState({ workspace: null, mode: "create" });
+  }, [setState]);
 
   const handleCancel = useCallback((): void => {
-    setIsCreateMode(false);
-  }, []);
+    setState({ mode: "view" });
+  }, [setState]);
 
   const handleSaved = useCallback(
     (handle: string): void => {
-      setSelectedWorkspaceHandle(handle);
-      setIsCreateMode(false);
+      setState({ workspace: handle, mode: "view" });
     },
-    [setSelectedWorkspaceHandle],
+    [setState],
   );
 
   const handleDetailClose = useCallback((): void => {
-    setSelectedWorkspaceHandle(null);
-    setIsCreateMode(false);
-  }, [setSelectedWorkspaceHandle]);
+    setState({ workspace: null, mode: "view" });
+  }, [setState]);
 
   return {
     selectedWorkspaceHandle,

--- a/typescript/apps/azents-admin-web/src/shared/components/MasterDetailLayout.tsx
+++ b/typescript/apps/azents-admin-web/src/shared/components/MasterDetailLayout.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 /**
- * 반응형 Master-Detail 레이아웃.
+ * Responsive master-detail layout.
  *
- * 데스크톱: CSS Grid 2컬럼 (master + detail), height 100%, overflow auto
- * 모바일: master만 표시, detail은 Drawer로 오버레이
- *
- * azents admin-web의 레이아웃 패턴을 따름.
+ * Desktop: two-column CSS Grid with independently scrolling panels.
+ * Mobile: master panel with the detail rendered in a full-screen Drawer.
  */
 import { Box, Drawer, Paper } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
@@ -16,6 +14,10 @@ interface MasterDetailLayoutProps {
   detail: React.ReactNode;
   detailOpen: boolean;
   onDetailClose: () => void;
+  /** CSS grid-template-columns value. */
+  columns?: string;
+  /** Additional styles for the root container. */
+  style?: React.CSSProperties;
 }
 
 export function MasterDetailLayout({
@@ -23,9 +25,11 @@ export function MasterDetailLayout({
   detail,
   detailOpen,
   onDetailClose,
+  columns = "1fr 1fr",
+  style,
 }: MasterDetailLayoutProps): React.ReactElement {
-  // Mantine md breakpoint = 62em = 992px
-  // SSR 기본값을 true로 설정하여 레이아웃 시프트 방지
+  // Mantine's md breakpoint is 62em. Default to desktop during SSR to avoid
+  // shifting an already-wide layout after hydration.
   const isDesktop = useMediaQuery("(min-width: 62em)", true);
 
   if (isDesktop) {
@@ -33,9 +37,10 @@ export function MasterDetailLayout({
       <Box
         style={{
           display: "grid",
-          gridTemplateColumns: "1fr 1fr",
+          gridTemplateColumns: columns,
           gap: "var(--mantine-spacing-md)",
           height: "100%",
+          ...style,
         }}
       >
         <Paper
@@ -54,10 +59,11 @@ export function MasterDetailLayout({
     );
   }
 
-  // 모바일: master만 표시, detail은 Drawer
   return (
-    <>
-      <Box h="100%">{master}</Box>
+    <Box style={{ height: "100%", ...style }}>
+      <Paper withBorder style={{ overflow: "auto", height: "100%" }}>
+        {master}
+      </Paper>
       <Drawer
         opened={detailOpen}
         onClose={onDetailClose}
@@ -67,6 +73,6 @@ export function MasterDetailLayout({
       >
         {detail}
       </Drawer>
-    </>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- align the shared Admin master-detail layout with the Menufans Admin Web pattern
- render detail as a full-screen Drawer on mobile and keep independent desktop panels
- migrate Runtime Providers and Runtime Execution Profiles to the shared layout
- represent Provider, Profile, and Workspace create detail state in URL query parameters
- wrap long Provider identifiers and contract/authentication values safely

## Verification
- pnpm --filter=@azents/admin-web test
- pnpm run typecheck --filter=@azents/admin-web
- pnpm run lint --filter=@azents/admin-web
- pnpm run build --filter=@azents/admin-web