### PR TITLE
Prevent false Runtime start failures

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,7 +32,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 33 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 34 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,7 +29,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 33 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 34 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -30,7 +30,7 @@ code_paths:
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
 last_verified_at: 2026-07-27
-spec_version: 33
+spec_version: 34
 ---
 
 # Agent Runtime Control
@@ -103,7 +103,7 @@ Generation fencing is enforced before volatile stream messages mutate durable st
 
 Provider report framing always uses the generation accepted for the current Control stream. A Provider reconnect or leader failover may observe backend resources whose labels contain an older Provider generation; those labels are historical command metadata and must be replaced with the current connection generation before initial resync reports, watch reports, or command completion reports are sent to Control.
 
-Control periodically dispatches idempotent Provider `start` commands for running Runtimes and read-only Provider `observe` commands for stopped-desired Runtimes whose Provider state has not yet converged to `stopped`. Periodic `start` revalidates the desired Runner image and Provider-managed workload configuration, reuses an equivalent workload, and replaces only a drifted workload while preserving Agent Workspace storage. The live Provider connection registry, rather than a cached per-Runtime connection flag, gates dispatch; periodic attempts are durably throttled while a Provider is unavailable, and a successful dispatch refreshes the cached connection flag. This converges Runner image/configuration drift after deployment and closes gaps when a backend deletion event is missed during Provider reconnect or leader handoff. A current-generation Provider `stopped` report also converges durable Runner state to `disconnected`; the stopped backend is authoritative that no Runner remains available.
+Control periodically dispatches idempotent Provider `start` commands for running Runtimes and read-only Provider `observe` commands for stopped-desired Runtimes whose Provider state has not yet converged to `stopped`. Periodic `start` revalidates the desired Runner image and Provider-managed workload configuration, reuses an equivalent workload, and replaces only a drifted workload while preserving Agent Workspace storage. The live Provider connection registry, rather than a cached per-Runtime connection flag, gates dispatch; periodic attempts are durably throttled while a Provider is unavailable, and a successful dispatch refreshes the cached connection flag. Start timeout evaluation happens only after the current reconciliation pass has checked that live registry and only for a desired generation already dispatched to its Provider, so a Control rollout cannot convert a stale durable `connected` flag into a false `START_TIMEOUT`. This converges Runner image/configuration drift after deployment and closes gaps when a backend deletion event is missed during Provider reconnect or leader handoff. A current-generation Provider `stopped` report also converges durable Runner state to `disconnected`; the stopped backend is authoritative that no Runner remains available. Kubernetes Pod replacement treats deletion as asynchronous: the Provider must not apply the replacement under the same name until the old Pod is no longer observable, avoiding immutable-field PATCH failures during restart.
 
 Provider and Runner request streams use explicit claim/ack delivery. Control returns each claimed request with the stream cursor and consumer-group metadata needed to acknowledge the request only after it has been sent on the matching gRPC stream. Unacknowledged requests may be reclaimed after an idle interval so a Control replica crash or stream interruption does not strand in-flight Provider/Runner work.
 
@@ -313,6 +313,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-27** (spec_version 34) — Prevented false start timeouts across Control rollouts and made Kubernetes Runtime Pod replacement wait for asynchronous deletion before recreation.
 - **2026-07-27** (spec_version 33) — Made mixed-policy convergence use a valid module-level security meet and kept invalidated historical evidence in automatic recovery state.
 - **2026-07-27** (spec_version 32) — Removed Platform policy source evidence and made the selected Profile the complete execution ceiling.
 - **2026-07-26** (spec_version 31) — Added immutable execution-policy targets, generation-fenced convergence evidence, and reset-free fail-closed tightening semantics.

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -567,12 +567,13 @@ class KubernetesRuntimeProvider:
                 self._config.namespace,
                 grace_period_seconds=grace_period_seconds,
             )
