### PR TITLE
Fix Admin mobile forms and clarify Runtime policy controls

### DIFF
--- a/typescript/apps/azents-admin-web/src/app/globals.css
+++ b/typescript/apps/azents-admin-web/src/app/globals.css
@@ -1,0 +1,8 @@
+@media (pointer: coarse) {
+  .azents-admin input:not([type="checkbox"]):not([type="radio"]),
+  .azents-admin select,
+  .azents-admin textarea {
+    /* iOS Safari zooms focused form controls whose computed font is below 16px. */
+    font-size: max(1rem, 16px);
+  }
+}

--- a/typescript/apps/azents-admin-web/src/app/globals.test.mts
+++ b/typescript/apps/azents-admin-web/src/app/globals.test.mts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+void test("touch form controls keep an iOS-safe font size", async () => {
+  const stylesheet = await readFile(
+    new URL("./globals.css", import.meta.url),
+    "utf8",
+  );
+  const layout = await readFile(
+    new URL("./layout.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(layout, /import "\.\/globals\.css";/);
+  assert.match(stylesheet, /@media \(pointer: coarse\)/);
+  assert.match(stylesheet, /\.azents-admin input/);
+  assert.match(stylesheet, /\.azents-admin select/);
+  assert.match(stylesheet, /\.azents-admin textarea/);
+  assert.match(stylesheet, /font-size: max\(1rem, 16px\)/);
+});

--- a/typescript/apps/azents-admin-web/src/app/layout.tsx
+++ b/typescript/apps/azents-admin-web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ClientLayout } from "./client-layout";
 
 import "@mantine/core/styles.css";
 import "@mantine/notifications/styles.css";
+import "./globals.css";
 
 export const metadata = {
   title: "Azents Admin",
@@ -54,7 +55,7 @@ export default async function RootLayout({
       <head>
         <ColorSchemeScript defaultColorScheme={colorScheme} />
       </head>
-      <body style={{ height: "100%", margin: 0 }}>
+      <body className="azents-admin" style={{ height: "100%", margin: 0 }}>
         <ConfigProvider config={getPublicConfig()}>
           <MantineProvider defaultColorScheme={colorScheme}>
             <ModalsProvider>

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/byteSize.test.mts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/byteSize.test.mts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bytesInUnit,
+  preferredByteSizeUnit,
+  unitValueInBytes,
+} from "./byteSize.ts";
+
+void test("empty byte sizes default to GiB", () => {
+  assert.equal(preferredByteSizeUnit(null), "GiB");
+});
+
+void test("existing byte sizes use the largest exact unit up to GiB", () => {
+  assert.equal(preferredByteSizeUnit(8 * 1_073_741_824), "GiB");
+  assert.equal(preferredByteSizeUnit(1_610_612_736), "MiB");
+  assert.equal(preferredByteSizeUnit(3_145_728), "MiB");
+  assert.equal(preferredByteSizeUnit(3_072), "KiB");
+  assert.equal(preferredByteSizeUnit(3_073), "B");
+});
+
+void test("byte size values convert in both directions", () => {
+  assert.equal(bytesInUnit(8_589_934_592, "GiB"), 8);
+  assert.equal(unitValueInBytes(1.5, "GiB"), 1_610_612_736);
+  assert.equal(unitValueInBytes("", "GiB"), null);
+});

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/byteSize.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/byteSize.ts
@@ -1,0 +1,40 @@
+export const BYTE_SIZE_UNITS = ["B", "KiB", "MiB", "GiB"] as const;
+
+export type ByteSizeUnit = (typeof BYTE_SIZE_UNITS)[number];
+
+const BYTES_PER_UNIT: Record<ByteSizeUnit, number> = {
+  B: 1,
+  KiB: 1_024,
+  MiB: 1_048_576,
+  GiB: 1_073_741_824,
+};
+
+export function isByteSizeUnit(value: string): value is ByteSizeUnit {
+  return BYTE_SIZE_UNITS.some((unit) => unit === value);
+}
+
+export function preferredByteSizeUnit(bytes: number | null): ByteSizeUnit {
+  if (bytes === null) {
+    return "GiB";
+  }
+  for (const unit of ["GiB", "MiB", "KiB"] satisfies ByteSizeUnit[]) {
+    if (bytes % BYTES_PER_UNIT[unit] === 0) {
+      return unit;
+    }
+  }
+  return "B";
+}
+
+export function bytesInUnit(bytes: number, unit: ByteSizeUnit): number {
+  return bytes / BYTES_PER_UNIT[unit];
+}
+
+export function unitValueInBytes(
+  value: string | number,
+  unit: ByteSizeUnit,
+): number | null {
+  if (typeof value !== "number") {
+    return null;
+  }
+  return Math.round(value * BYTES_PER_UNIT[unit]);
+}

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/components/ByteSizeInput.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/components/ByteSizeInput.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Grid, NumberInput, Select } from "@mantine/core";
+import { useState } from "react";
+import {
+  BYTE_SIZE_UNITS,
+  bytesInUnit,
+  isByteSizeUnit,
+  preferredByteSizeUnit,
+  unitValueInBytes,
+} from "../byteSize";
+import type { ByteSizeUnit } from "../byteSize";
+
+interface ByteSizeInputProps {
+  label: string;
+  description?: string;
+  value: number | null;
+  disabled: boolean;
+  required?: boolean;
+  placeholder?: string;
+  onChange: (value: number | null) => void;
+}
+
+export function ByteSizeInput({
+  label,
+  description,
+  value,
+  disabled,
+  required = false,
+  placeholder,
+  onChange,
+}: ByteSizeInputProps): React.ReactElement {
+  const [unit, setUnit] = useState<ByteSizeUnit>(() =>
+    preferredByteSizeUnit(value),
+  );
+
+  return (
+    <Grid align="flex-end">
+      <Grid.Col span={8}>
+        <NumberInput
+          label={label}
+          description={description}
+          value={value === null ? "" : bytesInUnit(value, unit)}
+          placeholder={placeholder}
+          min={bytesInUnit(1, unit)}
+          decimalScale={unit === "B" ? 0 : 10}
+          withAsterisk={required}
+          disabled={disabled}
+          onChange={(nextValue) => onChange(unitValueInBytes(nextValue, unit))}
+        />
+      </Grid.Col>
+      <Grid.Col span={4}>
+        <Select
+          label="Unit"
+          data={[...BYTE_SIZE_UNITS]}
+          value={unit}
+          allowDeselect={false}
+          disabled={disabled}
+          onChange={(nextUnit) => {
+            if (nextUnit !== null && isByteSizeUnit(nextUnit)) {
+              setUnit(nextUnit);
+            }
+          }}
+        />
+      </Grid.Col>
+    </Grid>
+  );
+}

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPageContent.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPageContent.tsx
@@ -19,7 +19,7 @@ import {
   Title,
 } from "@mantine/core";
 import { MasterDetailLayout } from "@/shared/components/MasterDetailLayout";
-import { isRuntimeExecutionPolicySupported } from "../runtimeExecutionPresentation";
+import { getRuntimeExecutionPolicyIssue } from "../runtimeExecutionPresentation";
 import { RuntimeExecutionPolicyEditor } from "./RuntimeExecutionPolicyEditor";
 import type {
   RuntimeExecutionPageContentProps,
@@ -46,7 +46,7 @@ function ProfileEditor({
   onSave: () => void;
   onRetire: () => void;
 }): React.ReactElement {
-  const policySupported = isRuntimeExecutionPolicySupported(
+  const policyIssue = getRuntimeExecutionPolicyIssue(
     draft.policy,
     capabilities,
   );
@@ -79,7 +79,7 @@ function ProfileEditor({
             disabled={
               draft.id.trim().length === 0 ||
               draft.displayName.trim().length === 0 ||
-              !policySupported
+              policyIssue !== null
             }
             onClick={onSave}
           >
@@ -93,13 +93,7 @@ function ProfileEditor({
           retired. Their policy remains editable.
         </Alert>
       )}
-      {!policySupported && (
-        <Alert color="yellow">
-          This draft requests Runtime authority that the current server
-          capability gate cannot enforce. Remove the unavailable authority
-          before saving.
-        </Alert>
-      )}
+      {policyIssue !== null && <Alert color="yellow">{policyIssue}</Alert>}
       {creating && (
         <TextInput
           label="Profile ID"
@@ -127,6 +121,7 @@ function ProfileEditor({
         }
       />
       <RuntimeExecutionPolicyEditor
+        key={creating ? "new-profile" : draft.id}
         policy={draft.policy}
         capabilities={capabilities}
         onChange={(policy) => onChange({ ...draft, policy })}

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPolicyEditor.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPolicyEditor.tsx
@@ -168,6 +168,52 @@ export function RuntimeExecutionPolicyEditor({
               }}
             />
           </SimpleGrid>
+          <Stack gap={2}>
+            <Text size="sm" fw={500}>
+              Nested container limits
+            </Text>
+            <Text size="xs" c="dimmed">
+              Enforced across the Docker containers created inside this Runtime.
+            </Text>
+          </Stack>
+          <SimpleGrid cols={{ base: 1, sm: 2 }}>
+            <NumberInput
+              label="Aggregate PID limit"
+              description="Maximum total PIDs across all nested Docker containers."
+              value={policy.resources.pids ?? ""}
+              min={1}
+              placeholder="e.g. 256"
+              withAsterisk={dockerEnabled}
+              disabled={readOnly}
+              onChange={(value) =>
+                onChange({
+                  ...policy,
+                  resources: {
+                    ...policy.resources,
+                    pids: optionalNumber(value),
+                  },
+                })
+              }
+            />
+            <NumberInput
+              label="Container count limit"
+              description="Maximum number of nested Docker containers."
+              value={policy.resources.container_count ?? ""}
+              min={1}
+              placeholder="e.g. 4"
+              withAsterisk={dockerEnabled}
+              disabled={readOnly}
+              onChange={(value) =>
+                onChange({
+                  ...policy,
+                  resources: {
+                    ...policy.resources,
+                    container_count: optionalNumber(value),
+                  },
+                })
+              }
+            />
+          </SimpleGrid>
           <ByteSizeInput
             label="Temporary Docker storage capacity"
             description="Required for Docker images and containers."
@@ -190,14 +236,22 @@ export function RuntimeExecutionPolicyEditor({
 
       <Paper withBorder p="md" radius="md">
         <Stack gap="sm">
-          <Text fw={600}>Resource ceilings</Text>
+          <Stack gap={2}>
+            <Text fw={600}>Kubernetes resource limits</Text>
+            <Text size="sm" c="dimmed">
+              Applied as Kubernetes resources.limits and split between the
+              Docker engine and policy-gateway containers. resources.requests
+              are not set.
+            </Text>
+          </Stack>
           <Grid>
             <Grid.Col span={{ base: 12, sm: 6, lg: 4 }}>
               <NumberInput
-                label="CPU millicores"
+                label="CPU limit (millicores)"
                 value={policy.resources.cpu_millicores ?? ""}
                 min={1}
                 placeholder="e.g. 1000"
+                withAsterisk={dockerEnabled}
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
@@ -212,9 +266,10 @@ export function RuntimeExecutionPolicyEditor({
             </Grid.Col>
             <Grid.Col span={{ base: 12, sm: 6, lg: 8 }}>
               <ByteSizeInput
-                label="Memory"
+                label="Memory limit"
                 value={policy.resources.memory_bytes}
                 placeholder="e.g. 4"
+                required={dockerEnabled}
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
@@ -227,47 +282,12 @@ export function RuntimeExecutionPolicyEditor({
                 }
               />
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 6, lg: 4 }}>
-              <NumberInput
-                label="Process limit"
-                value={policy.resources.pids ?? ""}
-                min={1}
-                placeholder="e.g. 256"
-                disabled={readOnly}
-                onChange={(value) =>
-                  onChange({
-                    ...policy,
-                    resources: {
-                      ...policy.resources,
-                      pids: optionalNumber(value),
-                    },
-                  })
-                }
-              />
-            </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 6, lg: 4 }}>
-              <NumberInput
-                label="Container count"
-                value={policy.resources.container_count ?? ""}
-                min={1}
-                placeholder="e.g. 4"
-                disabled={readOnly}
-                onChange={(value) =>
-                  onChange({
-                    ...policy,
-                    resources: {
-                      ...policy.resources,
-                      container_count: optionalNumber(value),
-                    },
-                  })
-                }
-              />
-            </Grid.Col>
             <Grid.Col span={{ base: 12, sm: 6, lg: 8 }}>
               <ByteSizeInput
-                label="Runtime temporary storage"
+                label="Ephemeral storage limit"
                 value={policy.resources.ephemeral_storage_bytes}
                 placeholder="e.g. 8"
+                required={dockerEnabled}
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPolicyEditor.tsx
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/components/RuntimeExecutionPolicyEditor.tsx
@@ -13,10 +13,13 @@ import {
 } from "@mantine/core";
 import {
   isSupportedRuntimeExecutionNetworkMode,
-  isSupportedRuntimeExecutionStorageMode,
+  updateRuntimeExecutionDockerCapability,
+  updateRuntimeExecutionNetworkMode,
 } from "../runtimeExecutionPresentation";
+import { ByteSizeInput } from "./ByteSizeInput";
 import type {
   RuntimeExecutionManagementCapabilitiesResponse,
+  RuntimeExecutionNetworkMode,
   RuntimeExecutionPolicyDocument,
 } from "@azents/admin-client";
 
@@ -38,81 +41,150 @@ function lines(value: string): string[] {
     .filter((item) => item.length > 0);
 }
 
+const NETWORK_MODE_OPTIONS: {
+  value: RuntimeExecutionNetworkMode;
+  label: string;
+}[] = [
+  { value: "none", label: "System traffic only" },
+  { value: "direct", label: "All IP addresses" },
+  { value: "restricted", label: "Selected IP ranges only" },
+];
+
+function networkModeDescription(mode: RuntimeExecutionNetworkMode): string {
+  switch (mode) {
+    case "none":
+      return "Allows only DNS and the Runtime Control connection required by the platform. Blocks all other outbound traffic.";
+    case "direct":
+      return "Allows outbound traffic to all IPv4 and IPv6 addresses except the blocked CIDR ranges below.";
+    case "restricted":
+      return "Allows only the IPv4 and IPv6 CIDR ranges listed below, excluding blocked ranges.";
+  }
+}
+
 export function RuntimeExecutionPolicyEditor({
   policy,
   capabilities,
   readOnly = false,
   onChange,
 }: RuntimeExecutionPolicyEditorProps): React.ReactElement {
+  const dockerEnabled =
+    policy.image_build.enabled || policy.container_run.enabled;
+  const temporaryDockerStorageSupported =
+    capabilities.storage_modes.includes("ephemeral");
+
   return (
     <Stack gap="md">
       <Paper withBorder p="md" radius="md">
         <Stack gap="sm">
-          <Text fw={600}>Container capabilities</Text>
+          <Stack gap={2}>
+            <Text fw={600}>Docker</Text>
+            <Text size="sm" c="dimmed">
+              Configure Docker access inside the Runtime. Docker data is
+              temporary and is deleted when the Runtime Pod is replaced.
+            </Text>
+          </Stack>
           <SimpleGrid cols={{ base: 1, sm: 3 }}>
             <Checkbox
-              label="Build container images"
+              label="Build Docker images"
               checked={policy.image_build.enabled}
               disabled={
                 readOnly ||
-                (!capabilities.image_build && !policy.image_build.enabled)
+                ((!capabilities.image_build ||
+                  !temporaryDockerStorageSupported) &&
+                  !policy.image_build.enabled)
               }
               onChange={(event) => {
                 const enabled = event.currentTarget.checked;
-                if (enabled && !capabilities.image_build) {
+                if (
+                  enabled &&
+                  (!capabilities.image_build ||
+                    !temporaryDockerStorageSupported)
+                ) {
                   return;
                 }
-                onChange({
-                  ...policy,
-                  image_build: {
-                    ...policy.image_build,
+                onChange(
+                  updateRuntimeExecutionDockerCapability(
+                    policy,
+                    "image_build",
                     enabled,
-                  },
-                });
+                  ),
+                );
               }}
             />
             <Checkbox
-              label="Run nested containers"
+              label="Run Docker containers"
               checked={policy.container_run.enabled}
               disabled={
                 readOnly ||
-                (!capabilities.container_run && !policy.container_run.enabled)
+                ((!capabilities.container_run ||
+                  !temporaryDockerStorageSupported) &&
+                  !policy.container_run.enabled)
               }
               onChange={(event) => {
                 const enabled = event.currentTarget.checked;
-                if (enabled && !capabilities.container_run) {
+                if (
+                  enabled &&
+                  (!capabilities.container_run ||
+                    !temporaryDockerStorageSupported)
+                ) {
                   return;
                 }
-                onChange({
-                  ...policy,
-                  container_run: {
-                    ...policy.container_run,
+                onChange(
+                  updateRuntimeExecutionDockerCapability(
+                    policy,
+                    "container_run",
                     enabled,
-                  },
-                });
+                  ),
+                );
               }}
             />
             <Checkbox
-              label="Use Compose"
+              label="Use Docker Compose"
               checked={policy.compose.enabled}
               disabled={
-                readOnly || (!capabilities.compose && !policy.compose.enabled)
+                readOnly ||
+                ((!capabilities.compose ||
+                  !capabilities.container_run ||
+                  !temporaryDockerStorageSupported) &&
+                  !policy.compose.enabled)
               }
               onChange={(event) => {
                 const enabled = event.currentTarget.checked;
-                if (enabled && !capabilities.compose) {
+                if (
+                  enabled &&
+                  (!capabilities.compose ||
+                    !capabilities.container_run ||
+                    !temporaryDockerStorageSupported)
+                ) {
                   return;
                 }
-                onChange({
-                  ...policy,
-                  compose: {
-                    ...policy.compose,
+                onChange(
+                  updateRuntimeExecutionDockerCapability(
+                    policy,
+                    "compose",
                     enabled,
-                  },
-                });
+                  ),
+                );
               }}
             />
           </SimpleGrid>
+          <ByteSizeInput
+            label="Temporary Docker storage capacity"
+            description="Required for Docker images and containers."
+            value={policy.engine_storage.capacity_bytes}
+            required={dockerEnabled}
+            placeholder="e.g. 8"
+            disabled={readOnly || !dockerEnabled}
+            onChange={(value) =>
+              onChange({
+                ...policy,
+                engine_storage: {
+                  ...policy.engine_storage,
+                  capacity_bytes: value,
+                },
+              })
+            }
+          />
         </Stack>
       </Paper>
 
@@ -124,7 +196,8 @@ export function RuntimeExecutionPolicyEditor({
               <NumberInput
                 label="CPU millicores"
                 value={policy.resources.cpu_millicores ?? ""}
-                min={0}
+                min={1}
+                placeholder="e.g. 1000"
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
@@ -137,18 +210,18 @@ export function RuntimeExecutionPolicyEditor({
                 }
               />
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 6, lg: 4 }}>
-              <NumberInput
-                label="Memory bytes"
-                value={policy.resources.memory_bytes ?? ""}
-                min={0}
+            <Grid.Col span={{ base: 12, sm: 6, lg: 8 }}>
+              <ByteSizeInput
+                label="Memory"
+                value={policy.resources.memory_bytes}
+                placeholder="e.g. 4"
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
                     ...policy,
                     resources: {
                       ...policy.resources,
-                      memory_bytes: optionalNumber(value),
+                      memory_bytes: value,
                     },
                   })
                 }
@@ -158,7 +231,8 @@ export function RuntimeExecutionPolicyEditor({
               <NumberInput
                 label="Process limit"
                 value={policy.resources.pids ?? ""}
-                min={0}
+                min={1}
+                placeholder="e.g. 256"
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
@@ -175,7 +249,8 @@ export function RuntimeExecutionPolicyEditor({
               <NumberInput
                 label="Container count"
                 value={policy.resources.container_count ?? ""}
-                min={0}
+                min={1}
+                placeholder="e.g. 4"
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
@@ -188,18 +263,18 @@ export function RuntimeExecutionPolicyEditor({
                 }
               />
             </Grid.Col>
-            <Grid.Col span={{ base: 12, sm: 6, lg: 4 }}>
-              <NumberInput
-                label="Ephemeral storage bytes"
-                value={policy.resources.ephemeral_storage_bytes ?? ""}
-                min={0}
+            <Grid.Col span={{ base: 12, sm: 6, lg: 8 }}>
+              <ByteSizeInput
+                label="Runtime temporary storage"
+                value={policy.resources.ephemeral_storage_bytes}
+                placeholder="e.g. 8"
                 disabled={readOnly}
                 onChange={(value) =>
                   onChange({
                     ...policy,
                     resources: {
                       ...policy.resources,
-                      ephemeral_storage_bytes: optionalNumber(value),
+                      ephemeral_storage_bytes: value,
                     },
                   })
                 }
@@ -211,82 +286,13 @@ export function RuntimeExecutionPolicyEditor({
 
       <Paper withBorder p="md" radius="md">
         <Stack gap="sm">
-          <Text fw={600}>Engine storage</Text>
-          <SimpleGrid cols={{ base: 1, sm: 2 }}>
-            <Select
-              label="Mode"
-              data={[
-                {
-                  value: "none",
-                  label: "None",
-                  disabled: !capabilities.storage_modes.includes("none"),
-                },
-                {
-                  value: "ephemeral",
-                  label: "Ephemeral",
-                  disabled: !capabilities.storage_modes.includes("ephemeral"),
-                },
-              ]}
-              value={policy.engine_storage.mode}
-              disabled={readOnly}
-              allowDeselect={false}
-              onChange={(value) => {
-                if (
-                  value === null ||
-                  !isSupportedRuntimeExecutionStorageMode(value, capabilities)
-                ) {
-                  return;
-                }
-                onChange({
-                  ...policy,
-                  engine_storage: {
-                    ...policy.engine_storage,
-                    mode: value,
-                  },
-                });
-              }}
-            />
-            <NumberInput
-              label="Capacity bytes"
-              value={policy.engine_storage.capacity_bytes ?? ""}
-              min={0}
-              disabled={readOnly}
-              onChange={(value) =>
-                onChange({
-                  ...policy,
-                  engine_storage: {
-                    ...policy.engine_storage,
-                    capacity_bytes: optionalNumber(value),
-                  },
-                })
-              }
-            />
-          </SimpleGrid>
-        </Stack>
-      </Paper>
-
-      <Paper withBorder p="md" radius="md">
-        <Stack gap="sm">
-          <Text fw={600}>Network egress</Text>
+          <Text fw={600}>Outbound network access</Text>
           <Select
-            label="Mode"
-            data={[
-              {
-                value: "none",
-                label: "None",
-                disabled: !capabilities.network_modes.includes("none"),
-              },
-              {
-                value: "restricted",
-                label: "Restricted",
-                disabled: !capabilities.network_modes.includes("restricted"),
-              },
-              {
-                value: "direct",
-                label: "Direct",
-                disabled: !capabilities.network_modes.includes("direct"),
-              },
-            ]}
+            label="Access policy"
+            description={networkModeDescription(policy.network_egress.mode)}
+            data={NETWORK_MODE_OPTIONS.filter(({ value }) =>
+              capabilities.network_modes.includes(value),
+            )}
             value={policy.network_egress.mode}
             disabled={readOnly}
             allowDeselect={false}
@@ -297,19 +303,14 @@ export function RuntimeExecutionPolicyEditor({
               ) {
                 return;
               }
-              onChange({
-                ...policy,
-                network_egress: {
-                  ...policy.network_egress,
-                  mode: value,
-                },
-              });
+              onChange(updateRuntimeExecutionNetworkMode(policy, value));
             }}
           />
-          <SimpleGrid cols={{ base: 1, sm: 2 }}>
+          {policy.network_egress.mode === "restricted" && (
             <Textarea
-              label="Allowed destinations"
-              description="One destination per line."
+              label="Allowed IP ranges (CIDR)"
+              description="One IPv4 or IPv6 CIDR per line, for example 140.82.112.0/20 or 2606:50c0::/32. Hostnames and URLs are not accepted."
+              placeholder={"140.82.112.0/20\n2606:50c0::/32"}
               value={policy.network_egress.allowed_destinations.join("\n")}
               disabled={readOnly}
               autosize
@@ -324,9 +325,12 @@ export function RuntimeExecutionPolicyEditor({
                 })
               }
             />
+          )}
+          {policy.network_egress.mode !== "none" && (
             <Textarea
-              label="Denied destinations"
-              description="One destination per line."
+              label="Blocked IP ranges (CIDR)"
+              description="One IPv4 or IPv6 CIDR per line. Traffic to these ranges is blocked even when otherwise allowed."
+              placeholder={"10.0.0.0/8\nfd00::/8"}
               value={policy.network_egress.denied_destinations.join("\n")}
               disabled={readOnly}
               autosize
@@ -341,7 +345,7 @@ export function RuntimeExecutionPolicyEditor({
                 })
               }
             />
-          </SimpleGrid>
+          )}
         </Stack>
       </Paper>
     </Stack>

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/containers/useRuntimeExecutionContainer.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/containers/useRuntimeExecutionContainer.ts
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { serializers, useQueryState } from "@/hooks/use-query-state";
 import { trpc } from "@/trpc/client";
-import { isRuntimeExecutionPolicySupported } from "../runtimeExecutionPresentation";
+import { getRuntimeExecutionPolicyIssue } from "../runtimeExecutionPresentation";
 import type {
   RuntimeExecutionPageContentProps,
   RuntimeExecutionProfileDraft,
@@ -135,10 +135,10 @@ export function useRuntimeExecutionContainer(): RuntimeExecutionPageContentProps
       if (
         !profileDraft ||
         !profilesQuery.data ||
-        !isRuntimeExecutionPolicySupported(
+        getRuntimeExecutionPolicyIssue(
           profileDraft.policy,
           profilesQuery.data.capabilities,
-        )
+        ) !== null
       ) {
         return;
       }

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.test.mts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.test.mts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isRuntimeExecutionPolicySupported } from "./runtimeExecutionPresentation.ts";
+import {
+  getRuntimeExecutionPolicyIssue,
+  isRuntimeExecutionPolicySupported,
+  updateRuntimeExecutionDockerCapability,
+  updateRuntimeExecutionNetworkMode,
+} from "./runtimeExecutionPresentation.ts";
 import type {
   RuntimeExecutionManagementCapabilitiesResponse,
   RuntimeExecutionPolicyDocument,
@@ -79,5 +84,121 @@ void test("Admin policy saves only server-supported authority", () => {
       capabilities,
     ),
     false,
+  );
+});
+
+void test("Docker capabilities and temporary storage stay consistent", () => {
+  const withCompose = updateRuntimeExecutionDockerCapability(
+    policy,
+    "compose",
+    true,
+  );
+  assert.equal(withCompose.container_run.enabled, true);
+  assert.equal(withCompose.compose.enabled, true);
+  assert.equal(withCompose.engine_storage.mode, "ephemeral");
+
+  const withoutContainerRun = updateRuntimeExecutionDockerCapability(
+    withCompose,
+    "container_run",
+    false,
+  );
+  assert.equal(withoutContainerRun.container_run.enabled, false);
+  assert.equal(withoutContainerRun.compose.enabled, false);
+  assert.equal(withoutContainerRun.engine_storage.mode, "none");
+  assert.equal(withoutContainerRun.engine_storage.capacity_bytes, null);
+});
+
+void test("Docker storage remains enabled while image builds require it", () => {
+  const withImageBuild = updateRuntimeExecutionDockerCapability(
+    {
+      ...policy,
+      engine_storage: {
+        ...policy.engine_storage,
+        capacity_bytes: 8_589_934_592,
+      },
+    },
+    "image_build",
+    true,
+  );
+  const withoutContainerRun = updateRuntimeExecutionDockerCapability(
+    withImageBuild,
+    "container_run",
+    false,
+  );
+
+  assert.equal(withoutContainerRun.image_build.enabled, true);
+  assert.equal(withoutContainerRun.engine_storage.mode, "ephemeral");
+  assert.equal(
+    withoutContainerRun.engine_storage.capacity_bytes,
+    8_589_934_592,
+  );
+});
+
+void test("network modes clear fields that the selected policy does not use", () => {
+  const policyWithCidrs: RuntimeExecutionPolicyDocument = {
+    ...policy,
+    network_egress: {
+      ...policy.network_egress,
+      mode: "restricted",
+      allowed_destinations: ["140.82.112.0/20"],
+      denied_destinations: ["140.82.120.0/24"],
+    },
+  };
+
+  const direct = updateRuntimeExecutionNetworkMode(policyWithCidrs, "direct");
+  assert.deepEqual(direct.network_egress.allowed_destinations, []);
+  assert.deepEqual(direct.network_egress.denied_destinations, [
+    "140.82.120.0/24",
+  ]);
+
+  const systemOnly = updateRuntimeExecutionNetworkMode(direct, "none");
+  assert.deepEqual(systemOnly.network_egress.allowed_destinations, []);
+  assert.deepEqual(systemOnly.network_egress.denied_destinations, []);
+});
+
+void test("Docker profiles require storage and positive Runtime limits", () => {
+  const dockerCapabilities: RuntimeExecutionManagementCapabilitiesResponse = {
+    image_build: true,
+    container_run: true,
+    compose: true,
+    storage_modes: ["none", "ephemeral"],
+    network_modes: ["none", "direct"],
+  };
+  const withDocker = updateRuntimeExecutionDockerCapability(
+    policy,
+    "container_run",
+    true,
+  );
+  assert.equal(
+    getRuntimeExecutionPolicyIssue(withDocker, dockerCapabilities),
+    "Enter a temporary Docker storage capacity before saving.",
+  );
+
+  const withStorage: RuntimeExecutionPolicyDocument = {
+    ...withDocker,
+    engine_storage: {
+      ...withDocker.engine_storage,
+      capacity_bytes: 8_589_934_592,
+    },
+  };
+  assert.equal(
+    getRuntimeExecutionPolicyIssue(withStorage, dockerCapabilities),
+    "Set every Runtime resource limit to a positive value before enabling Docker.",
+  );
+
+  const complete: RuntimeExecutionPolicyDocument = {
+    ...withStorage,
+    resources: {
+      ...withStorage.resources,
+      cpu_millicores: 1_000,
+      memory_bytes: 4_294_967_296,
+      pids: 256,
+      container_count: 4,
+      ephemeral_storage_bytes: 8_589_934_592,
+    },
+  };
+  assert.equal(
+    getRuntimeExecutionPolicyIssue(complete, dockerCapabilities),
+    null,
   );
 });

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.test.mts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.test.mts
@@ -183,7 +183,7 @@ void test("Docker profiles require storage and positive Runtime limits", () => {
   };
   assert.equal(
     getRuntimeExecutionPolicyIssue(withStorage, dockerCapabilities),
-    "Set every Runtime resource limit to a positive value before enabling Docker.",
+    "Set every Kubernetes and nested-container limit to a positive value before enabling Docker.",
   );
 
   const complete: RuntimeExecutionPolicyDocument = {

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.ts
@@ -2,8 +2,12 @@ import type {
   RuntimeExecutionManagementCapabilitiesResponse,
   RuntimeExecutionNetworkMode,
   RuntimeExecutionPolicyDocument,
-  RuntimeExecutionStorageMode,
 } from "@azents/admin-client";
+
+export type RuntimeExecutionDockerCapability =
+  | "image_build"
+  | "container_run"
+  | "compose";
 
 export function isRuntimeExecutionPolicySupported(
   policy: RuntimeExecutionPolicyDocument,
@@ -18,11 +22,41 @@ export function isRuntimeExecutionPolicySupported(
   );
 }
 
-export function isSupportedRuntimeExecutionStorageMode(
-  value: string,
+export function getRuntimeExecutionPolicyIssue(
+  policy: RuntimeExecutionPolicyDocument,
   capabilities: RuntimeExecutionManagementCapabilitiesResponse,
-): value is RuntimeExecutionStorageMode {
-  return capabilities.storage_modes.some((mode) => mode === value);
+): string | null {
+  if (!isRuntimeExecutionPolicySupported(policy, capabilities)) {
+    return "This Profile uses a capability that the current Runtime Provider does not support.";
+  }
+  if (policy.compose.enabled && !policy.container_run.enabled) {
+    return "Docker Compose requires Docker container execution.";
+  }
+  const dockerEnabled =
+    policy.image_build.enabled || policy.container_run.enabled;
+  if (!dockerEnabled) {
+    return null;
+  }
+  if (
+    policy.engine_storage.mode !== "ephemeral" ||
+    policy.engine_storage.capacity_bytes === null ||
+    policy.engine_storage.capacity_bytes < 1
+  ) {
+    return "Enter a temporary Docker storage capacity before saving.";
+  }
+  const resources = policy.resources;
+  if (
+    [
+      resources.cpu_millicores,
+      resources.memory_bytes,
+      resources.pids,
+      resources.container_count,
+      resources.ephemeral_storage_bytes,
+    ].some((value) => value === null || value < 1)
+  ) {
+    return "Set every Runtime resource limit to a positive value before enabling Docker.";
+  }
+  return null;
 }
 
 export function isSupportedRuntimeExecutionNetworkMode(
@@ -30,4 +64,66 @@ export function isSupportedRuntimeExecutionNetworkMode(
   capabilities: RuntimeExecutionManagementCapabilitiesResponse,
 ): value is RuntimeExecutionNetworkMode {
   return capabilities.network_modes.some((mode) => mode === value);
+}
+
+export function updateRuntimeExecutionDockerCapability(
+  policy: RuntimeExecutionPolicyDocument,
+  capability: RuntimeExecutionDockerCapability,
+  enabled: boolean,
+): RuntimeExecutionPolicyDocument {
+  const imageBuildEnabled =
+    capability === "image_build" ? enabled : policy.image_build.enabled;
+  const containerRunEnabled =
+    capability === "container_run"
+      ? enabled
+      : capability === "compose" && enabled
+        ? true
+        : policy.container_run.enabled;
+  const composeEnabled =
+    capability === "compose"
+      ? enabled
+      : capability === "container_run" && !enabled
+        ? false
+        : policy.compose.enabled;
+  const dockerEnabled = imageBuildEnabled || containerRunEnabled;
+
+  return {
+    ...policy,
+    image_build: {
+      ...policy.image_build,
+      enabled: imageBuildEnabled,
+    },
+    container_run: {
+      ...policy.container_run,
+      enabled: containerRunEnabled,
+    },
+    compose: {
+      ...policy.compose,
+      enabled: composeEnabled,
+    },
+    engine_storage: {
+      ...policy.engine_storage,
+      mode: dockerEnabled ? "ephemeral" : "none",
+      capacity_bytes: dockerEnabled
+        ? policy.engine_storage.capacity_bytes
+        : null,
+    },
+  };
+}
+
+export function updateRuntimeExecutionNetworkMode(
+  policy: RuntimeExecutionPolicyDocument,
+  mode: RuntimeExecutionNetworkMode,
+): RuntimeExecutionPolicyDocument {
+  return {
+    ...policy,
+    network_egress: {
+      ...policy.network_egress,
+      mode,
+      allowed_destinations:
+        mode === "restricted" ? policy.network_egress.allowed_destinations : [],
+      denied_destinations:
+        mode === "none" ? [] : policy.network_egress.denied_destinations,
+    },
+  };
 }

--- a/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.ts
+++ b/typescript/apps/azents-admin-web/src/features/runtime-execution/runtimeExecutionPresentation.ts
@@ -54,7 +54,7 @@ export function getRuntimeExecutionPolicyIssue(
       resources.ephemeral_storage_bytes,
     ].some((value) => value === null || value < 1)
   ) {
-    return "Set every Runtime resource limit to a positive value before enabling Docker.";
+    return "Set every Kubernetes and nested-container limit to a positive value before enabling Docker.";
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- prevent iOS Safari focus zoom across Admin form controls by enforcing a touch-safe minimum input font size
- group Docker capabilities with temporary storage, aggregate PID, and nested-container count limits while keeping Docker, Compose, and storage state consistent
- label CPU, memory, and ephemeral storage as Kubernetes `resources.limits`, explicitly documenting that `resources.requests` are not set
- add B/KiB/MiB/GiB selectors for memory and temporary storage, defaulting empty values to GiB and choosing the largest exact unit for existing byte values
- replace internal network mode labels with explicit behavior, show only Provider-supported modes, and document IPv4/IPv6 CIDR inputs with examples
- block invalid Docker Profile saves until storage capacity and all required Kubernetes and nested-container limits are positive

## Root cause

Mantine form controls compute below 16px on mobile, which triggers persistent iOS Safari focus zoom. Runtime policy fields also exposed internal contract terminology and independently editable values even where the backend requires them to move together. The resource section mixed Kubernetes container limits with Docker gateway limits without distinguishing `requests` from `limits`.

## Validation

- `pnpm --filter @azents/admin-web lint`
- `pnpm --filter @azents/admin-web typecheck`
- `pnpm --filter @azents/admin-web test` (16 passed)
- `pnpm --filter @azents/admin-web build`
- `uv run pytest -vv -m "web_surface and not live_external and not runtime_provider" ./src/tests/azents/admin/test_01_admin_web.py` (3 passed)