### PR TITLE
Normalize Docker client headers

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,7 +32,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 36 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 37 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,7 +29,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 36 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-27 | 37 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-27 | 10 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -30,7 +30,7 @@ code_paths:
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
 last_verified_at: 2026-07-27
-spec_version: 36
+spec_version: 37
 ---
 
 # Agent Runtime Control
@@ -292,6 +292,7 @@ Production deploys the new path through GitOps:
 - ECR repositories and GitHub Actions build/push runtime images.
 - The policy Gateway image exposes its executable at the stable `/usr/local/bin/azents-container-policy-gateway` path consumed by the Kubernetes Provider for the container command and readiness probe.
 - The policy Gateway treats Docker CLI's `HostConfig.MemorySwappiness=-1` wire default as unset and removes it before forwarding, while rejecting explicit swappiness authority.
+- The policy Gateway validates transport framing and security-sensitive headers, forwards only its fixed Engine header contract, and silently removes all other bounded client metadata instead of coupling compatibility to individual Docker clients.
 - Helm values/templates render runtime-control, runtime-runner, and Kubernetes provider settings.
 - ArgoCD Application/root/overlay includes the runtime provider deployment.
 - Final cutover defaults route production to the Agent Runtime path and disables/prunes the legacy sandbox provider-control traffic path.
@@ -315,6 +316,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-27** (spec_version 37) — Replaced the Docker client header allowlist with effect-based validation and stripping so SDK metadata cannot break otherwise authorized Engine operations.
 - **2026-07-27** (spec_version 36) — Normalized Docker CLI's unset memory-swappiness sentinel so ordinary `docker run` requests pass the policy Gateway without granting swappiness authority.
 - **2026-07-27** (spec_version 35) — Fenced Runner policy evidence by desired generation during workload replacement and aligned the Gateway image executable with the Kubernetes container contract.
 - **2026-07-27** (spec_version 34) — Prevented false start timeouts across Control rollouts and made Kubernetes Runtime Pod replacement wait for asynchronous deletion before recreation.

--- a/python/apps/azents-container-policy-gateway/src/azents_container_policy_gateway/authorization.py
+++ b/python/apps/azents-container-policy-gateway/src/azents_container_policy_gateway/authorization.py
@@ -23,23 +23,13 @@ _MAX_BUILD_CONTEXT_FILES = 10_000
 _MAX_QUERY_BYTES = 64 * 1024
 _MAX_BUILD_CONTEXT_BYTES = 256 * 1024 * 1024
 _GATEWAY_MEMORY_MAX_BYTES = 512 * 1024 * 1024