-            if command.command_type is RuntimeLifecycleCommandType.START:
-                pod = await self._api.get_pod(pod_name, self._config.namespace)
-                if pod is not None:
-                    return
-            else:
-                pod = None
+            # Kubernetes Pod deletion is asynchronous. Never server-side apply a
+            # replacement while the old object still owns the name: that becomes an
+            # immutable Pod PATCH and fails with 422. A later idempotent lifecycle
+            # retry creates the replacement after deletion is observable.
+            pod = await self._api.get_pod(pod_name, self._config.namespace)
+            if pod is not None:
+                return
         if pod is None:
             _LOGGER.info(
                 "Kubernetes Runtime applying Pod",

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -83,12 +83,14 @@ class FakeKubernetesApi(KubernetesApi):
         self.pods: dict[tuple[str, str], PodResource] = {}
         self.pvcs: dict[tuple[str, str], PersistentVolumeClaimResource] = {}
         self.network_policies: dict[tuple[str, str], NetworkPolicyResource] = {}
+        self.applied_pods: list[str] = []
         self.deleted_pods: list[str] = []
         self.deleted_pod_grace_periods: list[int | None] = []
         self.deleted_pvcs: list[str] = []
         self.deleted_network_policies: list[str] = []
         self.watch_events: list[PodWatchEvent] = []
         self.fail_pod_deletion = False
+        self.defer_pod_deletion = False
 
     async def get_pod(self, name: str, namespace: str) -> PodResource | None:
         """Return a Pod by name."""
@@ -96,6 +98,7 @@ class FakeKubernetesApi(KubernetesApi):
 
     async def apply_pod(self, pod: PodResource) -> None:
         """Apply a Pod."""
+        self.applied_pods.append(pod.metadata.name)
         self.pods[(pod.metadata.namespace, pod.metadata.name)] = pod
 
     async def delete_pod(
@@ -110,7 +113,8 @@ class FakeKubernetesApi(KubernetesApi):
         self.deleted_pod_grace_periods.append(grace_period_seconds)
         if self.fail_pod_deletion:
             raise RuntimeError("Pod deletion failed")
-        self.pods.pop((namespace, name), None)
+        if not self.defer_pod_deletion:
+            self.pods.pop((namespace, name), None)
 
     async def list_pods(
         self,
@@ -1066,6 +1070,30 @@ async def test_restart_preserves_pvc_and_replaces_pod() -> None:
     assert api.deleted_pods == ["azents-runtime-runtime-1"]
     assert ("azents-runtime", "azents-runtime-runtime-1-workspace") in api.pvcs
     assert ("azents-runtime", "azents-runtime-runtime-1") in api.pods
+
+
+@pytest.mark.asyncio
+async def test_restart_waits_for_asynchronous_pod_deletion_before_recreate() -> None:
+    """Restart never patches immutable fields on a terminating Pod."""
+    api = FakeKubernetesApi()
+    provider = _provider(api)
+    await provider.start(_command(RuntimeLifecycleCommandType.START))
+    api.defer_pod_deletion = True
+
+    result = await provider.restart(_command(RuntimeLifecycleCommandType.RESTART))
+
+    assert result.report.observed_state is RuntimeProviderObservedState.STARTING
+    assert api.deleted_pods == ["azents-runtime-runtime-1"]
+    assert api.applied_pods == ["azents-runtime-runtime-1"]
+
+    api.pods.pop(("azents-runtime", "azents-runtime-runtime-1"))
+    api.defer_pod_deletion = False
+    await provider.restart(_command(RuntimeLifecycleCommandType.RESTART))
+
+    assert api.applied_pods == [
+        "azents-runtime-runtime-1",
+        "azents-runtime-runtime-1",
+    ]
 
 
 @pytest.mark.asyncio

--- a/python/apps/azents/src/azents/repos/agent_runtime/__init__.py
+++ b/python/apps/azents/src/azents/repos/agent_runtime/__init__.py
@@ -637,6 +637,8 @@ class AgentRuntimeRepository:
                 RDBAgentRuntime.desired_state == RuntimeDesiredState.RUNNING,
                 RDBAgentRuntime.provider_connection_state
                 == RuntimeProviderConnectionState.CONNECTED,
+                RDBAgentRuntime.last_lifecycle_dispatch_generation
+                == RDBAgentRuntime.desired_generation,
                 RDBAgentRuntime.last_state_change_at
                 < sa.func.clock_timestamp() - stale_threshold,
                 sa.not_(

--- a/python/apps/azents/src/azents/repos/agent_runtime/repository_test.py
+++ b/python/apps/azents/src/azents/repos/agent_runtime/repository_test.py
@@ -1313,6 +1313,12 @@ class TestAgentRuntimeRepository:
             RuntimeDesiredState.RUNNING,
         )
         assert command is not None
+        dispatched = await repo.mark_lifecycle_dispatched(
+            rdb_session,
+            runtime.id,
+            command.desired_generation,
+        )
+        assert dispatched is not None
         old_state_change_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
             minutes=10
         )
@@ -1334,3 +1340,48 @@ class TestAgentRuntimeRepository:
         )
         assert timed_out[0].failure_generation == command.desired_generation
         assert timed_out[0].failure_code == "START_TIMEOUT"
+
+    async def test_mark_start_timeouts_skips_undispatched_generation(
+        self, rdb_session: AsyncSession
+    ) -> None:
+        """A desired generation cannot time out before reaching its Provider."""
+        workspace_id = await _create_workspace(
+            rdb_session, "agent-runtime-undispatched-timeout-ws"
+        )
+        agent_id = await _create_agent(
+            rdb_session, workspace_id, "agent-runtime-undispatched-timeout"
+        )
+        repo = AgentRuntimeRepository()
+        runtime = await repo.ensure_for_agent(rdb_session, agent_id)
+        runtime = await repo.record_provider_connection_state(
+            rdb_session,
+            runtime.id,
+            RuntimeProviderConnectionState.CONNECTED,
+        )
+        assert runtime is not None
+        command = await repo.set_desired_state(
+            rdb_session,
+            runtime.id,
+            RuntimeLifecycleCommandType.START,
+            RuntimeDesiredState.RUNNING,
+        )
+        assert command is not None
+        old_state_change_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=10
+        )
+        await rdb_session.execute(
+            sa.update(RDBAgentRuntime)
+            .where(RDBAgentRuntime.id == runtime.id)
+            .values(last_state_change_at=old_state_change_at)
+        )
+
+        timed_out = await repo.mark_start_timeouts(
+            rdb_session,
+            stale_threshold=datetime.timedelta(minutes=5),
+            limit=10,
+        )
+        current = await repo.get_by_id(rdb_session, runtime.id)
+
+        assert timed_out == []
+        assert current is not None
+        assert current.failure_code is None

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
@@ -100,11 +100,6 @@ class RuntimeLifecycleReconciler:
     async def reconcile_once(self, *, limit: int = _DEFAULT_LIMIT) -> int:
         """Dispatch one batch of pending lifecycle commands."""
         async with self._session_manager() as session:
