### PR TITLE
Fix Runtime staging initializer capabilities

### DIFF
--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -853,7 +853,7 @@ class KubernetesRuntimeProvider:
                 args=(),
                 working_dir=_PVC_ROOT_MOUNT_PATH,
                 resources=None,
-                security_context=_runner_supervisor_security_context(),
+                security_context=_staging_initializer_security_context(),
                 readiness_probe=None,
                 env=(),
                 volume_mounts=(
@@ -1481,6 +1481,20 @@ def _runner_supervisor_security_context() -> ContainerSecurityContext:
         run_as_user=0,
         run_as_group=0,
         capabilities_add=("SETGID", "SETUID"),
+        capabilities_drop=("ALL",),
+    )
+
+
+def _staging_initializer_security_context() -> ContainerSecurityContext:
+    """Allow only the ownership changes required to prepare PVC subpaths."""
+    return ContainerSecurityContext(
+        privileged=False,
+        allow_privilege_escalation=False,
+        read_only_root_filesystem=False,
+        run_as_non_root=False,
+        run_as_user=0,
+        run_as_group=0,
+        capabilities_add=("CHOWN", "FOWNER"),
         capabilities_drop=("ALL",),
     )
 

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -395,6 +395,9 @@ async def test_start_creates_pvc_and_pod_with_workspace_mount() -> None:
     assert initializer.image == _RUNNER_IMAGE
     assert initializer.command is not None
     assert "transfer-staging" in initializer.command[-1]
+    assert initializer.security_context.capabilities_add == ("CHOWN", "FOWNER")
+    assert initializer.security_context.capabilities_drop == ("ALL",)
+    assert container.security_context.capabilities_add == ("SETGID", "SETUID")
     assert pvc.spec.storage_class_name == "gp3"
     assert pvc.spec.storage_request == "20Gi"
     assert "azents/workspace-path" not in pod.metadata.labels


### PR DESCRIPTION
## Summary

- give the Runtime transfer staging initializer only the CHOWN and FOWNER Linux capabilities required by its filesystem setup
- keep the Runner supervisor capability set unchanged
- add a regression assertion for the distinct security contexts

## Root cause

The initializer ran as UID 0 but dropped every Linux capability and added only SETUID and SETGID. Its first chown against an existing workspace subdirectory therefore failed with Operation not permitted, leaving every Runtime Pod in Init:CrashLoopBackOff.

## Impact

After deployment, the provider can recreate existing Runtime Pods against their preserved PVCs and complete the transfer staging initialization.

## Validation

- uv run ruff check .
- uv run ruff format --check .
- uv run pyright
- uv run pytest (71 passed)