### PR TITLE
Fix Docker CLI create defaults

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,7 +32,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 35 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 36 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,7 +29,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 35 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 36 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -30,7 +30,7 @@ code_paths:
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
 last_verified_at: 2026-07-27
-spec_version: 35
+spec_version: 36
 ---
 
 # Agent Runtime Control
@@ -291,6 +291,7 @@ Production deploys the new path through GitOps:
 
 - ECR repositories and GitHub Actions build/push runtime images.
 - The policy Gateway image exposes its executable at the stable `/usr/local/bin/azents-container-policy-gateway` path consumed by the Kubernetes Provider for the container command and readiness probe.
+- The policy Gateway treats Docker CLI's `HostConfig.MemorySwappiness=-1` wire default as unset and removes it before forwarding, while rejecting explicit swappiness authority.
 - Helm values/templates render runtime-control, runtime-runner, and Kubernetes provider settings.
 - ArgoCD Application/root/overlay includes the runtime provider deployment.
 - Final cutover defaults route production to the Agent Runtime path and disables/prunes the legacy sandbox provider-control traffic path.
@@ -314,6 +315,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-27** (spec_version 36) — Normalized Docker CLI's unset memory-swappiness sentinel so ordinary `docker run` requests pass the policy Gateway without granting swappiness authority.
 - **2026-07-27** (spec_version 35) — Fenced Runner policy evidence by desired generation during workload replacement and aligned the Gateway image executable with the Kubernetes container contract.
 - **2026-07-27** (spec_version 34) — Prevented false start timeouts across Control rollouts and made Kubernetes Runtime Pod replacement wait for asynchronous deletion before recreation.
 - **2026-07-27** (spec_version 33) — Made mixed-policy convergence use a valid module-level security meet and kept invalidated historical evidence in automatic recovery state.

--- a/python/apps/azents-container-policy-gateway/src/azents_container_policy_gateway/authorization.py
+++ b/python/apps/azents-container-policy-gateway/src/azents_container_policy_gateway/authorization.py
@@ -834,7 +834,10 @@ def _host_config(
         "IOMaximumBandwidth",
     }
     for field in always_denied:
-        if _has_authority(value.get(field)):
+        field_value = value.get(field)
+        if field == "MemorySwappiness" and field_value == -1:
+            continue
+        if _has_authority(field_value):
             raise GatewayAuthorizationDenied(
                 "unsafe_container_field",
                 f"HostConfig.{field} is not permitted.",

--- a/python/apps/azents-container-policy-gateway/tests/authorization_test.py
+++ b/python/apps/azents-container-policy-gateway/tests/authorization_test.py
@@ -119,7 +119,7 @@ def _docker_cli_create_wire_body() -> dict[str, object]:
             "DeviceRequests": None,
             "MemoryReservation": 0,
             "MemorySwap": 0,
-            "MemorySwappiness": None,
+            "MemorySwappiness": -1,
             "OomKillDisable": None,
             "PidsLimit": 0,
             "Ulimits": None,
@@ -307,6 +307,7 @@ def test_pinned_docker_cli_create_defaults_are_normalized(
     assert request.requested_pids_limit == 32
     assert value["HostConfig"]["PidsLimit"] == 32
     assert value["HostConfig"]["ShmSize"] == 67_108_864
+    assert "MemorySwappiness" not in value["HostConfig"]
     assert value["AttachStdout"] is True
     assert value["AttachStderr"] is True
     for dropped in (
@@ -319,6 +320,26 @@ def test_pinned_docker_cli_create_defaults_are_normalized(
         "OnBuild",
     ):
         assert dropped not in value
+
+
+@pytest.mark.parametrize("memory_swappiness", [1, 50, 100])
+def test_container_create_rejects_explicit_memory_swappiness(
+    run_policy: RuntimeExecutionPolicy,
+    memory_swappiness: int,
+) -> None:
+    body = _docker_cli_create_wire_body()
+    host_config = body["HostConfig"]
+    assert isinstance(host_config, dict)
+    host_config["MemorySwappiness"] = memory_swappiness
+
+    with pytest.raises(GatewayAuthorizationDenied, match="MemorySwappiness"):
+        _authorize(
+            run_policy,
+            method="POST",
+            path="/v1.51/containers/create",
+            headers=json_headers(),
+            body=body,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- normalize Docker CLI 28.5.2's `HostConfig.MemorySwappiness=-1` default as unset
- keep explicit memory-swappiness authority rejected by the Runtime policy Gateway
- pin the real CLI wire default in authorization coverage and document the contract

## Root cause

An ordinary `docker run` request from the Runtime's Docker CLI includes `MemorySwappiness=-1` to mean no explicit setting. The Gateway treated every nonzero value as requested authority, rejected container creation, and returned `HostConfig.MemorySwappiness is not permitted` before the Docker daemon could start the container.

## Impact

Normal Docker container creation can pass through the Gateway while callers still cannot configure memory swappiness.

## Validation

- `TMPDIR=/tmp uv run ruff check .`
- `TMPDIR=/tmp uv run ruff format --check .`
- `TMPDIR=/tmp uv run pyright`
- `TMPDIR=/tmp uv run pytest` (`144 passed`)
- pre-commit on all five changed files

Live reproduction before the fix: `docker run --rm alpine:3.22 /bin/true` reached the Docker daemon through the Gateway but failed with `HostConfig.MemorySwappiness is not permitted`.