-            timed_out = await self._runtime_repository.mark_start_timeouts(
-                session,
-                stale_threshold=self._config.start_timeout,
-                limit=limit,
-            )
             runtimes = (
                 await self._runtime_repository.find_lifecycle_dispatch_candidates(
                     session,
@@ -120,14 +115,6 @@ class RuntimeLifecycleReconciler:
                 )
             )
 
-        if timed_out:
-            _LOGGER.warning(
-                "Runtime lifecycle start timed out",
-                extra={
-                    "count": len(timed_out),
-                    "start_timeout_seconds": self._config.start_timeout.total_seconds(),
-                },
-            )
         dispatched = 0
         for runtime in runtimes:
             if await self._dispatch_runtime(runtime):
@@ -138,6 +125,27 @@ class RuntimeLifecycleReconciler:
                 continue
             if await self._dispatch_periodic_reconcile(runtime):
                 dispatched += 1
+
+        # A persisted CONNECTED flag can outlive the Control process that owned the
+        # actual Provider stream. Give the current coordination registry a chance to
+        # refresh that cache (or dispatch and refresh the start timer) before turning
+        # an old start attempt into a terminal timeout.
+        async with self._session_manager() as session:
+            timed_out = await self._runtime_repository.mark_start_timeouts(
+                session,
+                stale_threshold=self._config.start_timeout,
+                limit=limit,
+            )
+        if timed_out:
+            _LOGGER.warning(
+                "Runtime lifecycle start timed out",
+                extra={
+                    "count": len(timed_out),
+                    "start_timeout_seconds": (
+                        self._config.start_timeout.total_seconds()
+                    ),
+                },
+            )
         return dispatched
 
     async def _dispatch_runtime(self, runtime: AgentRuntime) -> bool:

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
@@ -60,6 +60,86 @@ from azents.runtime.coordination.memory import (
 from azents.testing.model_selection import make_test_model_selection_dict
 
 
+async def test_reconciler_refreshes_stale_provider_connection_before_start_timeout(
+    rdb_session_manager: SessionManager[AsyncSession],
+) -> None:
+    """A Control restart must not trust the previous process's connection cache."""
+    runtime_repository = AgentRuntimeRepository()
+    async with rdb_session_manager() as session:
+        workspace_id = await _create_workspace(session, "reconciler-stale-provider-ws")
+        agent_id = await _create_agent(
+            session,
+            workspace_id,
+            "reconciler-stale-provider-agent",
+            runtime_provider_id="provider-1",
+        )
+        runtime = await runtime_repository.ensure_for_agent(session, agent_id)
+        command = await runtime_repository.set_desired_state(
+            session,
+            runtime.id,
+            RuntimeLifecycleCommandType.START,
+            RuntimeDesiredState.RUNNING,
+        )
+        assert command is not None
+        dispatched = await runtime_repository.mark_lifecycle_dispatched(
+            session,
+            runtime.id,
+            command.desired_generation,
+        )
+        assert dispatched is not None
+        observed = await runtime_repository.record_provider_observed_state(
+            session,
+            runtime.id,
+            RuntimeProviderObservedState.STARTING,
+            1,
+            command.desired_generation,
+        )
+        assert observed is not None
+        connected = await runtime_repository.record_provider_connection_state(
+            session,
+            runtime.id,
+            RuntimeProviderConnectionState.CONNECTED,
+        )
+        assert connected is not None
+        old_state_change_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=10
+        )
+        await session.execute(
+            sa.update(RDBAgentRuntime)
+            .where(RDBAgentRuntime.id == runtime.id)
+            .values(last_state_change_at=old_state_change_at)
+        )
+
+    store = InMemoryRuntimeCoordinationStore()
+    reconciler = RuntimeLifecycleReconciler(
+        runtime_repository=runtime_repository,
+        policy_repository=RuntimeProviderPolicyRepository(),
+        session_manager=rdb_session_manager,
+        coordination_store=store,
+        control_protocol=RuntimeControlProtocolService(store),
+        config=RuntimeLifecycleDispatchConfig(
+            runner_image="runner:test",
+            runner_control_endpoint="runtime-control:9090",
+            runner_credential_identifier=_runner_credential_verifier(),
+            runner_control_tls_ca_pem=None,
+            allow_insecure_runner_control=True,
+            start_timeout=datetime.timedelta(minutes=5),
+            lifecycle_retry_delay=datetime.timedelta(minutes=1),
+        ),
+    )
+
+    dispatched_count = await reconciler.reconcile_once(limit=10)
+    async with rdb_session_manager() as session:
+        updated = await runtime_repository.get_by_agent_id(session, agent_id)
+
+    assert dispatched_count == 0
+    assert updated is not None
+    assert (
+        updated.provider_connection_state == RuntimeProviderConnectionState.DISCONNECTED
+    )
+    assert updated.failure_code is None
+
+
 async def test_reconciler_dispatches_periodic_provider_start_for_running_runtime(
     rdb_session_manager: SessionManager[AsyncSession],
 ) -> None:


