### PR TITLE
Fix Runtime Control integer environment rendering

### DIFF
--- a/infra/charts/azents/templates/server/runtime-control-deployment.yaml.tpl
+++ b/infra/charts/azents/templates/server/runtime-control-deployment.yaml.tpl
@@ -50,43 +50,43 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: AZ_RUNTIME_CONTROL_RECONCILE_INTERVAL_SECONDS
-              value: {{ .Values.server.runtimeControl.reconcileIntervalSeconds | quote }}
+              value: {{ printf "%d" (int64 .Values.server.runtimeControl.reconcileIntervalSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_LIFECYCLE_RETRY_DELAY_SECONDS
-              value: {{ .Values.server.runtimeControl.lifecycleRetryDelaySeconds | quote }}
+              value: {{ printf "%d" (int64 .Values.server.runtimeControl.lifecycleRetryDelaySeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_START_TIMEOUT_SECONDS
-              value: {{ .Values.server.runtimeControl.startTimeoutSeconds | quote }}
+              value: {{ printf "%d" (int64 .Values.server.runtimeControl.startTimeoutSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_BACKEND
               value: {{ $transfer.stateBackend | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_REDIS_NAMESPACE
               value: {{ $transfer.redisNamespace | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_PER_RUNTIME_ATTEMPTS
-              value: {{ $transfer.perRuntimeAttempts | quote }}
+              value: {{ printf "%d" (int64 $transfer.perRuntimeAttempts) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_PER_RUNTIME_BYTES
-              value: {{ $transfer.perRuntimeBytes | quote }}
+              value: {{ printf "%d" (int64 $transfer.perRuntimeBytes) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_DEPLOYMENT_ATTEMPTS
-              value: {{ $transfer.deploymentAttempts | quote }}
+              value: {{ printf "%d" (int64 $transfer.deploymentAttempts) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_DEPLOYMENT_BYTES
-              value: {{ $transfer.deploymentBytes | quote }}
+              value: {{ printf "%d" (int64 $transfer.deploymentBytes) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_ADMISSION_LEASE_SECONDS
-              value: {{ $transfer.admissionLeaseSeconds | quote }}
+              value: {{ printf "%d" (int64 $transfer.admissionLeaseSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_CONSUMER_LEASE_SECONDS
-              value: {{ $transfer.consumerLeaseSeconds | quote }}
+              value: {{ printf "%d" (int64 $transfer.consumerLeaseSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_STREAM_LEASE_SECONDS
-              value: {{ $transfer.streamLeaseSeconds | quote }}
+              value: {{ printf "%d" (int64 $transfer.streamLeaseSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_TERMINAL_TTL_SECONDS
-              value: {{ $transfer.terminalTtlSeconds | quote }}
+              value: {{ printf "%d" (int64 $transfer.terminalTtlSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_LIST_PAGE_SIZE
-              value: {{ $transfer.listPageSize | quote }}
+              value: {{ printf "%d" (int64 $transfer.listPageSize) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_MAX_CONCURRENT_DOWNLOADS
-              value: {{ $transfer.maxConcurrentDownloads | quote }}
+              value: {{ printf "%d" (int64 $transfer.maxConcurrentDownloads) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_MAX_CONCURRENT_UPLOADS
-              value: {{ $transfer.maxConcurrentUploads | quote }}
+              value: {{ printf "%d" (int64 $transfer.maxConcurrentUploads) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_CHUNK_BYTES
-              value: {{ $transfer.chunkBytes | quote }}
+              value: {{ printf "%d" (int64 $transfer.chunkBytes) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_MULTIPART_PART_BYTES
-              value: {{ $transfer.multipartPartBytes | quote }}
+              value: {{ printf "%d" (int64 $transfer.multipartPartBytes) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_REPAIR_INTERVAL_SECONDS
-              value: {{ $transfer.repairIntervalSeconds | quote }}
+              value: {{ printf "%d" (int64 $transfer.repairIntervalSeconds) | quote }}
             - name: AZ_RUNTIME_CONTROL_TRANSFER_OBJECT_PREFIX
               value: {{ $transfer.objectPrefix | quote }}
             - name: AZ_RUNTIME_CONTROL_WORKSPACE_S3_PREFIX

--- a/infra/charts/azents/tests/runtime_control_render_test.py
+++ b/infra/charts/azents/tests/runtime_control_render_test.py
@@ -14,7 +14,7 @@ _WEB_DIGEST = f"sha256:{'e' * 64}"
 _ADMIN_WEB_DIGEST = f"sha256:{'f' * 64}"
 
 
-def _helm_template(*values: str) -> str:
+def _helm_template(*values: str, json_values: tuple[str, ...] = ()) -> str:
     """Run helm template or skip when helm is unavailable."""
     helm = shutil.which("helm")
     if helm is None:
@@ -35,6 +35,8 @@ def _helm_template(*values: str) -> str:
     )
     for value in (*base_values, *values):
         command.extend(["--set", value])
+    for value in json_values:
+        command.extend(["--set-json", value])
     completed = subprocess.run(
         command,
         cwd=CHART_DIR,
@@ -104,6 +106,34 @@ def test_runtime_control_enabled_render_contract() -> None:
     assert 'namespace: "default"' in tokenreview_binding
     assert "azents-runtime-provider-kubernetes" not in tokenreview_binding
     assert rendered.count("mountPath: /var/run/secrets/azents/runtime-control-tls") == 3
+
+
+def test_runtime_control_renders_values_object_numbers_as_decimal_integers() -> None:
+    """ArgoCD valuesObject numbers remain valid integer environment values."""
+    rendered = _helm_template(
+        "server.runtimeControl.enabled=true",
+        "server.runtimeControl.runnerImage.repository=repo/runner",
+        "server.runtimeControl.runnerImage.tag=sha",
+        f"server.runtimeControl.runnerImage.digest={_RUNNER_DIGEST}",
+        json_values=(
+            "server.runtimeControl.transfer.perRuntimeBytes=8388608",
+            "server.runtimeControl.transfer.deploymentBytes=33554432",
+            "server.runtimeControl.transfer.multipartPartBytes=5242880",
+        ),
+    )
+
+    assert (
+        "name: AZ_RUNTIME_CONTROL_TRANSFER_PER_RUNTIME_BYTES\n"
+        '              value: "8388608"'
+    ) in rendered
+    assert (
+        "name: AZ_RUNTIME_CONTROL_TRANSFER_DEPLOYMENT_BYTES\n"
+        '              value: "33554432"'
+    ) in rendered
+    assert (
+        "name: AZ_RUNTIME_CONTROL_TRANSFER_MULTIPART_PART_BYTES\n"
+        '              value: "5242880"'
+    ) in rendered
 
 
 def test_runtime_control_renders_dedicated_workspace_s3_credential_aliases() -> None:


### PR DESCRIPTION
## Summary

- render Runtime Control integer settings as explicit decimal strings
- prevent ArgoCD valuesObject numbers from becoming scientific notation in Pod environment variables
- add a regression test using Helm JSON values, matching the failing deployment path

## Root cause

ArgoCD valuesObject decodes JSON numbers as floating-point values. Helm's generic quote formatting rendered byte settings such as 8388608 as 8.388608e+06. Pydantic then rejected those environment variables because Runtime Control requires integers, so the new Pod entered CrashLoopBackOff and the Kubernetes Provider subsequently lost a compatible Control endpoint.

## Validation

- helm lint infra/charts/azents
- uv run --with pytest pytest tests (42 passed)
- uvx pre-commit run --files infra/charts/azents/templates/server/runtime-control-deployment.yaml.tpl infra/charts/azents/tests/runtime_control_render_test.py