### PR TITLE
Fix Runtime policy convergence self-healing

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,7 +32,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 32 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 33 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,7 +29,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 32 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 33 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -30,7 +30,7 @@ code_paths:
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
 last_verified_at: 2026-07-27
-spec_version: 32
+spec_version: 33
 ---
 
 # Agent Runtime Control
@@ -277,6 +277,14 @@ not report compliance before matching observation. Failed tightening remains pen
 and may fence/stop noncompliant authority, but never invokes reset, terminal delete, Provider
 fallback, or workspace deletion. Unsupported capability remains unavailable rather than weakened.
 
+A mixed policy edit computes the module-owned security meet between the applied policy and current
+intent. Boolean authority intersects, numeric bounds take the lower finite value, Docker storage mode
+and capacity remain one valid module, and network allow/deny rules intersect and union respectively.
+The restrictive subset converges automatically before any remaining authority expansion is offered
+for explicit Apply. A historical applied Snapshot whose evidence was invalidated by a schema
+migration remains internal recovery state; it does not become an administrator action while a valid
+target can be reconciled.
+
 ## Delivery
 
 Production deploys the new path through GitOps:
@@ -305,6 +313,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-27** (spec_version 33) — Made mixed-policy convergence use a valid module-level security meet and kept invalidated historical evidence in automatic recovery state.
 - **2026-07-27** (spec_version 32) — Removed Platform policy source evidence and made the selected Profile the complete execution ceiling.
 - **2026-07-26** (spec_version 31) — Added immutable execution-policy targets, generation-fenced convergence evidence, and reset-free fail-closed tightening semantics.
 - **2026-07-26** (spec_version 30) — Changed periodic desired-running Runtime reconciliation from read-only observe to idempotent start so Runner image and Provider-managed configuration drift converges without deleting Agent Workspace storage.

--- a/python/apps/azents/src/azents/core/runtime_execution_policy.py
+++ b/python/apps/azents/src/azents/core/runtime_execution_policy.py
@@ -669,6 +669,97 @@ def classify_runtime_execution_change(
     )
 
 
