### PR TITLE
Fix Runtime resource migration for JSON null snapshots

### DIFF
--- a/python/apps/azents/db-schemas/rdb/migrations/versions/142ffe7ca6e9_upgrade_runtime_resource_policy.py
+++ b/python/apps/azents/db-schemas/rdb/migrations/versions/142ffe7ca6e9_upgrade_runtime_resource_policy.py
@@ -74,6 +74,16 @@ def _transform_document(
     return transformed
 
 
+def _transform_optional_document(
+    document: object,
+    transform: Callable[[Mapping[str, Any]], dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Transform JSON policy objects while preserving JSON null snapshots."""
+    if not isinstance(document, Mapping):
+        return None
+    return _transform_document(document, transform)
+
+
 def _transform_current_documents(
     *,
     table: str,
@@ -112,11 +122,15 @@ def _transform_snapshots(
     rows = bind.execute(
         sa.text(
             "SELECT id, resolved_execution_policy FROM runtime_policy_snapshots "
-            "WHERE resolved_execution_policy IS NOT NULL"
+            "WHERE jsonb_typeof(resolved_execution_policy) = 'object'"
         )
     ).mappings()
     for row in rows:
-        document = _transform_document(row["resolved_execution_policy"], transform)
+        document = _transform_optional_document(
+            row["resolved_execution_policy"], transform
+        )
+        if document is None:
+            continue
         bind.execute(
             sa.text(
                 "UPDATE runtime_policy_snapshots SET "

--- a/python/apps/azents/src/azents/rdb/runtime_execution_policy_migration_test.py
+++ b/python/apps/azents/src/azents/rdb/runtime_execution_policy_migration_test.py
@@ -127,6 +127,23 @@ def test_migration_backfill_restriction_is_canonical_empty_intent() -> None:
     assert all(value is None for name, value in restriction if name != "schema_version")
 
 
+def test_resource_migration_preserves_json_null_runtime_snapshots() -> None:
+    """Unresolved snapshots store JSON null and are not policy documents."""
+    resource_values = _migration_values(_RESOURCE_V2_MIGRATION)
+
+    assert (
+        resource_values["_transform_optional_document"](
+            None,
+            resource_values["_upgrade_resources"],
+        )
+        is None
+    )
+    assert (
+        "jsonb_typeof(resolved_execution_policy) = 'object'"
+        in _RESOURCE_V2_MIGRATION.read_text()
+    )
+
+
 def test_revision_pointer_and_backfills_are_present() -> None:
     """The latest revision is selected and preserves existing Runtime snapshots."""
     revision_file = PROJECT_ROOT / "db-schemas" / "rdb" / "revision"


### PR DESCRIPTION
## Summary
- migrate only object-valued resolved Runtime policy snapshots
- preserve SQL NULL and JSONB null unresolved snapshots
- add a regression test for the production failure shape

## Root cause
The resources/v2 migration filtered with `IS NOT NULL`, which includes JSONB `null`. PostgreSQL returned that value as Python `None`, and the migration crashed in `dict(document)`, leaving new server Pods in CrashLoopBackOff while the new Admin Web called the old API contract.

## Verification
- `ruff check` and `ruff format --check`
- Azents pyright: 0 errors
- Runtime migration/core tests: 16 passed
- pre-commit: passed

This PR does not perform a live database write or restart.