### PR DESCRIPTION
## Summary

- refresh live Provider connectivity before evaluating Runtime start timeouts
- require the current desired generation to have reached the Provider before it can time out
- avoid applying a replacement Kubernetes Pod while deletion of the old same-name Pod is still in progress

## Root cause

During the production rollout, Runtime Control started at `12:04:58` and immediately trusted a persisted `connected` flag owned by the previous process, recording `START_TIMEOUT`. The current Kubernetes Provider did not acquire leadership and reconnect until `12:05:20`.

The following restart also deleted the old Pod and immediately attempted server-side apply under the same name. Because Kubernetes deletion is asynchronous, this became an immutable-field PATCH against the terminating Pod and failed with HTTP 422. A later retry created the Pod, which became Ready at `12:06:25`, but the UI had already exposed the false timeout failure.

## Validation

- Azents full suite: `3401 passed`
- Kubernetes Runtime Provider full suite: `77 passed`
- live-failure regression tests for stale Provider connection and undispatched generation timeout
- asynchronous Pod deletion/restart regression test
- Ruff and Pyright for both affected Python applications
- docs index validation

## Live state

The recovered Runtime is currently `Running/Ready`, desired and observed generation are both `442`, and the stale failure fields have cleared. This patch prevents the same false failure and Kubernetes 422 during future rollouts.