+def meet_runtime_execution_policies(
+    left: RuntimeExecutionPolicyDocument,
+    right: RuntimeExecutionPolicyDocument,
+) -> RuntimeExecutionPolicyDocument:
+    """Return the greatest valid policy no broader than either input."""
+    resource_values = {
+        name: _minimum_bound(
+            getattr(left.resources, name),
+            getattr(right.resources, name),
+        )
+        for name in _RESOURCE_PATHS
+    }
+    for request_name, limit_name in (
+        ("cpu_request_millicores", "cpu_limit_millicores"),
+        ("memory_request_bytes", "memory_limit_bytes"),
+    ):
+        request = resource_values[request_name]
+        limit = resource_values[limit_name]
+        if request is not None and limit is not None and request > limit:
+            resource_values[request_name] = limit
+
+    storage_mode = min(
+        left.engine_storage.mode,
+        right.engine_storage.mode,
+        key=_STORAGE_RANK.__getitem__,
+    )
+    storage_capacity = (
+        None
+        if storage_mode is RuntimeExecutionStorageMode.NONE
+        else _minimum_bound(
+            left.engine_storage.capacity_bytes,
+            right.engine_storage.capacity_bytes,
+        )
+    )
+
+    network_mode = min(
+        left.network_egress.mode,
+        right.network_egress.mode,
+        key=_NETWORK_RANK.__getitem__,
+    )
+    denied_destinations = (
+        left.network_egress.denied_destinations
+        | right.network_egress.denied_destinations
+    )
+    restricted_allow_sets = [
+        policy.network_egress.allowed_destinations
+        for policy in (left, right)
+        if policy.network_egress.mode is RuntimeExecutionNetworkMode.RESTRICTED
+    ]
+    if network_mode is RuntimeExecutionNetworkMode.RESTRICTED:
+        allowed_destinations = restricted_allow_sets[0]
+        for destinations in restricted_allow_sets[1:]:
+            allowed_destinations &= destinations
+        allowed_destinations -= denied_destinations
+    else:
+        allowed_destinations = frozenset()
+
+    return RuntimeExecutionPolicyDocument(
+        schema_version=1,
+        image_build=left.image_build.model_copy(
+            update={"enabled": left.image_build.enabled and right.image_build.enabled}
+        ),
+        container_run=left.container_run.model_copy(
+            update={
+                "enabled": left.container_run.enabled and right.container_run.enabled
+            }
+        ),
+        compose=left.compose.model_copy(
+            update={"enabled": left.compose.enabled and right.compose.enabled}
+        ),
+        resources=RuntimeExecutionResourceModule(
+            module_id=RuntimeExecutionModuleId.RESOURCES,
+            version=1,
+            **resource_values,
+        ),
+        engine_storage=RuntimeExecutionStorageModule(
+            module_id=RuntimeExecutionModuleId.ENGINE_STORAGE,
+            version=1,
+            mode=storage_mode,
+            capacity_bytes=storage_capacity,
+        ),
+        network_egress=RuntimeExecutionNetworkModule(
+            module_id=RuntimeExecutionModuleId.NETWORK_EGRESS,
+            version=1,
+            mode=network_mode,
+            allowed_destinations=allowed_destinations,
+            denied_destinations=denied_destinations,
+        ),
+    )
+
+
 def _apply_restriction(
     policy: RuntimeExecutionPolicyDocument,
     restriction: RuntimeExecutionPolicyRestriction,

--- a/python/apps/azents/src/azents/core/runtime_execution_policy_test.py
+++ b/python/apps/azents/src/azents/core/runtime_execution_policy_test.py
@@ -26,6 +26,7 @@ from azents.core.runtime_execution_policy import (
     classify_runtime_execution_change,
     digest_runtime_execution_policy,
     empty_runtime_execution_restriction,
+    meet_runtime_execution_policies,
     resolve_runtime_execution_policy,
     standard_runtime_execution_policy,
     validate_runtime_execution_restriction,
@@ -413,4 +414,66 @@ def test_change_classification_distinguishes_restriction_expansion_and_mixed() -
     assert (
         classify_runtime_execution_change(baseline, mixed).direction
         is RuntimeExecutionChangeDirection.MIXED
+    )
+
+
+def test_policy_meet_preserves_valid_storage_module() -> None:
+    """Storage mode and capacity narrow as one valid authority module."""
+    disabled = _policy(
+        storage_mode=RuntimeExecutionStorageMode.NONE,
+        network_mode=RuntimeExecutionNetworkMode.DIRECT,
+    )
+    ephemeral = _policy(
+        storage_mode=RuntimeExecutionStorageMode.EPHEMERAL,
+        storage_capacity=17_179_869_184,
+        network_mode=RuntimeExecutionNetworkMode.DIRECT,
+    )
+
+    result = meet_runtime_execution_policies(disabled, ephemeral)
+
+    assert result.engine_storage.mode is RuntimeExecutionStorageMode.NONE
+    assert result.engine_storage.capacity_bytes is None
+
+
+def test_policy_meet_intersects_restricted_network_authority() -> None:
+    """Direct authority behaves as the universe while restrictions intersect."""
+    direct = _policy(
+        network_mode=RuntimeExecutionNetworkMode.DIRECT,
+        denied=frozenset({"metadata"}),
+    )
+    restricted = _policy(
+        network_mode=RuntimeExecutionNetworkMode.RESTRICTED,
+        allowed=frozenset({"public", "registry"}),
+        denied=frozenset({"private"}),
+    )
+
+    result = meet_runtime_execution_policies(direct, restricted)
+
+    assert result.network_egress.mode is RuntimeExecutionNetworkMode.RESTRICTED
+    assert result.network_egress.allowed_destinations == frozenset(
+        {"public", "registry"}
+    )
+    assert result.network_egress.denied_destinations == frozenset(
+        {"metadata", "private"}
+    )
+
+
+def test_policy_meet_intersects_two_network_allowlists() -> None:
+    """Two restricted policies retain only destinations allowed by both."""
+    left = _policy(
+        network_mode=RuntimeExecutionNetworkMode.RESTRICTED,
+        allowed=frozenset({"public", "registry"}),
+        denied=frozenset({"metadata"}),
+    )
+    right = _policy(
+        network_mode=RuntimeExecutionNetworkMode.RESTRICTED,
+        allowed=frozenset({"registry", "packages"}),
+        denied=frozenset({"private"}),
+    )
+
+    result = meet_runtime_execution_policies(left, right)
+
+    assert result.network_egress.allowed_destinations == frozenset({"registry"})
+    assert result.network_egress.denied_destinations == frozenset(
+        {"metadata", "private"}
     )

--- a/python/apps/azents/src/azents/services/runtime_execution_policy/application_service.py
+++ b/python/apps/azents/src/azents/services/runtime_execution_policy/application_service.py
@@ -21,7 +21,6 @@ from azents.core.runtime_execution_policy import (
     JsonValue,
     RuntimeExecutionAuditEventType,
     RuntimeExecutionChangeDirection,
-    RuntimeExecutionChangeSummary,
     RuntimeExecutionManagementLayer,
     RuntimeExecutionModuleId,
     RuntimeExecutionNetworkMode,
@@ -34,10 +33,10 @@ from azents.core.runtime_execution_policy import (
     RuntimeExecutionResolution,
     RuntimeExecutionSourceVersions,
     RuntimeExecutionStorageMode,
-    canonical_runtime_execution_policy,
     canonical_runtime_execution_policy_json,
     digest_runtime_execution_policy,
     empty_runtime_execution_restriction,
+    meet_runtime_execution_policies,
     resolve_runtime_execution_policy,
 )
 from azents.core.runtime_provider_contract import (
@@ -465,28 +464,28 @@ class RuntimeExecutionPolicyApplicationService:
                 )
                 return "stopped"
 
-            direction = resolved.resolution.change.direction
-            if direction in {
-                RuntimeExecutionChangeDirection.METADATA_ONLY,
-                RuntimeExecutionChangeDirection.AUTHORITY_EXPANDING,
-            }:
-                return (
-                    "pending_expansion"
-                    if direction is RuntimeExecutionChangeDirection.AUTHORITY_EXPANDING
-                    else "unchanged"
-                )
             applied_policy = _snapshot_policy(resolved.applied_snapshot)
             if applied_policy is None:
-                applied_policy = resolved.resolution.effective_policy
-            effective_policy = (
-                resolved.resolution.effective_policy
-                if direction is RuntimeExecutionChangeDirection.RESTRICTIVE
-                else _restrictive_projection(
-                    applied_policy,
-                    resolved.resolution.effective_policy,
-                    resolved.resolution.change,
+                return (
+                    "pending_expansion"
+                    if resolved.resolution.change.direction
+                    is not RuntimeExecutionChangeDirection.METADATA_ONLY
+                    else "unchanged"
                 )
+            effective_policy = _restrictive_projection(
+                applied_policy,
+                resolved.resolution.effective_policy,
             )
+            if digest_runtime_execution_policy(
+                effective_policy
+            ) == digest_runtime_execution_policy(applied_policy):
+                return (
+                    "pending_expansion"
+                    if resolved.resolution.digest
+                    != digest_runtime_execution_policy(applied_policy)
+                    else "unchanged"
+                )
+            direction = resolved.resolution.change.direction
             result = await self._target_resolution(
                 session,
                 resolved=resolved,
@@ -887,10 +886,7 @@ def _build_status_projection(
         desired_generation=runtime.desired_generation,
     )
     if not configured_matches_target:
-        automatic = (
-            resolution.change.direction is RuntimeExecutionChangeDirection.RESTRICTIVE
-            and _automatic_convergence_source_allowed(resolved)
-        )
+        automatic = _has_automatic_restriction(resolved)
         return RuntimeExecutionPolicyStatusProjection(
             status=(
                 RuntimeExecutionPolicyStatus.PENDING
@@ -964,11 +960,6 @@ def _divergence_reasons(resolved: _ResolvedRuntimePolicy) -> tuple[str, ...]:
     if runtime.applied_runtime_policy_snapshot_id is not None:
         if applied is None:
             reasons.append("applied_snapshot_missing")
-        elif (
-            applied.application_state
-            is not RuntimePolicySnapshotApplicationState.APPLIED
-        ):
-            reasons.append("applied_snapshot_unverified")
     if (
         target.application_state is RuntimePolicySnapshotApplicationState.APPLIED
         and runtime.applied_runtime_policy_snapshot_id != target.id
@@ -1123,61 +1114,27 @@ def _automatic_convergence_source_allowed(
     return target.execution_agent_version == source_versions.agent
 
 
+def _has_automatic_restriction(resolved: _ResolvedRuntimePolicy) -> bool:
+    """Report whether the current intent contains authority that must be removed."""
+    applied_policy = _snapshot_policy(resolved.applied_snapshot)
+    return (
+        applied_policy is not None
+        and _automatic_convergence_source_allowed(resolved)
+        and digest_runtime_execution_policy(
+            _restrictive_projection(
+                applied_policy,
+                resolved.resolution.effective_policy,
+            )
+        )
+        != digest_runtime_execution_policy(applied_policy)
+    )
+
+
 def _restrictive_projection(
     applied: RuntimeExecutionPolicyDocument,
     current: RuntimeExecutionPolicyDocument,
-    change: RuntimeExecutionChangeSummary,
 ) -> RuntimeExecutionPolicyDocument:
-    projected = canonical_runtime_execution_policy(applied)
-    current_values = canonical_runtime_execution_policy(current)
-    if not isinstance(projected, dict) or not isinstance(current_values, dict):
-        raise AssertionError("Canonical execution policies must be objects.")
-    atomic_modules = {
-        field.path.split(".", 1)[0]
-        for field in change.fields
-        if field.direction is RuntimeExecutionChangeDirection.RESTRICTIVE
-        and field.path in {"engine_storage.mode", "network_egress.mode"}
-    }
-    for module in atomic_modules:
-        projected[module] = current_values[module]
-    for field in change.fields:
-        if field.direction is RuntimeExecutionChangeDirection.RESTRICTIVE:
-            if field.path.split(".", 1)[0] in atomic_modules:
-                continue
-            _copy_path(projected, current_values, field.path.split("."))
-    _normalize_projected_resource_pairs(projected)
-    return RuntimeExecutionPolicyDocument.model_validate(projected)
-
-
-def _normalize_projected_resource_pairs(policy: dict[str, JsonValue]) -> None:
-    """Keep selectively projected Kubernetes requests within their limits."""
-    resources = policy.get("resources")
-    if not isinstance(resources, dict):
-        raise ValueError("Execution-policy resources module is invalid.")
-    for request_name, limit_name in (
-        ("cpu_request_millicores", "cpu_limit_millicores"),
-        ("memory_request_bytes", "memory_limit_bytes"),
-    ):
-        request = resources.get(request_name)
-        limit = resources.get(limit_name)
-        if isinstance(request, int) and isinstance(limit, int) and request > limit:
-            resources[request_name] = limit
-
-
-def _copy_path(
-    target: dict[str, JsonValue],
-    source: dict[str, JsonValue],
-    path: list[str],
-) -> None:
-    key = path[0]
-    if len(path) == 1:
-        target[key] = source[key]
-        return
-    target_child = target.get(key)
-    source_child = source.get(key)
-    if not isinstance(target_child, dict) or not isinstance(source_child, dict):
-        raise ValueError("Execution-policy change path is invalid.")
-    _copy_path(target_child, source_child, path[1:])
+    return meet_runtime_execution_policies(applied, current)
 
 
 def _snapshot_digest(

--- a/python/apps/azents/src/azents/services/runtime_execution_policy/application_service_test.py
+++ b/python/apps/azents/src/azents/services/runtime_execution_policy/application_service_test.py
@@ -83,6 +83,22 @@ def _direct_provider_capabilities() -> RuntimeExecutionProviderCapabilities:
     )
 
 
+def _engine_provider_capabilities() -> RuntimeExecutionProviderCapabilities:
+    """Model a Provider that supports temporary Docker storage."""
+    direct = _direct_provider_capabilities()
+    return direct.model_copy(
+        update={
+            "privileged_engine": True,
+            "storage_modes": frozenset(
+                {
+                    RuntimeExecutionStorageMode.NONE,
+                    RuntimeExecutionStorageMode.EPHEMERAL,
+                }
+            ),
+        }
+    )
+
+
 @asynccontextmanager
 async def _session_manager() -> AsyncIterator[Mock]:
     yield Mock()
@@ -310,6 +326,67 @@ def _upper_layer_change_resolved(
     )
 
 
+def _storage_expansion_resolved() -> _ResolvedRuntimePolicy:
+    """Return a Runtime whose only remaining change expands Docker storage."""
+    applied_policy = standard_runtime_execution_policy()
+    current_policy = applied_policy.model_copy(
+        update={
+            "engine_storage": applied_policy.engine_storage.model_copy(
+                update={
+                    "mode": RuntimeExecutionStorageMode.EPHEMERAL,
+                    "capacity_bytes": 17_179_869_184,
+                }
+            )
+        }
+    )
+    source_versions = RuntimeExecutionSourceVersions(
+        profile=4,
+        workspace=3,
+        agent=4,
+    )
+    resolution = resolve_runtime_execution_policy(
+        profile_policy=current_policy,
+        workspace_restriction=empty_runtime_execution_restriction(),
+        agent_restriction=empty_runtime_execution_restriction(),
+        source_versions=source_versions,
+        provider_capabilities=_engine_provider_capabilities(),
+        profile_active=True,
+        profile_allowed=True,
+        applied_policy=applied_policy,
+    )
+    target_digest = digest_runtime_execution_policy(applied_policy)
+    target = dataclasses.replace(
+        _snapshot(),
+        execution_profile_id="system-standard",
+        execution_profile_version=source_versions.profile,
+        execution_workspace_version=source_versions.workspace,
+        execution_agent_version=source_versions.agent,
+        resolved_execution_policy_json=canonical_runtime_execution_policy_json(
+            applied_policy
+        ),
+        execution_source_trace={},
+        execution_provider_compatibility={},
+        execution_target_digest=target_digest,
+        execution_reported_digest=target_digest,
+        application_state=RuntimePolicySnapshotApplicationState.APPLIED,
+    )
+    runtime = _runtime().model_copy(
+        update={"applied_runtime_policy_snapshot_id": target.id}
+    )
+    return _ResolvedRuntimePolicy(
+        runtime=runtime,
+        target_snapshot=target,
+        applied_snapshot=target,
+        accepted_contract_revision_id="contract-1",
+        provider_compatibility={
+            "mode": "accepted_contract",
+            "contract_revision_id": "contract-1",
+        },
+        profile_id="system-standard",
+        resolution=resolution,
+    )
+
+
 def test_status_projection_requires_explicit_apply_for_saved_intent() -> None:
     """A configured intent mismatch is not presented as applied."""
     status = _build_status_projection(_resolved())
@@ -367,8 +444,8 @@ def test_status_projection_requires_apply_for_upper_layer_expansion(
     assert status.reason_codes == ("explicit_apply_required",)
 
 
-def test_status_projection_requires_apply_for_mixed_upper_layer_change() -> None:
-    """Mixed changes cannot hide their remaining expansion behind Wait."""
+def test_status_projection_waits_while_mixed_change_removes_authority() -> None:
+    """Mixed changes converge their restrictive subset before offering expansion."""
     status = _build_status_projection(
         _upper_layer_change_resolved(
             current_cpu=1_000,
@@ -386,8 +463,18 @@ def test_status_projection_requires_apply_for_mixed_upper_layer_change() -> None
         )
     )
 
+    assert status.status is RuntimeExecutionPolicyStatus.PENDING
+    assert status.required_action is RuntimeExecutionRequiredAction.WAIT
+    assert status.reason_codes == ("automatic_convergence_pending",)
+
+
+def test_status_projection_offers_apply_after_restrictive_subset_converges() -> None:
+    """A module expansion does not remain stuck in automatic convergence."""
+    status = _build_status_projection(_storage_expansion_resolved())
+
     assert status.status is RuntimeExecutionPolicyStatus.CONFIGURED
     assert status.required_action is RuntimeExecutionRequiredAction.APPLY
+    assert status.reason_codes == ("explicit_apply_required",)
 
 
 def test_status_projection_marks_exact_target_pending_until_evidence() -> None:
@@ -403,6 +490,20 @@ def test_status_projection_marks_exact_target_pending_until_evidence() -> None:
     assert status.required_action is RuntimeExecutionRequiredAction.WAIT
     assert status.target is not None
     assert status.applied is None
+
+
+def test_status_projection_recovers_pending_historical_applied_snapshot() -> None:
+    """Migrated historical evidence does not become a user-actionable divergence."""
+    status = _build_status_projection(
+        _targeted_resolved(
+            state=RuntimePolicySnapshotApplicationState.PENDING,
+            applied=True,
+        )
+    )
+
+    assert status.status is RuntimeExecutionPolicyStatus.PENDING
+    assert status.required_action is RuntimeExecutionRequiredAction.WAIT
+    assert status.reason_codes == ("application_pending",)
 
 
 def test_status_projection_marks_only_promoted_exact_target_applied() -> None:
@@ -795,6 +896,32 @@ def test_automatic_convergence_requires_unchanged_agent_intent() -> None:
     )
 
 
+async def test_convergence_leaves_remaining_storage_expansion_for_apply() -> None:
+    """An already-converged security meet does not create restart targets forever."""
+    resolved = _storage_expansion_resolved()
+    snapshot_repository = Mock()
+    snapshot_repository.create_and_advance_target_snapshot = AsyncMock()
+    runtime_repository = Mock()
+    runtime_repository.get_by_id_for_update = AsyncMock(return_value=resolved.runtime)
+    policy_repository = Mock()
+    policy_repository.append_audit_event = AsyncMock()
+    service = RuntimeExecutionPolicyApplicationService(
+        session_manager=_session_manager,
+        policy_repository=policy_repository,
+        snapshot_repository=snapshot_repository,
+        runtime_repository=runtime_repository,
+        provider_repository=Mock(),
+        agent_admin_repository=Mock(),
+    )
+    service._resolve_locked = AsyncMock(return_value=resolved)
+
+    outcome = await service._converge_runtime("runtime-1")
+
+    assert outcome == "pending_expansion"
+    snapshot_repository.create_and_advance_target_snapshot.assert_not_awaited()
+    policy_repository.append_audit_event.assert_not_awaited()
+
+
 async def test_incompatible_convergence_stops_with_a_new_exact_target() -> None:
     """Fail-closed stopping never advances generation without a target snapshot."""
     resolved = _unavailable_resolved()
@@ -903,7 +1030,7 @@ def test_mixed_convergence_copies_only_restrictive_fields() -> None:
     change = classify_runtime_execution_change(applied, current)
     assert change.direction is RuntimeExecutionChangeDirection.MIXED
 
-    projected = _restrictive_projection(applied, current, change)
+    projected = _restrictive_projection(applied, current)
 
     assert projected.image_build.enabled is False
     assert projected.network_egress.mode is RuntimeExecutionNetworkMode.NONE
@@ -922,9 +1049,7 @@ def test_restrictive_projection_keeps_storage_mode_and_capacity_atomic() -> None
             )
         }
     )
-    change = classify_runtime_execution_change(applied, standard)
-
-    projected = _restrictive_projection(applied, standard, change)
+    projected = _restrictive_projection(applied, standard)
 
     assert projected.engine_storage.mode is RuntimeExecutionStorageMode.NONE
     assert projected.engine_storage.capacity_bytes is None
@@ -947,9 +1072,7 @@ def test_restrictive_projection_keeps_network_mode_and_ranges_atomic() -> None:
             )
         }
     )
-    change = classify_runtime_execution_change(applied, current)
-
-    projected = _restrictive_projection(applied, current, change)
+    projected = _restrictive_projection(applied, current)
 
     assert projected.network_egress.mode is RuntimeExecutionNetworkMode.NONE
     assert projected.network_egress.allowed_destinations == frozenset()
@@ -972,12 +1095,36 @@ def test_restrictive_projection_keeps_request_within_new_limit() -> None:
             )
         }
     )
-    change = classify_runtime_execution_change(applied, current)
-
-    projected = _restrictive_projection(applied, current, change)
+    projected = _restrictive_projection(applied, current)
 
     assert projected.resources.cpu_request_millicores == 1_000
     assert projected.resources.cpu_limit_millicores == 1_000
+
+
+def test_restrictive_projection_does_not_split_expanding_storage_module() -> None:
+    """A mixed change cannot produce a capacity with no Docker storage mode."""
+    applied = standard_runtime_execution_policy()
+    current = applied.model_copy(
+        update={
+            "resources": applied.resources.model_copy(
+                update={"cpu_limit_millicores": 1_000}
+            ),
+            "engine_storage": applied.engine_storage.model_copy(
+                update={
+                    "mode": RuntimeExecutionStorageMode.EPHEMERAL,
+                    "capacity_bytes": 17_179_869_184,
+                }
+            ),
+        }
+    )
+    change = classify_runtime_execution_change(applied, current)
+    assert change.direction is RuntimeExecutionChangeDirection.MIXED
+
+    projected = _restrictive_projection(applied, current)
+
+    assert projected.resources.cpu_limit_millicores == 1_000
+    assert projected.engine_storage.mode is RuntimeExecutionStorageMode.NONE
+    assert projected.engine_storage.capacity_bytes is None
 
 
 def test_legacy_capabilities_cannot_grant_engine_or_network_authority() -> None:

--- a/typescript/apps/azents-web/messages/en-US.json
+++ b/typescript/apps/azents-web/messages/en-US.json
@@ -1718,7 +1718,6 @@
           "reported_digest_mismatch": "The Runtime reported a different policy fingerprint from the current target.",
           "target_generation_mismatch": "The Runtime target belongs to an older Generation and must be reconciled.",
           "applied_snapshot_missing": "The recorded applied policy Snapshot is missing.",
-          "applied_snapshot_unverified": "The previously applied policy evidence must be verified again before it can be trusted.",
           "applied_pointer_mismatch": "The Runtime's applied policy reference does not point to the current verified target.",
           "provider_evidence_mismatch": "The Runtime Provider did not return policy evidence matching the requested Generation and target.",
           "runtime_failure": "The Runtime reported an operational failure. Reference code: {code}"

--- a/typescript/apps/azents-web/messages/fr-FR.json
+++ b/typescript/apps/azents-web/messages/fr-FR.json
@@ -1718,7 +1718,6 @@
           "reported_digest_mismatch": "Le Runtime a signalé une empreinte de politique différente de celle de la target actuelle.",
           "target_generation_mismatch": "La target Runtime appartient à une ancienne Generation et doit être réconciliée.",
           "applied_snapshot_missing": "Le Snapshot de politique enregistré comme appliqué est introuvable.",
-          "applied_snapshot_unverified": "Les preuves de la politique précédemment appliquée doivent être vérifiées à nouveau.",
           "applied_pointer_mismatch": "La référence de politique appliquée du Runtime ne pointe pas vers la target actuellement vérifiée.",
           "provider_evidence_mismatch": "Le Runtime Provider n'a pas renvoyé de preuve de politique correspondant à la Generation et à la target demandées.",
           "runtime_failure": "L'opération Runtime a échoué. Code de référence : {code}"

--- a/typescript/apps/azents-web/messages/ja-JP.json
+++ b/typescript/apps/azents-web/messages/ja-JP.json
@@ -1718,7 +1718,6 @@
           "reported_digest_mismatch": "Runtime が現在の target と異なるポリシーフィンガープリントを報告しました。",
           "target_generation_mismatch": "Runtime target が以前の Generation に属しているため、再調整が必要です。",
           "applied_snapshot_missing": "適用済みとして記録されたポリシー Snapshot が見つかりません。",
-          "applied_snapshot_unverified": "以前に適用されたポリシー証拠を再検証する必要があります。",
           "applied_pointer_mismatch": "Runtime の適用済みポリシー参照が現在の検証済み target を指していません。",
           "provider_evidence_mismatch": "Runtime Provider が要求された Generation と target に一致するポリシー証拠を返しませんでした。",
           "runtime_failure": "Runtime 操作に失敗しました。参照コード: {code}"

--- a/typescript/apps/azents-web/messages/ko-KR.json
+++ b/typescript/apps/azents-web/messages/ko-KR.json
@@ -1718,7 +1718,6 @@
           "reported_digest_mismatch": "Runtime이 현재 target과 다른 정책 식별값을 보고했습니다.",
           "target_generation_mismatch": "Runtime target이 이전 Generation에 속해 있어 다시 조정해야 합니다.",
           "applied_snapshot_missing": "적용된 것으로 기록된 정책 Snapshot을 찾을 수 없습니다.",
-          "applied_snapshot_unverified": "이전에 적용된 정책 증거를 다시 검증해야 합니다.",
           "applied_pointer_mismatch": "Runtime의 적용 정책 참조가 현재 검증된 target을 가리키지 않습니다.",
           "provider_evidence_mismatch": "Runtime Provider가 요청한 Generation과 target에 맞는 정책 증거를 반환하지 않았습니다.",
           "runtime_failure": "Runtime 작업에 실패했습니다. 참조 코드: {code}"

--- a/typescript/apps/azents-web/src/features/runtime-execution/runtimeExecutionPresentation.test.mts
+++ b/typescript/apps/azents-web/src/features/runtime-execution/runtimeExecutionPresentation.test.mts
@@ -223,10 +223,6 @@ void test("status polling follows wait and stops at terminal actions", () => {
 
 void test("every Runtime policy reason has a visible message fallback", () => {
   assert.equal(
-    runtimePolicyReasonMessageKey("applied_snapshot_unverified"),
-    "reasonExplanations.applied_snapshot_unverified",
-  );
-  assert.equal(
     runtimePolicyReasonMessageKey("RUNTIME_POLICY_PROVIDER_EVIDENCE_MISMATCH"),
     "reasonExplanations.provider_evidence_mismatch",
   );

--- a/typescript/apps/azents-web/src/features/runtime-execution/runtimeExecutionPresentation.ts
+++ b/typescript/apps/azents-web/src/features/runtime-execution/runtimeExecutionPresentation.ts
@@ -30,7 +30,6 @@ const RUNTIME_POLICY_REASON_MESSAGE_KEYS = {
   reported_digest_mismatch: "reasonExplanations.reported_digest_mismatch",
   target_generation_mismatch: "reasonExplanations.target_generation_mismatch",
   applied_snapshot_missing: "reasonExplanations.applied_snapshot_missing",
-  applied_snapshot_unverified: "reasonExplanations.applied_snapshot_unverified",
   applied_pointer_mismatch: "reasonExplanations.applied_pointer_mismatch",
   RUNTIME_POLICY_PROVIDER_EVIDENCE_MISMATCH:
     "reasonExplanations.provider_evidence_mismatch",


### PR DESCRIPTION
## Summary

- compute mixed automatic convergence with a module-level security meet
- keep Docker storage mode/capacity and network policy valid and atomic
- recover migrated applied snapshots automatically instead of showing an administrator-action divergence
- transition remaining expansion to explicit Apply after the restrictive subset converges

## Root cause

The old projection copied individually classified restrictive fields. `none -> ephemeral` storage mode was an expansion, while `null -> 16 GiB` capacity was classified as restrictive, producing the invalid pair `mode=none, capacity=16 GiB`. Separately, migration-invalidated applied evidence was surfaced as a user-actionable divergence even though it is server-owned recovery state.

## Validation

- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest -q` (3399 passed)
- `pnpm --filter=@azents/web test` (135 passed)
- `pnpm run lint --filter=@azents/web`
- `pnpm run typecheck --filter=@azents/web`
- docs index check
- Runtime Execution API E2E
- Runtime Execution Web E2E

## E2E note

The runtime-provider hierarchy E2E was also executed but stops before this scenario with `provider_module_unsupported`: its local `system-docker` Provider intentionally advertises no execution-policy modules. This is a pre-existing fixture/coverage mismatch, not a failure of this patch.
