### PR TITLE
Fix Runtime policy handoff and Gateway image

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,7 +32,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 34 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 35 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,7 +29,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 34 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 35 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -30,7 +30,7 @@ code_paths:
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
 last_verified_at: 2026-07-27
-spec_version: 34
+spec_version: 35
 ---
 
 # Agent Runtime Control
@@ -99,7 +99,7 @@ The store owns:
 - generation fencing data used to reject stale provider/runner messages
 - request claim cursors and stream metadata used to acknowledge delivered Provider/Runner requests
 
-Generation fencing is enforced before volatile stream messages mutate durable state. Control rejects or closes Provider/Runner streams whose inbound message generation differs from the accepted registration generation. Durable Provider reports are accepted only when both the Provider stream generation and observed desired generation are monotonic relative to the `agent_runtimes` row. Durable Runner state reports are accepted only when the Runner generation is not older than the row generation. Stale reports must not overwrite workspace path, observed state, runner availability, or current failure fields.
+Generation fencing is enforced before volatile stream messages mutate durable state. Control rejects or closes Provider/Runner streams whose inbound message generation differs from the accepted registration generation. Durable Provider reports are accepted only when both the Provider stream generation and observed desired generation are monotonic relative to the `agent_runtimes` row. Durable Runner state reports are accepted only when the Runner generation is not older than the row generation and the reported execution-policy desired generation equals the current durable desired generation. A Runner from the replaced desired generation is ignored during workload handoff and cannot create an evidence-mismatch failure for the new target. Stale reports must not overwrite workspace path, observed state, runner availability, or current failure fields.
 
 Provider report framing always uses the generation accepted for the current Control stream. A Provider reconnect or leader failover may observe backend resources whose labels contain an older Provider generation; those labels are historical command metadata and must be replaced with the current connection generation before initial resync reports, watch reports, or command completion reports are sent to Control.
 
@@ -290,6 +290,7 @@ target can be reconciled.
 Production deploys the new path through GitOps:
 
 - ECR repositories and GitHub Actions build/push runtime images.
+- The policy Gateway image exposes its executable at the stable `/usr/local/bin/azents-container-policy-gateway` path consumed by the Kubernetes Provider for the container command and readiness probe.
 - Helm values/templates render runtime-control, runtime-runner, and Kubernetes provider settings.
 - ArgoCD Application/root/overlay includes the runtime provider deployment.
 - Final cutover defaults route production to the Agent Runtime path and disables/prunes the legacy sandbox provider-control traffic path.
@@ -313,6 +314,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-27** (spec_version 35) — Fenced Runner policy evidence by desired generation during workload replacement and aligned the Gateway image executable with the Kubernetes container contract.
 - **2026-07-27** (spec_version 34) — Prevented false start timeouts across Control rollouts and made Kubernetes Runtime Pod replacement wait for asynchronous deletion before recreation.
 - **2026-07-27** (spec_version 33) — Made mixed-policy convergence use a valid module-level security meet and kept invalidated historical evidence in automatic recovery state.
 - **2026-07-27** (spec_version 32) — Removed Platform policy source evidence and made the selected Profile the complete execution ceiling.

--- a/python/apps/azents-container-policy-gateway/Dockerfile
+++ b/python/apps/azents-container-policy-gateway/Dockerfile
@@ -14,9 +14,10 @@ COPY python/apps/azents-container-policy-gateway/src ./src
 
 RUN uv sync --frozen --no-dev \
     && groupadd --gid 1001 gateway \
-    && useradd --uid 1001 --gid 1001 --no-create-home --home-dir /nonexistent gateway
+    && useradd --uid 1001 --gid 1001 --no-create-home --home-dir /nonexistent gateway \
+    && ln -s /workspace/python/apps/azents-container-policy-gateway/.venv/bin/azents-container-policy-gateway /usr/local/bin/azents-container-policy-gateway
 
 USER 1001:1001
 
-ENTRYPOINT ["/workspace/python/apps/azents-container-policy-gateway/.venv/bin/azents-container-policy-gateway"]
+ENTRYPOINT ["/usr/local/bin/azents-container-policy-gateway"]
 CMD ["serve"]

--- a/python/apps/azents-container-policy-gateway/tests/image_contract_test.py
+++ b/python/apps/azents-container-policy-gateway/tests/image_contract_test.py
@@ -50,3 +50,9 @@ def test_gateway_image_runs_as_the_fixed_unprivileged_user() -> None:
     assert "useradd --uid 1001 --gid 1001" in dockerfile
     assert "USER 1001:1001" in dockerfile
     assert "uv sync --frozen --no-dev" in dockerfile