-_CLIENT_HEADERS = frozenset(
-    {
-        "accept",
-        "accept-encoding",
-        "content-encoding",
-        "content-length",
-        "content-type",
-        "host",
-        "transfer-encoding",
-        "user-agent",
-        "x-azents-correlation-id",
-    }
-)
 _FORWARDED_HEADERS = frozenset({"accept", "content-encoding", "content-type"})
 _FORBIDDEN_HEADERS = frozenset(
     {
-        "connection",
+        "expect",
+        "proxy-connection",
+        "te",
+        "trailer",
         "upgrade",
         "x-registry-auth",
         "x-registry-config",
@@ -532,11 +522,14 @@ def _validate_headers(
             "unsafe_header",
             f"Unsupported headers: {', '.join(sorted(forbidden))}.",
         )
-    unknown = set(lowered).difference(_CLIENT_HEADERS)
-    if unknown:
+    connection = lowered.get("connection")
+    if connection is not None and connection.strip().lower() not in {
+        "close",
+        "keep-alive",
+    }:
         raise GatewayAuthorizationDenied(
-            "unsupported_header",
-            f"Unsupported headers: {', '.join(sorted(unknown))}.",
+            "unsafe_header",
+            "Only close and keep-alive Connection headers are supported.",
         )
     content_length = lowered.get("content-length")
     if content_length is not None and (

--- a/python/apps/azents-container-policy-gateway/tests/authorization_test.py
+++ b/python/apps/azents-container-policy-gateway/tests/authorization_test.py
@@ -676,7 +676,7 @@ def test_unsupported_methods_and_paths_are_denied(
         _authorize(run_policy, method=method, path=path)
 
 
-def test_query_and_header_surface_is_default_deny(
+def test_query_surface_is_default_deny(
     run_policy: RuntimeExecutionPolicy,
 ) -> None:
     with pytest.raises(GatewayAuthorizationDenied, match="Duplicate"):
@@ -693,12 +693,69 @@ def test_query_and_header_surface_is_default_deny(
             path="/v1.51/containers/json",
             query=(("all", "yes"),),
         )
+
+
+@pytest.mark.parametrize("connection", ["keep-alive", "close", "KEEP-ALIVE"])
+def test_nonsemantic_client_headers_are_accepted_and_stripped(
+    run_policy: RuntimeExecutionPolicy,
+    connection: str,
+) -> None:
+    request = authorize_request(
+        policy=run_policy,
+        runtime_id="runtime-1",
+        method="GET",
+        raw_path="/v1.51/containers/json",
+        query=(),
+        headers={
+            "Accept": "application/json",
+            "Connection": connection,
+            "X-Client-Metadata": "session-1",
+        },
+        body=b"",
+    )
+
+    assert request.headers == {"accept": "application/json"}
+
+
+@pytest.mark.parametrize(
+    "connection",
+    ["upgrade", "keep-alive, upgrade", "x-client-metadata", ""],
+)
+def test_authority_bearing_connection_headers_are_denied(
+    run_policy: RuntimeExecutionPolicy,
+    connection: str,
+) -> None:
+    with pytest.raises(GatewayAuthorizationDenied, match="Connection"):
+        _authorize(
+            run_policy,
+            method="GET",
+            path="/v1.51/containers/json",
+            headers={"Connection": connection},
+        )
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Expect",
+        "Proxy-Connection",
+        "TE",
+        "Trailer",
+        "Upgrade",
+        "X-Registry-Auth",
+        "X-Registry-Config",
+    ],
+)
+def test_security_sensitive_headers_remain_denied(
+    run_policy: RuntimeExecutionPolicy,
+    header: str,
+) -> None:
     with pytest.raises(GatewayAuthorizationDenied, match="headers"):
         _authorize(
             run_policy,
             method="GET",
             path="/v1.51/containers/json",
-            headers={"X-Unrecognized": "value"},
+            headers={header: "value"},
         )
 
 


### PR DESCRIPTION
## What changed

- Validate Docker client headers by security effect instead of maintaining a client-specific allowlist.
- Accept `Connection: close` and `Connection: keep-alive`, while rejecting unsafe connection-token values.
- Strip bounded client metadata before forwarding requests to the Docker Engine.
- Continue rejecting transport-sensitive and registry-credential headers.

## Why

Python docker-py sends a `Connection` header and testcontainers adds client metadata such as `x-tc-sid`. These headers are not authority-bearing, but the gateway rejected them before an allowed Docker API request reached the Engine. The gateway should remain independent of individual Docker clients while forwarding only its fixed Engine-facing header contract.

## Validation

- Gateway Ruff, format, and Pyright checks passed.
- Gateway test suite: 158 passed.
- Changed-file pre-commit checks passed.
- Focused deterministic E2E passed.
- Real pinned Docker-in-Docker integration passed through the gateway with docker-py 7.1.0 and testcontainers 4.14.0:
  - Docker SDK ping
  - testcontainers Network create/remove
  - testcontainers Alpine container create/start/log/remove

## Local DIND environment

- Point `DOCKER_HOST` at `unix:///var/run/azents-gateway/docker.sock`.
- Set `TESTCONTAINERS_RYUK_DISABLED=true`; Ryuk requires Docker socket bind-mount/privilege that the Runtime intentionally does not expose.
- Use the Runtime-pinned Docker Engine/API 1.51. A newer host Engine may negotiate an API version outside the gateway's supported surface.
