### PR TITLE
Support Runtime Docker bind mounts

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,8 +32,8 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-28 | 38 |
-| [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-28 | 11 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-28 | 39 |
+| [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-28 | 12 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |
 | [Context Compaction](spec/flow/context-compaction.md) | @Hardtack | 2026-07-22 | 31 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,8 +29,8 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-28 | 38 |
-| [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-28 | 11 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-28 | 39 |
+| [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-28 | 12 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |
 | [Context Compaction](flow/context-compaction.md) | @Hardtack | 2026-07-22 | 31 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -30,7 +30,7 @@ code_paths:
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
 last_verified_at: 2026-07-28
-spec_version: 38
+spec_version: 39
 ---
 
 # Agent Runtime Control
@@ -291,6 +291,7 @@ Production deploys the new path through GitOps:
 
 - ECR repositories and GitHub Actions build/push runtime images.
 - A Docker-enabled Kubernetes Runtime mounts its private DIND Unix socket directly into the Runner.
+- The Runner and DIND sidecar mount the Agent Workspace and Pod-local shared temporary directory at identical absolute paths so ordinary workspace and temporary-file bind mounts resolve against the same files in both containers.
 - The Runner receives Docker and Testcontainers endpoint settings; no Azents component filters or rewrites Docker HTTP requests.
 - The privileged DIND sidecar receives the Profile's Kubernetes resource values and owns a separate bounded temporary data volume.
 - Helm values/templates render runtime-control, runtime-runner, and Kubernetes provider settings.
@@ -309,7 +310,7 @@ Required deterministic coverage:
 - Runner operation tests for process, file, Git, and strict V4A patch operations
 - Runtime Control contract tests for ordered operation cancellation, start/cancel races, terminal cursor authority, and typed patch result folding
 - Provider tests for Docker host bind mount persistence, Kubernetes PVC persistence, direct DIND socket topology, and deployment-owned NetworkPolicy hard caps
-- Docker compatibility tests for CLI, Compose, SDK, Testcontainers Network, PostgreSQL port binding, and Ryuk cleanup
+- Docker compatibility tests for CLI, Buildx, Compose, workspace and temporary-file bind mounts, SDK, Testcontainers Network, PostgreSQL port binding, and Ryuk cleanup
 - azents deterministic E2E for Agent Workspace bootstrap and lifecycle actions
 - credential-free runtime-provider E2E for multi-file `apply_patch`, typed results, final manifests, and traversal rejection
 
@@ -317,6 +318,7 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-28** (spec_version 39) — Shared the Agent Workspace and Pod-local temporary directory with the DIND sidecar at identical paths so ordinary Docker and Compose bind mounts resolve correctly.
 - **2026-07-28** (spec_version 38) — Removed the Container Policy Gateway, exposed each Runtime's private DIND socket directly, collapsed Docker into one atomic v1 capability, and removed unenforceable nested PID/count and Profile network controls.
 - **2026-07-27** (spec_version 37) — Replaced the Docker client header allowlist with effect-based validation and stripping so SDK metadata cannot break otherwise authorized Engine operations.
 - **2026-07-27** (spec_version 36) — Normalized Docker CLI's unset memory-swappiness sentinel so ordinary `docker run` requests pass the policy Gateway without granting swappiness authority.

--- a/docs/azents/spec/flow/agent-runtime-persistence.md
+++ b/docs/azents/spec/flow/agent-runtime-persistence.md
@@ -18,7 +18,7 @@ code_paths:
   - infra/charts/azents/**
   - infra/argocd/azents-runtime-provider-kubernetes/**
 last_verified_at: 2026-07-28
-spec_version: 11
+spec_version: 12
 ---
 
 # Agent Runtime Persistence
@@ -133,6 +133,12 @@ Docker-disabled Runtime contains only the unprivileged Runner. A Docker-enabled 
 privileged DIND sidecar and mounts its Runtime-private Unix socket read-only into the Runner. There
 is no Docker API Gateway or partial operation allowlist. The complete Docker capability supports
 CLI, Compose, SDK, Testcontainers, Ryuk, and port-binding workflows supported by the daemon.
+The Runner and DIND sidecar mount the Agent Workspace PVC at the same provider-reported absolute
+path and mount one Pod-local shared temporary volume at `/tmp`, bounded by the Profile's Runtime
+ephemeral-storage allocation. Docker bind mounts sourced from the Agent Workspace or `/tmp`,
+including Compose paths relative to the Agent Workspace, therefore resolve to the same files from
+the Docker daemon's mount namespace. Other Runner root-filesystem paths are not shared bind-mount
+sources.
 
 The Runner and nested workloads do not receive the Provider ServiceAccount, Provider credentials,
 host Docker socket, or another Runtime's DIND socket. Agent Workspace PVC storage remains distinct
@@ -186,6 +192,7 @@ Required checks:
 
 ## Changelog
 
+- **2026-07-28 (spec_version=12)** — Mounted the Agent Workspace and Pod-local `/tmp` into the Runner and DIND sidecar at identical paths to support ordinary Docker and Compose bind mounts.
 - **2026-07-28 (spec_version=11)** — Replaced the policy Gateway with a direct Runtime-private DIND socket, collapsed Docker operations into one capability, and removed unenforceable PID, nested-container, and Profile network controls while retaining Kubernetes resource, storage, and deployment hard-cap boundaries.
 - **2026-07-27 (spec_version=10)** — Added all implemented Profile network modes, Kubernetes request/limit resource semantics, and Profile-controlled PVC expansion with destructive shrink application.
 - **2026-07-27 (spec_version=9)** — Removed Platform execution-policy state and made the selected Profile the complete versioned ceiling and snapshot source.

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -86,9 +86,11 @@ _ENGINE_CONTAINER_NAME = "container-engine"
 _WORKSPACE_VOLUME_NAME = "agent-workspace"
 _ENGINE_SOCKET_VOLUME_NAME = "container-engine-socket"
 _ENGINE_STORAGE_VOLUME_NAME = "container-engine-storage"
+_SHARED_TMP_VOLUME_NAME = "runtime-shared-tmp"
 _ENGINE_SOCKET_DIR = "/var/run/azents-engine"
 _ENGINE_STORAGE_PATH = "/var/lib/azents-engine"
 _ENGINE_SOCKET_PATH = f"{_ENGINE_SOCKET_DIR}/docker.sock"
+_SHARED_TMP_PATH = "/tmp"
 _RUNNER_UID = 1000
 _RUNNER_GID = 1000
 _ENGINE_SOCKET_GROUP = "azents-runner"
@@ -639,8 +641,11 @@ class KubernetesRuntimeProvider:
     ) -> PodResource:
         docker_enabled = policy.docker.enabled
         docker_storage_capacity = policy.docker.storage_capacity_bytes
+        runtime_ephemeral_storage = policy.resources.ephemeral_storage_bytes
         if docker_enabled and docker_storage_capacity is None:
             raise AssertionError("Docker storage capacity is required")
+        if docker_enabled and runtime_ephemeral_storage is None:
+            raise AssertionError("Runtime ephemeral storage is required")
         return PodResource(
             metadata=ObjectMeta(
                 name=_pod_name(command.identity.runtime_id),
@@ -667,6 +672,11 @@ class KubernetesRuntimeProvider:
                                 name=_ENGINE_SOCKET_VOLUME_NAME,
                                 medium="Memory",
                                 size_limit="16Mi",
+                            ),
+                            EmptyDirVolume(
+                                name=_SHARED_TMP_VOLUME_NAME,
+                                medium=None,
+                                size_limit=str(runtime_ephemeral_storage),
                             ),
                             EmptyDirVolume(
                                 name=_ENGINE_STORAGE_VOLUME_NAME,
@@ -702,6 +712,13 @@ class KubernetesRuntimeProvider:
                     name=_ENGINE_SOCKET_VOLUME_NAME,
                     mount_path=_ENGINE_SOCKET_DIR,
                     read_only=True,
+                )
+            )
+            runner_mounts.append(
+                VolumeMount(
+                    name=_SHARED_TMP_VOLUME_NAME,
+                    mount_path=_SHARED_TMP_PATH,
+                    read_only=False,
                 )
             )
             runner_env[_ENV_DOCKER_HOST] = f"unix://{_ENGINE_SOCKET_PATH}"
@@ -745,8 +762,18 @@ class KubernetesRuntimeProvider:
             env=(),
             volume_mounts=(
                 VolumeMount(
+                    name=_WORKSPACE_VOLUME_NAME,
+                    mount_path=self._workspace_mount_path,
+                    read_only=False,
+                ),
+                VolumeMount(
                     name=_ENGINE_SOCKET_VOLUME_NAME,
                     mount_path=_ENGINE_SOCKET_DIR,
+                    read_only=False,
+                ),
+                VolumeMount(
+                    name=_SHARED_TMP_VOLUME_NAME,
+                    mount_path=_SHARED_TMP_PATH,
                     read_only=False,
                 ),
                 VolumeMount(

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -362,6 +362,8 @@ async def test_start_creates_pvc_and_pod_with_workspace_mount() -> None:
     workspace_volume = pod.spec.volumes[0]
     assert isinstance(workspace_volume, PersistentVolumeClaimVolume)
     assert workspace_volume.claim_name == pvc.metadata.name
+    assert [volume.name for volume in pod.spec.volumes] == ["agent-workspace"]
+    assert [mount.name for mount in container.volume_mounts] == ["agent-workspace"]
     assert pvc.spec.storage_class_name == "gp3"
     assert pvc.spec.storage_request == "20Gi"
     assert "azents/workspace-path" not in pod.metadata.labels
@@ -645,6 +647,8 @@ async def test_start_reuses_pod_with_canonicalized_kubernetes_quantities() -> No
     engine = pod.spec.containers[-1]
     assert engine.resources is not None
     assert engine.resources.limits is not None
+    shared_tmp = pod.spec.volumes[-2]
+    assert isinstance(shared_tmp, EmptyDirVolume)
     engine_storage = pod.spec.volumes[-1]
     assert isinstance(engine_storage, EmptyDirVolume)
     api.pods[pod_key] = dataclasses.replace(
@@ -667,7 +671,11 @@ async def test_start_reuses_pod_with_canonicalized_kubernetes_quantities() -> No
                 ),
             ),
             volumes=(
-                *pod.spec.volumes[:-1],
+                *pod.spec.volumes[:-2],
+                dataclasses.replace(
+                    shared_tmp,
+                    size_limit="10Gi",
+                ),
                 dataclasses.replace(
                     engine_storage,
                     size_limit="8Gi",
@@ -1405,6 +1413,7 @@ async def test_docker_policy_exposes_private_dind_socket_directly() -> None:
     assert {mount.name for mount in runner.volume_mounts} == {
         "agent-workspace",
         "container-engine-socket",
+        "runtime-shared-tmp",
     }
     runner_engine_mount = next(
         mount
@@ -1421,10 +1430,21 @@ async def test_docker_policy_exposes_private_dind_socket_directly() -> None:
         "/var/run/azents-engine/docker.sock"
     )
     assert {mount.name for mount in engine.volume_mounts} == {
+        "agent-workspace",
         "container-engine-socket",
         "container-engine-storage",
+        "runtime-shared-tmp",
     }
-    assert all(mount.name != "agent-workspace" for mount in engine.volume_mounts)
+    runner_mounts = {mount.name: mount for mount in runner.volume_mounts}
+    engine_mounts = {mount.name: mount for mount in engine.volume_mounts}
+    assert runner_mounts["agent-workspace"].mount_path == "/workspace/agent"
+    assert engine_mounts["agent-workspace"].mount_path == "/workspace/agent"
+    assert runner_mounts["agent-workspace"].read_only is False
+    assert engine_mounts["agent-workspace"].read_only is False
+    assert runner_mounts["runtime-shared-tmp"].mount_path == "/tmp"
+    assert engine_mounts["runtime-shared-tmp"].mount_path == "/tmp"
+    assert runner_mounts["runtime-shared-tmp"].read_only is False
+    assert engine_mounts["runtime-shared-tmp"].read_only is False
     assert engine.args[-1] == "--group=azents-runner"
     assert engine.readiness_probe is not None
     engine_probe = engine.readiness_probe.exec_action.command
@@ -1433,6 +1453,11 @@ async def test_docker_policy_exposes_private_dind_socket_directly() -> None:
     engine_storage = pod.spec.volumes[-1]
     assert isinstance(engine_storage, EmptyDirVolume)
     assert engine_storage.size_limit == "8589934592"
+    shared_tmp = pod.spec.volumes[-2]
+    assert isinstance(shared_tmp, EmptyDirVolume)
+    assert shared_tmp.name == "runtime-shared-tmp"
+    assert shared_tmp.medium is None
+    assert shared_tmp.size_limit == "10737418240"
     assert len(api.pvcs) == 1
 
     network_policy = api.network_policies[

--- a/testenv/azents/scripts/verify-runtime-docker.py
+++ b/testenv/azents/scripts/verify-runtime-docker.py
@@ -22,6 +22,8 @@ POSTGRES_IMAGE = (
     "postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193"
 )
 ENGINE_SOCKET_PATH = "/var/run/azents-engine/docker.sock"
+RUNTIME_WORKSPACE_PATH = "/workspace/agent"
+RUNTIME_TMP_PATH = "/tmp"
 
 
 def _run(
@@ -45,6 +47,8 @@ def _client_command(
     *,
     engine_name: str,
     socket_volume: str,
+    workspace_volume: str,
+    tmp_volume: str,
     image: str,
     connection_mode: bool = False,
 ) -> list[str]:
@@ -57,10 +61,16 @@ def _client_command(
         "1000:1000",
         "--network",
         f"container:{engine_name}",
+        "--workdir",
+        RUNTIME_WORKSPACE_PATH,
         "--volume",
         f"{socket_volume}:/var/run/azents-engine:ro",
+        "--volume",
+        f"{workspace_volume}:{RUNTIME_WORKSPACE_PATH}",
+        "--volume",
+        f"{tmp_volume}:{RUNTIME_TMP_PATH}",
         "--env",
-        "HOME=/tmp",
+        f"HOME={RUNTIME_WORKSPACE_PATH}",
         "--env",
         f"DOCKER_HOST=unix://{ENGINE_SOCKET_PATH}",
     ]
@@ -124,12 +134,84 @@ def _verify_cli(client: list[str]) -> None:
     if result.stdout.strip() != "azents-runtime-docker-ok":
         raise RuntimeError(f"Unexpected Docker run output: {result.stdout!r}")
 
+    workspace_proof = ".azents-docker-workspace-bind-proof"
+    tmp_proof = "azents-docker-tmp-bind-proof"
+    _run(
+        [
+            *client,
+            "sh",
+            "-ec",
+            f"printf runner-workspace > {RUNTIME_WORKSPACE_PATH}/{workspace_proof} "
+            f"&& printf runner-tmp > {RUNTIME_TMP_PATH}/{tmp_proof}",
+        ]
+    )
+    workspace_result = _run(
+        [
+            *client,
+            "docker",
+            "run",
+            "--rm",
+            "--volume",
+            f"{RUNTIME_WORKSPACE_PATH}:/proof-workspace",
+            "azents-runtime-docker-proof:latest",
+            "cat",
+            f"/proof-workspace/{workspace_proof}",
+        ],
+        capture_output=True,
+    )
+    if workspace_result.stdout.strip() != "runner-workspace":
+        raise RuntimeError(f"Unexpected workspace bind output: {workspace_result.stdout!r}")
+    tmp_result = _run(
+        [
+            *client,
+            "docker",
+            "run",
+            "--rm",
+            "--volume",
+            f"{RUNTIME_TMP_PATH}:/proof-tmp",
+            "azents-runtime-docker-proof:latest",
+            "cat",
+            f"/proof-tmp/{tmp_proof}",
+        ],
+        capture_output=True,
+    )
+    if tmp_result.stdout.strip() != "runner-tmp":
+        raise RuntimeError(f"Unexpected temporary bind output: {tmp_result.stdout!r}")
+    _run(
+        [
+            *client,
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "1000:1000",
+            "--volume",
+            f"{RUNTIME_WORKSPACE_PATH}:/proof-workspace",
+            "azents-runtime-docker-proof:latest",
+            "sh",
+            "-ec",
+            "printf nested-workspace > /proof-workspace/.azents-docker-nested-write-proof",
+        ]
+    )
+    nested_write = _run(
+        [
+            *client,
+            "cat",
+            f"{RUNTIME_WORKSPACE_PATH}/.azents-docker-nested-write-proof",
+        ],
+        capture_output=True,
+    )
+    if nested_write.stdout.strip() != "nested-workspace":
+        raise RuntimeError(f"Unexpected nested bind write: {nested_write.stdout!r}")
+
     compose = textwrap.dedent(
-        """
+        f"""
         services:
           proof:
             image: azents-runtime-docker-proof:latest
-            command: ["cat", "/proof"]
+            volumes:
+              - .:/proof-workspace
+            command: ["cat", "/proof-workspace/{workspace_proof}"]
         """
     )
     compose_command = [
@@ -138,6 +220,8 @@ def _verify_cli(client: list[str]) -> None:
         "compose",
         "--project-name",
         "azents-runtime-docker-proof",
+        "--project-directory",
+        RUNTIME_WORKSPACE_PATH,
         "-f",
         "-",
     ]
@@ -146,7 +230,7 @@ def _verify_cli(client: list[str]) -> None:
         input_text=compose,
     )
     _run([*compose_command, "down", "--remove-orphans"], input_text=compose)
-    print("DOCKER_CLI_BUILD_RUN_COMPOSE_OK")
+    print("DOCKER_CLI_BUILD_RUN_BIND_MOUNT_COMPOSE_OK")
 
 
 def _build_python_client(image: str) -> None:
@@ -208,6 +292,8 @@ def main() -> int:
     engine_name = f"azents-runtime-docker-verify-{suffix}"
     socket_volume = f"{engine_name}-socket"
     data_volume = f"{engine_name}-data"
+    workspace_volume = f"{engine_name}-workspace"
+    tmp_volume = f"{engine_name}-tmp"
     engine_image = f"{engine_name}-engine:latest"
     python_image = f"{engine_name}-python:latest"
 
@@ -223,6 +309,26 @@ def main() -> int:
         )
         _run(["docker", "volume", "create", socket_volume])
         _run(["docker", "volume", "create", data_volume])
+        _run(["docker", "volume", "create", workspace_volume])
+        _run(["docker", "volume", "create", tmp_volume])
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--volume",
+                f"{workspace_volume}:{RUNTIME_WORKSPACE_PATH}",
+                "--volume",
+                f"{tmp_volume}:{RUNTIME_TMP_PATH}",
+                DOCKER_CLI_IMAGE,
+                "sh",
+                "-ec",
+                f"touch {RUNTIME_WORKSPACE_PATH}/.azents-volume-initialized "
+                f"{RUNTIME_TMP_PATH}/.azents-volume-initialized "
+                f"&& chown -R 1000:1000 {RUNTIME_WORKSPACE_PATH} "
+                f"&& chmod 1777 {RUNTIME_TMP_PATH}",
+            ]
+        )
         _run(
             [
                 "docker",
@@ -235,6 +341,10 @@ def main() -> int:
                 f"{socket_volume}:/var/run/azents-engine",
                 "--volume",
                 f"{data_volume}:/var/lib/docker",
+                "--volume",
+                f"{workspace_volume}:{RUNTIME_WORKSPACE_PATH}",
+                "--volume",
+                f"{tmp_volume}:{RUNTIME_TMP_PATH}",
                 engine_image,
                 f"--host=unix://{ENGINE_SOCKET_PATH}",
                 "--group=azents-runner",
@@ -245,6 +355,8 @@ def main() -> int:
         cli_client = _client_command(
             engine_name=engine_name,
             socket_volume=socket_volume,
+            workspace_volume=workspace_volume,
+            tmp_volume=tmp_volume,
             image=DOCKER_CLI_IMAGE,
         )
         _wait_for_engine(cli_client, engine_name)
@@ -254,6 +366,8 @@ def main() -> int:
         python_client = _client_command(
             engine_name=engine_name,
             socket_volume=socket_volume,
+            workspace_volume=workspace_volume,
+            tmp_volume=tmp_volume,
             image=python_image,
             connection_mode=True,
         )
@@ -264,6 +378,8 @@ def main() -> int:
         _run(["docker", "rm", "--force", engine_name], check=False)
         _run(["docker", "volume", "rm", socket_volume], check=False)
         _run(["docker", "volume", "rm", data_volume], check=False)
+        _run(["docker", "volume", "rm", workspace_volume], check=False)
+        _run(["docker", "volume", "rm", tmp_volume], check=False)
         _run(["docker", "image", "rm", engine_image], check=False)
         _run(["docker", "image", "rm", python_image], check=False)
 


### PR DESCRIPTION
## What changed

- mount the Agent Workspace PVC into the Runner and DIND sidecar at the same absolute path
- add a Pod-local shared `/tmp` volume to both containers, bounded by the Runtime ephemeral-storage allocation
- keep Docker-disabled Runtime Pods unchanged
- extend the Runtime Docker workflow to verify workspace and temporary-file bind mounts, nested-container write-back, and Compose relative bind mounts
- update the Runtime Control and Persistence living specs

## Why

Docker bind-mount source paths are resolved by the daemon. The DIND sidecar previously could not see the Runner workspace or temporary directory, so ordinary workflows such as `docker run -v "$PWD:/app"` and Compose `.:/app` mounts failed even though Docker itself was available.

## Validation

- Kubernetes Runtime Provider Ruff, format, Pyright, and 70 pytest tests
- real DIND workflow covering Buildx build/load, workspace and `/tmp` bind reads, nested-container workspace write-back, Compose relative bind mount, Docker SDK, Testcontainers Network, PostgreSQL port binding, and Ryuk
- changed-file pre-commit hooks
- docs index consistency check