### PR TITLE
Restore Docker Buildx in runtime runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -517,7 +517,10 @@ jobs:
             azents-runtime-runner)
               docker run --rm --entrypoint sh "${{ matrix.image }}" -ec \
                 'docker --version | grep -F "Docker version 28.5.2" &&
+                 docker buildx version | grep -F "github.com/docker/buildx v0.29.1" &&
                  docker compose version | grep -F "Docker Compose version v2.40.3" &&
+                 test -z "${DOCKER_BUILDKIT:-}" &&
+                 test -z "${COMPOSE_DOCKER_CLI_BUILD:-}" &&
                  test ! -e /var/run/azents-engine/docker.sock'
               ;;
             azents-runtime-engine)

--- a/python/apps/azents-runtime-runner/Dockerfile
+++ b/python/apps/azents-runtime-runner/Dockerfile
@@ -4,11 +4,10 @@ FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea5
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.1@sha256:fc93e9ecd7218e9ec8fba117af89348eef8fd2463c50c13347478769aaedd0ce /uv /uvx /bin/
 COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
 
 ENV DOCKER_API_VERSION=1.51
-ENV DOCKER_BUILDKIT=0
-ENV COMPOSE_DOCKER_CLI_BUILD=0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -111,6 +110,7 @@ RUN pip install --no-cache-dir --break-system-packages \
 RUN playwright install-deps chromium
 
 RUN docker --version | grep -F "Docker version 28.5.2" \
+    && docker buildx version | grep -F "github.com/docker/buildx v0.29.1" \
     && docker compose version | grep -F "Docker Compose version v2.40.3" \
     && test ! -e /var/run/azents-engine/docker.sock
 

--- a/testenv/azents/scripts/verify-runtime-docker.py
+++ b/testenv/azents/scripts/verify-runtime-docker.py
@@ -96,6 +96,7 @@ def _wait_for_engine(client: list[str], engine_name: str) -> None:
 
 
 def _verify_cli(client: list[str]) -> None:
+    _run([*client, "docker", "buildx", "version"])
     dockerfile = textwrap.dedent(
         """
         FROM alpine:3.22
@@ -104,7 +105,16 @@ def _verify_cli(client: list[str]) -> None:
         """
     )
     _run(
-        [*client, "docker", "build", "--tag", "azents-runtime-docker-proof:latest", "-"],
+        [
+            *client,
+            "docker",
+            "buildx",
+            "build",
+            "--load",
+            "--tag",
+            "azents-runtime-docker-proof:latest",
+            "-",
+        ],
         input_text=dockerfile,
     )
     result = _run(


### PR DESCRIPTION
## What changed

- copy the Docker Buildx CLI plugin into the Runtime Runner image
- remove the legacy BuildKit-disable environment variables left over from the policy gateway
- make the Runtime Docker workflow prove a real `docker buildx build --load`
- add image smoke checks for Buildx and the removed environment overrides

## Why

The Runtime Runner image copied Docker CLI and Compose from `docker:28.5.2-cli`, but omitted the Buildx plugin. As a result, normal development workflows failed with `docker: unknown command: docker buildx`.

## Validation

- built the complete Runtime Runner image locally
- verified Docker 28.5.2, Buildx v0.29.1, and Compose v2.40.3 inside the built image
- ran the DIND workflow end-to-end, including Buildx build/load, container run, Compose, Python Docker SDK, Testcontainers Network, PostgreSQL port binding, and Ryuk
- `python -m py_compile testenv/azents/scripts/verify-runtime-docker.py`
- Ruff check and format check
- pre-commit hooks for all changed files