+    assert (
+        "ln -s /workspace/python/apps/azents-container-policy-gateway/"
+        ".venv/bin/azents-container-policy-gateway "
+        "/usr/local/bin/azents-container-policy-gateway"
+    ) in dockerfile
+    assert 'ENTRYPOINT ["/usr/local/bin/azents-container-policy-gateway"]' in dockerfile

--- a/python/apps/azents/src/azents/runtime/control_protocol/grpc/state_sinks.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/grpc/state_sinks.py
@@ -204,6 +204,8 @@ class RuntimeRunnerStateRepositorySink:
                     failure=None,
                 )
                 return
+            if report.execution_policy.desired_generation != runtime.desired_generation:
+                return
             failure = _workspace_failure(
                 provider_workspace_path=runtime.workspace_path,
                 runner_workspace_path=report.workspace_path,

--- a/python/apps/azents/src/azents/runtime/control_protocol/grpc/state_sinks_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/grpc/state_sinks_test.py
@@ -380,6 +380,54 @@ async def test_runner_state_sink_ignores_stale_report_with_lower_generation(
     assert runtime.runner_generation == 2
 
 
+async def test_runner_state_sink_ignores_previous_desired_generation(
+    rdb_session_manager: SessionManager[AsyncSession],
+) -> None:
+    """A replaced Runner cannot fail the next desired Runtime generation."""
+    repo = AgentRuntimeRepository()
+    async with rdb_session_manager() as session:
+        runtime_id = await _create_runtime(session, "runner-sink-stale-desired")
+        command = await repo.set_desired_state(
+            session,
+            runtime_id,
+            RuntimeLifecycleCommandType.RESTART,
+            RuntimeDesiredState.RUNNING,
+        )
+        assert command is not None
+        await repo.record_provider_observed_state(
+            session,
+            runtime_id,
+            RuntimeProviderObservedState.STARTING,
+            1,
+            command.desired_generation,
+            workspace_path="/workspace/provider",
+        )
+    policy_repository = _policy_repository()
+    sink = RuntimeRunnerStateRepositorySink(
+        repo,
+        policy_repository,
+        rdb_session_manager,
+    )
+
+    await sink.record_runner_state(
+        _report(
+            runtime_id,
+            "/workspace/provider",
+            state=SharedRunnerState.FAILED,
+            runner_generation=99,
+            policy_desired_generation=command.desired_generation - 1,
+        )
+    )
+
+    async with rdb_session_manager() as session:
+        runtime = await repo.get_by_id(session, runtime_id)
+    assert runtime is not None
+    assert runtime.runner_state == RuntimeRunnerState.UNKNOWN
+    assert runtime.runner_generation == 0
+    assert runtime.failure_generation is None
+    assert runtime.failure_code is None
+
+
 async def _create_runtime(session: AsyncSession, slug: str) -> str:
     workspace_repo = WorkspaceRepository()
     result = await workspace_repo.create(
@@ -450,6 +498,7 @@ def _report(
     state: SharedRunnerState = SharedRunnerState.READY,
     runner_generation: int = 1,
     diagnostic: dict[str, str] | None = None,
+    policy_desired_generation: int = 0,
 ) -> RunnerStateReport:
     return RunnerStateReport(
         runtime_id=runtime_id,
@@ -462,7 +511,7 @@ def _report(
         diagnostic=diagnostic or {},
         workspace_path=workspace_path,
         reported_at=datetime(2026, 5, 25, tzinfo=UTC),
-        execution_policy=_execution_policy_evidence(),
+        execution_policy=_execution_policy_evidence(policy_desired_generation),
     )
 
 


### PR DESCRIPTION
## Summary

- fence Runner policy reports by desired generation during Runtime workload replacement
- expose the policy Gateway executable at the stable path used by the Kubernetes Provider
- add regression coverage and update the Runtime Control living spec

## Root cause

After an explicit policy Apply advanced the Runtime target, the replaced Runner could report evidence from the previous desired generation before its stream closed. Control treated that normal handoff report as a current-generation RUNTIME_POLICY_RUNNER_EVIDENCE_MISMATCH failure. The replacement Pod then failed independently because the Kubernetes Provider invoked /usr/local/bin/azents-container-policy-gateway, while the image only installed its executable inside the project virtual environment.

## Impact

Runtime policy Apply no longer fails on stale Runner evidence during replacement, and Docker-enabled Kubernetes Runtime Pods can start the policy Gateway at the declared container command and readiness-probe path.

## Validation

- azents: Ruff, Pyright, 3,402 tests
- Kubernetes Provider: Ruff, Pyright, 77 tests
- Container Policy Gateway: Ruff, Pyright, 141 tests
- deterministic E2E: 266 passed, 6 skipped
- locally built Gateway image and executed /usr/local/bin/azents-container-policy-gateway --help
- docs index validation and pre-commit hooks