### PR TITLE
Remove privileged Runtime transfer staging

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -32,7 +32,7 @@ Design documents are accumulated records and are not listed individually in this
 | Title | Owner | Last Verified At | Spec Version |
 |---|---|---|---|
 | [Agent Execution Loop](spec/flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-28 | 41 |
+| [Agent Runtime Control](spec/flow/agent-runtime-control.md) | @Hardtack | 2026-07-29 | 42 |
 | [Agent Runtime Persistence](spec/flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-28 | 12 |
 | [Chat Session Resync](spec/flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](spec/flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -29,7 +29,7 @@ Details of all living specs. Synchronized from frontmatter.
 | Title | Owner | Last Verified | Version |
 |---|---|---|---|
 | [Agent Execution Loop](flow/agent-execution-loop.md) | @Hardtack | 2026-07-27 | 135 |
-| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-28 | 41 |
+| [Agent Runtime Control](flow/agent-runtime-control.md) | @Hardtack | 2026-07-29 | 42 |
 | [Agent Runtime Persistence](flow/agent-runtime-persistence.md) | @Hardtack | 2026-07-28 | 12 |
 | [Chat Session Resync](flow/chat-session-resync.md) | @Hardtack | 2026-07-26 | 42 |
 | [ChatGPT OAuth Flow](flow/chatgpt-oauth.md) | @Hardtack | 2026-07-21 | 18 |

--- a/docs/azents/spec/flow/agent-runtime-control.md
+++ b/docs/azents/spec/flow/agent-runtime-control.md
@@ -29,8 +29,8 @@ code_paths:
   - python/apps/azents-runtime-provider-docker/**
   - python/apps/azents-runtime-provider-kubernetes/**
   - infra/charts/azents/**
-last_verified_at: 2026-07-28
-spec_version: 41
+last_verified_at: 2026-07-29
+spec_version: 42
 ---
 
 # Agent Runtime Control
@@ -104,13 +104,15 @@ terminal state are checked at the Control boundary. A malformed, stale, duplicat
 cross-attempt frame fails that attempt without exposing another object. Ordinary Runner
 control operations remain independently available while a transfer stream is active.
 
-For downloads, the Runner writes through protected same-filesystem staging and commits
-the requested destination only after complete verification. An existing destination is
-left unchanged unless an admitted overwrite can use that protected staging path; an
-unsafe overwrite configuration fails closed. For uploads, the Runner snapshots one
-authorized source before opening the transfer and reports its independently calculated
-manifest. A terminal transfer result is accepted only for the current dispatch and
-cannot be replaced by a late result.
+For downloads, the Runner writes to a randomly named temporary file in the destination
+directory and commits the requested destination only after complete verification. An
+admitted overwrite atomically replaces the destination; failed and cancelled attempts
+remove their temporary file and leave the prior destination unchanged. This transfer
+integrity does not require root, fixed Linux identities, Provider-created staging, or
+elevated Runner capabilities. For
+uploads, the Runner snapshots one authorized source before opening the transfer and
+reports its independently calculated manifest. A terminal transfer result is accepted
+only for the current dispatch and cannot be replaced by a late result.
 
 Verified objects are claimed by trusted consumers through short leases. A consumer
 receives an opaque handle and bounded async stream, acknowledges only after its
@@ -383,6 +385,10 @@ Live/provider evidence belongs in the testenv prerequisite system and must redac
 
 ## Changelog
 
+- **2026-07-29** (spec_version 42) — Removed root-owned transfer staging, Runner
+  identity switching, and the Kubernetes staging init container. Docker and
+  Kubernetes Providers run the Runner as UID/GID 1000 while verified downloads retain
+  same-filesystem atomic publication, including overwrite.
 - **2026-07-28** (spec_version 41) — Added state-independent bounded transfer-prefix
   object and multipart orphan cleanup, kept one-hour access authority in Runtime
   Control, and clarified empty memory/Redis recovery.

--- a/python/apps/azents-runtime-provider-docker/src/azents_runtime_provider_docker/provider.py
+++ b/python/apps/azents-runtime-provider-docker/src/azents_runtime_provider_docker/provider.py
@@ -39,12 +39,11 @@ _IMAGE_GENERATION = "agent-runtime-docker-v1"
 _RUNTIME_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _RUNNER_UID = 1000
 _RUNNER_GID = 1000
-_RUNNER_USER = "0:0"
+_RUNNER_USER = f"{_RUNNER_UID}:{_RUNNER_GID}"
 _WORKSPACE_DIR_MODE = 0o755
 _NON_ROOT_WORKSPACE_DIR_MODE = 0o777
 _CONTROL_HOST_ALIAS = "host.docker.internal:host-gateway"
 _LOGGER = logging.getLogger(__name__)
-_TRANSFER_STAGING_DIRECTORY_NAME = ".azents-transfer-staging"
 
 _LABEL_MANAGED_BY = "azents/managed-by"
 _LABEL_PROVIDER_ID = "azents/runtime-provider-id"
@@ -78,7 +77,6 @@ _ENV_POLICY_DIGEST = "AZ_RUNTIME_EXECUTION_POLICY_DIGEST"
 _ENV_POLICY_DESIRED_GENERATION = "AZ_RUNTIME_EXECUTION_POLICY_DESIRED_GENERATION"
 _ENV_POLICY_MODULE_VERSIONS = "AZ_RUNTIME_EXECUTION_POLICY_MODULE_VERSIONS"
 _ENV_POLICY_SOURCE_VERSIONS = "AZ_RUNTIME_EXECUTION_POLICY_SOURCE_VERSIONS"
-_ENV_TRANSFER_STAGING_DIRECTORY = "AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"
 RUNNER_LIMIT_ENV_NAMES = (
     "AZ_RUNTIME_RUNNER_MAX_CONCURRENT_OPERATIONS_PER_SESSION",
     "AZ_RUNTIME_RUNNER_MAX_CONCURRENT_SYSTEM_OPERATIONS",
@@ -410,10 +408,6 @@ class DockerRuntimeProvider:
             _ENV_WORKSPACE_ID: identity.workspace_id,
             _ENV_PROVIDER_ID: self._config.provider_id,
             _ENV_WORKSPACE_PATH: self._workspace_mount_path,
-            _ENV_TRANSFER_STAGING_DIRECTORY: str(
-                PurePosixPath(self._workspace_mount_path)
-                / _TRANSFER_STAGING_DIRECTORY_NAME
-            ),
         }
         if command.auth.control_tls_ca_pem is not None:
             env[_ENV_CONTROL_TLS_CA_PEM] = command.auth.control_tls_ca_pem
@@ -524,13 +518,9 @@ class DockerRuntimeProvider:
     def _tmp_host_dir(self, runtime_id: str) -> Path:
         return self._runtime_root(runtime_id) / "tmp-agent"
 
-    def _transfer_staging_host_dir(self, runtime_id: str) -> Path:
-        return self._workspace_host_dir(runtime_id) / _TRANSFER_STAGING_DIRECTORY_NAME
-
     def _ensure_workspace_dirs(self, runtime_id: str) -> None:
-        _ensure_workspace_dir(self._workspace_host_dir(runtime_id))
+        _ensure_writable_dir(self._workspace_host_dir(runtime_id))
         _ensure_writable_dir(self._tmp_host_dir(runtime_id))
-        _ensure_protected_staging_dir(self._transfer_staging_host_dir(runtime_id))
 
     def _delete_runtime_root(self, runtime_id: str) -> None:
         runtime_root = self._runtime_root(runtime_id)
@@ -561,44 +551,6 @@ def _ensure_writable_dir(path: Path) -> None:
     current_mode = stat.S_IMODE(path.stat().st_mode)
     if current_mode != expected_mode:
         path.chmod(expected_mode)  # noqa: S103
-
-
-def _ensure_workspace_dir(path: Path) -> None:
-    """Prepare a sticky workspace that protects its root-owned staging child."""
-    path.mkdir(parents=True, exist_ok=True)
-    if os.geteuid() == 0:
-        os.chown(path, 0, 0)
-        expected_mode = 0o1777
-    else:
-        expected_mode = _NON_ROOT_WORKSPACE_DIR_MODE
-    current_mode = stat.S_IMODE(path.stat().st_mode)
-    if current_mode != expected_mode:
-        path.chmod(expected_mode)  # noqa: S103
-
-
-def _ensure_protected_staging_dir(path: Path) -> None:
-    if os.geteuid() != 0:
-        raise PermissionError(
-            "protected Runtime transfer staging requires a root Docker provider"
-        )
-    try:
-        path.mkdir(parents=True)
-    except FileExistsError:
-        pass
-    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
-    try:
-        metadata = os.fstat(descriptor)
-        if not stat.S_ISDIR(metadata.st_mode):
-            raise OSError("transfer staging path is not a directory")
-        os.fchown(descriptor, 0, 0)
-        os.fchmod(descriptor, 0o700)
-        metadata = os.fstat(descriptor)
-        if metadata.st_uid != 0 or stat.S_IMODE(metadata.st_mode) != 0o700:
-            raise PermissionError(
-                "transfer staging directory protection was not applied"
-            )
-    finally:
-        os.close(descriptor)
 
 
 def _observed_state(

--- a/python/apps/azents-runtime-provider-docker/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-docker/tests/test_provider.py
@@ -1,7 +1,6 @@
 """Docker Runtime Provider lifecycle tests."""
 
 import dataclasses
-import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import cast
@@ -30,7 +29,6 @@ from azents_runtime_control.provider import (
     RuntimeProviderObservedState as ControlRuntimeProviderObservedState,
 )
 
-import azents_runtime_provider_docker.provider as docker_provider
 from azents_runtime_provider_docker.docker_api import (
     DockerApi,
     DockerContainerInfo,
@@ -51,27 +49,8 @@ from azents_runtime_provider_docker.provider import (
     DockerRuntimeProviderConfig,
     InvalidResetFinalDesiredState,
     InvalidWorkspacePath,
-    _ensure_protected_staging_dir,  # pyright: ignore[reportPrivateUsage] -- Verify the Provider fails closed without root ownership authority.
 )
 from azents_runtime_provider_docker.runtime_control import DockerRuntimeControlAdapter
-
-
-@pytest.fixture(autouse=True)
-def _fake_docker_lifecycle_staging(  # pyright: ignore[reportUnusedFunction] -- Pytest discovers autouse fixtures.
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Keep Docker API lifecycle tests independent from host root ownership."""
-    if os.geteuid() == 0:
-        return
-
-    def create_staging_for_fake_docker(path: Path) -> None:
-        path.mkdir(parents=True, exist_ok=True)
-
-    monkeypatch.setattr(
-        docker_provider,
-        "_ensure_protected_staging_dir",
-        create_staging_for_fake_docker,
-    )
 
 
 @dataclasses.dataclass
@@ -236,20 +215,13 @@ async def test_start_creates_container_with_workspace_bind(tmp_path: Path) -> No
     assert result.report.observed_state is RuntimeProviderObservedState.RUNNING
     assert result.report.workspace_path == "/workspace/agent"
     container = docker.containers["azents-runtime-runtime-1"]
-    assert container.spec.user == "0:0"
+    assert container.spec.user == "1000:1000"
     assert container.spec.working_dir == "/workspace/agent"
     assert any(
         bind.container_path == "/workspace/agent" for bind in container.spec.binds
     )
     assert container.spec.env["AZ_RUNTIME_TRANSFER_ENDPOINT"] == "runtime-transfer:8030"
-    assert (
-        container.spec.env["AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"]
-        == "/workspace/agent/.azents-transfer-staging"
-    )
-    assert all(
-        bind.container_path != "/workspace/agent/.azents-transfer-staging"
-        for bind in container.spec.binds
-    )
+    assert "AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY" not in container.spec.env
     assert container.spec.env["AZ_RUNTIME_RUNNER_AUTH_TOKEN"] == "runner-token-1"
     assert (
         container.spec.env["AZ_RUNTIME_RUNNER_AUTH_CREDENTIAL_ID"]
@@ -258,30 +230,7 @@ async def test_start_creates_container_with_workspace_bind(tmp_path: Path) -> No
     workspace_path = tmp_path / "agent-runtimes" / "runtime-1" / "workspace"
     assert workspace_path.exists()
     workspace_stat = workspace_path.stat()
-    if os.geteuid() == 0:
-        assert workspace_stat.st_uid == 0
-        assert workspace_stat.st_gid == 0
-        assert workspace_stat.st_mode & 0o7777 == 0o1777
-        staging_stat = (workspace_path / ".azents-transfer-staging").stat()
-        assert staging_stat.st_uid == 0
-        assert staging_stat.st_gid == 0
-        assert staging_stat.st_mode & 0o777 == 0o700
-    else:
-        assert workspace_stat.st_mode & 0o777 == 0o777
-
-
-def test_protected_staging_requires_root_provider(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A non-root Provider cannot accidentally expose a writable staging directory."""
-    staging = tmp_path / "transfer-staging"
-    monkeypatch.setattr(os, "geteuid", lambda: 1000)
-
-    with pytest.raises(PermissionError, match="requires a root Docker provider"):
-        _ensure_protected_staging_dir(staging)
-
-    assert not staging.exists()
+    assert workspace_stat.st_mode & 0o777 in {0o755, 0o777}
 
 
 @pytest.mark.asyncio

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/kubernetes_api.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/kubernetes_api.py
@@ -42,7 +42,6 @@ class VolumeMount:
     name: str
     mount_path: str
     read_only: bool
-    sub_path: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -161,7 +160,6 @@ class PodSpec:
     tolerations: Sequence[Toleration]
     containers: Sequence[ContainerSpec]
     volumes: Sequence[PodVolume]
-    init_containers: Sequence[ContainerSpec] = ()
 
 
 @dataclasses.dataclass(frozen=True)

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/kubernetes_http.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/kubernetes_http.py
@@ -413,10 +413,6 @@ def pod_manifest(pod: PodResource) -> JsonObject:
         ],
         "volumes": [_volume_manifest(volume) for volume in pod.spec.volumes],
     }
-    if pod.spec.init_containers:
-        spec["initContainers"] = [
-            _container_manifest(container) for container in pod.spec.init_containers
-        ]
     if pod.spec.service_account_name is not None:
         spec["serviceAccountName"] = pod.spec.service_account_name
     if pod.spec.image_pull_secrets:
@@ -469,14 +465,9 @@ def _container_manifest(container: ContainerSpec) -> JsonObject:
         "env": [{"name": item.name, "value": item.value} for item in container.env],
         "volumeMounts": [
             {
-                key: value
-                for key, value in {
-                    "name": item.name,
-                    "mountPath": item.mount_path,
-                    "readOnly": item.read_only,
-                    "subPath": item.sub_path,
-                }.items()
-                if value is not None
+                "name": item.name,
+                "mountPath": item.mount_path,
+                "readOnly": item.read_only,
             }
             for item in container.volume_mounts
         ],
@@ -740,9 +731,6 @@ def pod_resource(data: JsonObject) -> PodResource:
             ),
             containers=tuple(_container(item) for item in spec.get("containers", [])),
             volumes=tuple(_volume(item) for item in spec.get("volumes", [])),
-            init_containers=tuple(
-                _container(item) for item in spec.get("initContainers", [])
-            ),
         ),
         status=None if status is None else _pod_status(status),
     )
@@ -773,9 +761,6 @@ def _container(data: JsonObject) -> ContainerSpec:
                 name=str(item["name"]),
                 mount_path=str(item["mountPath"]),
                 read_only=bool(item.get("readOnly", False)),
-                sub_path=(
-                    None if item.get("subPath") is None else str(item["subPath"])
-                ),
             )
             for item in data.get("volumeMounts", [])
         ),

--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -95,30 +95,6 @@ _RUNNER_UID = 1000
 _RUNNER_GID = 1000
 _ENGINE_SOCKET_GROUP = "azents-runner"
 _FS_GROUP_CHANGE_POLICY = "OnRootMismatch"
-_TRANSFER_STAGING_MOUNT_PATH = "/var/run/azents-transfer"
-_TRANSFER_STAGING_DIRECTORY = _TRANSFER_STAGING_MOUNT_PATH
-_PVC_ROOT_MOUNT_PATH = "/var/run/azents-workspace-volume"
-_WORKSPACE_SUB_PATH = "workspace"
-_TRANSFER_STAGING_SUB_PATH = "transfer-staging"
-_STAGING_INIT_CONTAINER_NAME = "initialize-transfer-staging"
-_STAGING_INIT_COMMAND = (
-    "sh",
-    "-ec",
-    (
-        "for path in workspace transfer-staging; do "
-        "if [ -L /var/run/azents-workspace-volume/$path ] || "
-        "{ [ -e /var/run/azents-workspace-volume/$path ] && "
-        "[ ! -d /var/run/azents-workspace-volume/$path ]; }; then "
-        "exit 1; fi; "
-        "done\n"
-        "mkdir -p /var/run/azents-workspace-volume/workspace "
-        "/var/run/azents-workspace-volume/transfer-staging\n"
-        "chown 1000:1000 /var/run/azents-workspace-volume/workspace\n"
-        "chmod 0755 /var/run/azents-workspace-volume/workspace\n"
-        "chown 0:0 /var/run/azents-workspace-volume/transfer-staging\n"
-        "chmod 0700 /var/run/azents-workspace-volume/transfer-staging"
-    ),
-)
 
 _LABEL_MANAGED_BY = "azents/managed-by"
 _LABEL_PROVIDER_ID = "azents/runtime-provider-id"
@@ -157,7 +133,6 @@ _ENV_DOCKER_HOST = "DOCKER_HOST"
 _ENV_TESTCONTAINERS_HOST_OVERRIDE = "TESTCONTAINERS_HOST_OVERRIDE"
 _ENV_TESTCONTAINERS_CONNECTION_MODE = "TESTCONTAINERS_CONNECTION_MODE"
 _ENV_TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE = "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE"
-_ENV_TRANSFER_STAGING_DIRECTORY = "AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"
 RUNNER_LIMIT_ENV_NAMES = (
     "AZ_RUNTIME_RUNNER_MAX_CONCURRENT_OPERATIONS_PER_SESSION",
     "AZ_RUNTIME_RUNNER_MAX_CONCURRENT_SYSTEM_OPERATIONS",
@@ -627,11 +602,6 @@ class KubernetesRuntimeProvider:
             return False
         if pod.spec.automount_service_account_token:
             return False
-        if not _container_specs_equal(
-            pod.spec.init_containers,
-            expected.spec.init_containers,
-        ):
-            return False
         if dict(pod.spec.node_selector) != dict(expected.spec.node_selector):
             return False
         if not set(self._config.pod_tolerations).issubset(set(pod.spec.tolerations)):
@@ -719,7 +689,6 @@ class KubernetesRuntimeProvider:
                         else ()
                     ),
                 ),
-                init_containers=self._init_containers(command),
             ),
         )
 
@@ -728,7 +697,13 @@ class KubernetesRuntimeProvider:
         command: RuntimeLifecycleCommand,
         policy: RuntimeExecutionPolicy,
     ) -> tuple[ContainerSpec, ...]:
-        runner_mounts = list(self._runner_volume_mounts())
+        runner_mounts = [
+            VolumeMount(
+                name=_WORKSPACE_VOLUME_NAME,
+                mount_path=self._workspace_mount_path,
+                read_only=False,
+            )
+        ]
         docker_enabled = policy.docker.enabled
         runner_env = self._env(command)
         docker_resources = _docker_resources(policy) if docker_enabled else None
@@ -758,7 +733,10 @@ class KubernetesRuntimeProvider:
             args=(),
             working_dir=self._workspace_mount_path,
             resources=self._config.runner_resources,
-            security_context=_runner_supervisor_security_context(),
+            security_context=_unprivileged_security_context(
+                uid=_RUNNER_UID,
+                gid=_RUNNER_GID,
+            ),
             readiness_probe=None,
             env=tuple(
                 EnvVar(name=key, value=value) for key, value in runner_env.items()
@@ -788,7 +766,6 @@ class KubernetesRuntimeProvider:
                     name=_WORKSPACE_VOLUME_NAME,
                     mount_path=self._workspace_mount_path,
                     read_only=False,
-                    sub_path=_WORKSPACE_SUB_PATH,
                 ),
                 VolumeMount(
                     name=_ENGINE_SOCKET_VOLUME_NAME,
@@ -837,49 +814,6 @@ class KubernetesRuntimeProvider:
                     _runtime_control_egress_rule(self._config),
                     *_permitted_egress_rules(self._config),
                 ),
-            ),
-        )
-
-    def _init_containers(
-        self,
-        command: RuntimeLifecycleCommand,
-    ) -> tuple[ContainerSpec, ...]:
-        """Create the provider-owned filesystem boundary before Runner startup."""
-        return (
-            ContainerSpec(
-                name=_STAGING_INIT_CONTAINER_NAME,
-                image=command.runner_image,
-                command=_STAGING_INIT_COMMAND,
-                args=(),
-                working_dir=_PVC_ROOT_MOUNT_PATH,
-                resources=None,
-                security_context=_staging_initializer_security_context(),
-                readiness_probe=None,
-                env=(),
-                volume_mounts=(
-                    VolumeMount(
-                        name=_WORKSPACE_VOLUME_NAME,
-                        mount_path=_PVC_ROOT_MOUNT_PATH,
-                        read_only=False,
-                    ),
-                ),
-            ),
-        )
-
-    def _runner_volume_mounts(self) -> tuple[VolumeMount, ...]:
-        """Return the only workspace and protected staging paths visible to Runner."""
-        return (
-            VolumeMount(
-                name=_WORKSPACE_VOLUME_NAME,
-                mount_path=self._workspace_mount_path,
-                read_only=False,
-                sub_path=_WORKSPACE_SUB_PATH,
-            ),
-            VolumeMount(
-                name=_WORKSPACE_VOLUME_NAME,
-                mount_path=_TRANSFER_STAGING_MOUNT_PATH,
-                read_only=False,
-                sub_path=_TRANSFER_STAGING_SUB_PATH,
             ),
         )
 
@@ -946,7 +880,6 @@ class KubernetesRuntimeProvider:
             _ENV_WORKSPACE_ID: identity.workspace_id,
             _ENV_PROVIDER_ID: self._config.provider_id,
             _ENV_WORKSPACE_PATH: self._workspace_mount_path,
-            _ENV_TRANSFER_STAGING_DIRECTORY: _TRANSFER_STAGING_DIRECTORY,
         }
         if command.auth.control_tls_ca_pem is not None:
             env[_ENV_CONTROL_TLS_CA_PEM] = command.auth.control_tls_ca_pem
@@ -1142,6 +1075,24 @@ def _engine_security_context() -> ContainerSecurityContext:
         run_as_group=0,
         capabilities_add=(),
         capabilities_drop=(),
+    )
+
+
+def _unprivileged_security_context(
+    *,
+    uid: int,
+    gid: int,
+    read_only_root_filesystem: bool = False,
+) -> ContainerSecurityContext:
+    return ContainerSecurityContext(
+        privileged=False,
+        allow_privilege_escalation=False,
+        read_only_root_filesystem=read_only_root_filesystem,
+        run_as_non_root=True,
+        run_as_user=uid,
+        run_as_group=gid,
+        capabilities_add=(),
+        capabilities_drop=("ALL",),
     )
 
 
@@ -1469,34 +1420,6 @@ def _quantity_value(value: KubernetesResourceQuantity) -> Decimal | None:
         return quantity * _QUANTITY_SUFFIX_MULTIPLIERS[suffix]
     except InvalidOperation, ValueError:
         return None
-
-
-def _runner_supervisor_security_context() -> ContainerSecurityContext:
-    """Allow the Runner supervisor to own protected staging and drop children."""
-    return ContainerSecurityContext(
-        privileged=False,
-        allow_privilege_escalation=False,
-        read_only_root_filesystem=False,
-        run_as_non_root=False,
-        run_as_user=0,
-        run_as_group=0,
-        capabilities_add=("SETGID", "SETUID"),
-        capabilities_drop=("ALL",),
-    )
-
-
-def _staging_initializer_security_context() -> ContainerSecurityContext:
-    """Allow only the ownership changes required to prepare PVC subpaths."""
-    return ContainerSecurityContext(
-        privileged=False,
-        allow_privilege_escalation=False,
-        read_only_root_filesystem=False,
-        run_as_non_root=False,
-        run_as_user=0,
-        run_as_group=0,
-        capabilities_add=("CHOWN", "FOWNER"),
-        capabilities_drop=("ALL",),
-    )
 
 
 def _absolute_posix_path(raw_path: str) -> str:

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_kubernetes_http.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_kubernetes_http.py
@@ -1,7 +1,5 @@
 """Kubernetes HTTP resource mapping tests."""
 
-import dataclasses
-
 from azents_runtime_provider_kubernetes.kubernetes_api import (
     ContainerResourceClaim,
     ContainerResources,
@@ -96,68 +94,6 @@ def test_pod_manifest_preserves_image_pull_secrets() -> None:
     manifest = pod_manifest(pod)
 
     assert manifest["spec"]["imagePullSecrets"] == [{"name": "ecr-pull-secret"}]
-
-
-def test_pod_manifest_preserves_init_container_and_sub_path_mounts() -> None:
-    security_context = ContainerSecurityContext(
-        privileged=False,
-        allow_privilege_escalation=False,
-        read_only_root_filesystem=False,
-        run_as_non_root=False,
-        run_as_user=0,
-        run_as_group=0,
-        capabilities_add=("SETGID", "SETUID"),
-        capabilities_drop=("ALL",),
-    )
-    initializer = ContainerSpec(
-        name="initialize-transfer-staging",
-        image="runner:latest",
-        command=("sh", "-ec", "chmod 0700 /volume/transfer-staging"),
-        args=(),
-        working_dir="/volume",
-        resources=None,
-        security_context=security_context,
-        readiness_probe=None,
-        env=(),
-        volume_mounts=(
-            VolumeMount(
-                name="agent-workspace",
-                mount_path="/volume",
-                read_only=False,
-            ),
-        ),
-    )
-    pod = _pod(resources=None)
-    runner = dataclasses.replace(
-        pod.spec.containers[0],
-        security_context=security_context,
-        volume_mounts=(
-            VolumeMount(
-                name="agent-workspace",
-                mount_path="/workspace/agent",
-                read_only=False,
-                sub_path="workspace",
-            ),
-        ),
-    )
-    pod = dataclasses.replace(
-        pod,
-        spec=dataclasses.replace(
-            pod.spec, init_containers=(initializer,), containers=(runner,)
-        ),
-    )
-
-    manifest = pod_manifest(pod)
-
-    assert manifest["spec"]["initContainers"][0]["command"] == [
-        "sh",
-        "-ec",
-        "chmod 0700 /volume/transfer-staging",
-    ]
-    assert manifest["spec"]["containers"][0]["volumeMounts"][0]["subPath"] == (
-        "workspace"
-    )
-    assert pod_resource(manifest) == pod
 
 
 def test_pod_resource_returns_none_for_absent_container_resources() -> None:

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -47,7 +47,6 @@ from azents_runtime_provider_kubernetes.kubernetes_api import (
     PodStatus,
     PodWatchEvent,
     Toleration,
-    VolumeMount,
 )
 from azents_runtime_provider_kubernetes.models import (
     RuntimeContainerAuth,
@@ -341,7 +340,7 @@ async def test_start_creates_pvc_and_pod_with_workspace_mount() -> None:
     env = {item.name: item.value for item in container.env}
     assert container.image == _RUNNER_IMAGE
     assert env["AZ_RUNTIME_TRANSFER_ENDPOINT"] == "runtime-transfer:8030"
-    assert env["AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"] == "/var/run/azents-transfer"
+    assert "AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY" not in env
     assert container.working_dir == "/workspace/agent"
     assert container.resources == ContainerResources(
         requests={"cpu": "500m", "memory": "1Gi"},
@@ -368,36 +367,15 @@ async def test_start_creates_pvc_and_pod_with_workspace_mount() -> None:
     assert isinstance(workspace_volume, PersistentVolumeClaimVolume)
     assert workspace_volume.claim_name == pvc.metadata.name
     assert [volume.name for volume in pod.spec.volumes] == ["agent-workspace"]
-    assert [mount.name for mount in container.volume_mounts] == [
-        "agent-workspace",
-        "agent-workspace",
-    ]
-    assert (
-        VolumeMount(
-            name="agent-workspace",
-            mount_path="/var/run/azents-transfer",
-            read_only=False,
-            sub_path="transfer-staging",
-        )
-        in container.volume_mounts
-    )
-    assert (
-        VolumeMount(
-            name="agent-workspace",
-            mount_path="/workspace/agent",
-            read_only=False,
-            sub_path="workspace",
-        )
-        in container.volume_mounts
-    )
-    initializer = pod.spec.init_containers[0]
-    assert initializer.name == "initialize-transfer-staging"
-    assert initializer.image == _RUNNER_IMAGE
-    assert initializer.command is not None
-    assert "transfer-staging" in initializer.command[-1]
-    assert initializer.security_context.capabilities_add == ("CHOWN", "FOWNER")
-    assert initializer.security_context.capabilities_drop == ("ALL",)
-    assert container.security_context.capabilities_add == ("SETGID", "SETUID")
+    assert len(container.volume_mounts) == 1
+    assert container.volume_mounts[0].name == "agent-workspace"
+    assert container.volume_mounts[0].mount_path == "/workspace/agent"
+    assert container.volume_mounts[0].read_only is False
+    assert container.security_context.run_as_non_root is True
+    assert container.security_context.run_as_user == 1000
+    assert container.security_context.run_as_group == 1000
+    assert container.security_context.capabilities_add == ()
+    assert container.security_context.capabilities_drop == ("ALL",)
     assert pvc.spec.storage_class_name == "gp3"
     assert pvc.spec.storage_request == "20Gi"
     assert "azents/workspace-path" not in pod.metadata.labels
@@ -1426,6 +1404,11 @@ async def test_docker_policy_exposes_private_dind_socket_directly() -> None:
         "container-engine",
     ]
     assert runner.security_context.privileged is False
+    assert runner.security_context.run_as_non_root is True
+    assert runner.security_context.run_as_user == 1000
+    assert runner.security_context.run_as_group == 1000
+    assert runner.security_context.capabilities_add == ()
+    assert runner.security_context.capabilities_drop == ("ALL",)
     assert engine.resources == ContainerResources(
         requests={
             "cpu": "500m",
@@ -1473,10 +1456,8 @@ async def test_docker_policy_exposes_private_dind_socket_directly() -> None:
     runner_mounts = {mount.mount_path: mount for mount in runner.volume_mounts}
     engine_mounts = {mount.name: mount for mount in engine.volume_mounts}
     assert runner_mounts["/workspace/agent"].name == "agent-workspace"
-    assert runner_mounts["/var/run/azents-transfer"].name == "agent-workspace"
     assert engine_mounts["agent-workspace"].mount_path == "/workspace/agent"
     assert runner_mounts["/workspace/agent"].read_only is False
-    assert runner_mounts["/var/run/azents-transfer"].read_only is False
     assert engine_mounts["agent-workspace"].read_only is False
     assert runner_mounts["/tmp"].name == "runtime-shared-tmp"
     assert engine_mounts["runtime-shared-tmp"].mount_path == "/tmp"

--- a/python/apps/azents-runtime-runner/src/azents_runtime_runner/main.py
+++ b/python/apps/azents-runtime-runner/src/azents_runtime_runner/main.py
@@ -5,10 +5,8 @@ import dataclasses
 import json
 import logging
 import os
-import stat
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
 
 import grpc
 from azents_runtime_control.execution_policy import RuntimeExecutionPolicyEvidence
@@ -123,17 +121,13 @@ async def run_runtime_runner() -> None:
     credential_id = _required_env("AZ_RUNTIME_RUNNER_AUTH_CREDENTIAL_ID")
     runner_auth_token = _required_env("AZ_RUNTIME_RUNNER_AUTH_TOKEN")
     execution_policy = _execution_policy_evidence_from_env()
-    protected_staging_directory = _protected_staging_directory_from_env()
     control_tls = _control_tls_from_env()
     allow_insecure_control = _required_bool_env("AZ_RUNTIME_CONTROL_ALLOW_INSECURE")
     base_connection_id = (
         os.environ.get("AZ_RUNTIME_RUNNER_CONNECTION_ID") or uuid.uuid4().hex
     )
     limit_config = runner_limit_config_from_env()
-    workspace = Workspace(
-        workspace_path,
-        blocked_paths=(protected_staging_directory,),
-    )
+    workspace = Workspace(workspace_path)
     registration = RunnerRegistration(
         runtime_id=runtime_id,
         runner_id=runner_id,
@@ -213,7 +207,6 @@ async def run_runtime_runner() -> None:
             control=client,
             transfer=transfer_client,
             accepted_generation=accepted_generation,
-            protected_staging_directory=protected_staging_directory,
         )
         client.set_transfer_intent_handler(transfer_manager.handle_intent)
         client.set_transfer_cancel_handler(transfer_manager.handle_cancel)
@@ -366,26 +359,6 @@ def _required_env(name: str) -> str:
     if not value:
         raise SystemExit(f"{name} is required")
     return value
-
-
-def _protected_staging_directory_from_env() -> Path:
-    """Return the root-owned same-filesystem staging directory."""
-    path = Path(_required_env("AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"))
-    if not path.is_absolute() or os.geteuid() != 0:
-        raise SystemExit("AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY is not protected")
-    try:
-        metadata = path.lstat()
-    except OSError as exc:
-        raise SystemExit(
-            "AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY is not protected"
-        ) from exc
-    if (
-        not stat.S_ISDIR(metadata.st_mode)
-        or metadata.st_uid != 0
-        or stat.S_IMODE(metadata.st_mode) != 0o700
-    ):
-        raise SystemExit("AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY is not protected")
-    return path
 
 
 def _required_bool_env(name: str) -> bool:

--- a/python/apps/azents-runtime-runner/src/azents_runtime_runner/operations.py
+++ b/python/apps/azents-runtime-runner/src/azents_runtime_runner/operations.py
@@ -3,7 +3,6 @@
 import asyncio
 import base64
 import contextlib
-import ctypes
 import fnmatch
 import hashlib
 import logging
@@ -67,19 +66,6 @@ _PROCESS_CLOSE_TIMEOUT_SECONDS = 5.0
 _MAX_MISSING_PROCESS_RECORDS = 128
 _MANAGED_WORKTREE_ROOT = ".azents/worktrees"
 _MAX_MANAGED_WORKTREE_DISCOVERY_ENTRIES = 512
-_WORKLOAD_UID = 1000
-_WORKLOAD_GID = 1000
-_LIBC = ctypes.CDLL(None, use_errno=True)
-try:
-    _setfsuid = _LIBC.setfsuid
-    _setfsuid.argtypes = (ctypes.c_uint,)
-    _setfsuid.restype = ctypes.c_uint
-    _setfsgid = _LIBC.setfsgid
-    _setfsgid.argtypes = (ctypes.c_uint,)
-    _setfsgid.restype = ctypes.c_uint
-except AttributeError:
-    _setfsuid = None
-    _setfsgid = None
 
 _T = TypeVar("_T")
 
@@ -447,10 +433,7 @@ class RunnerOperations:
 
         def run() -> _T:
             started_at.append(time.perf_counter())
-            with _workload_filesystem_identity(
-                required=self._workspace.has_blocked_paths
-            ):
-                return func(cancellation)
+            return func(cancellation)
 
         future = asyncio.get_running_loop().run_in_executor(
             self._file_operation_executor,
@@ -531,7 +514,6 @@ class RunnerOperations:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             start_new_session=True,
-            preexec_fn=_drop_to_workload_identity,
         )
         try:
             stdout, stderr = await asyncio.wait_for(
@@ -626,22 +608,6 @@ class RunnerOperations:
                 ),
             )
             return
-        try:
-            base_path = str(self._workspace.resolve(base_path))
-        except ValueError as exc:
-            await self._file_apply_patch_error(
-                operation,
-                ApplyPatchFailure(
-                    phase="preflight",
-                    reason="base_path_reserved",
-                    message=str(exc),
-                    applied=(),
-                    failed=None,
-                    not_attempted=(),
-                    exact=True,
-                ),
-            )
-            return
         patch = b"".join(chunk.data for chunk in operation.body_chunks)
         declared_patch_bytes = _int_payload(
             operation.payload,
@@ -710,19 +676,16 @@ class RunnerOperations:
 
         def run() -> ApplyPatchResult:
             started_at.append(time.perf_counter())
-            with _workload_filesystem_identity(
-                required=self._workspace.has_blocked_paths
-            ):
-                return execute_apply_patch(
-                    base_path=base_path,
-                    patch=patch,
-                    declared_patch_bytes=declared_patch_bytes,
-                    schema_version=schema_version,
-                    cancellation=cancellation,
-                    deadline_at=operation.deadline_at,
-                    limits=self._apply_patch_limits,
-                    fault_injector=self._apply_patch_fault_injector,
-                )
+            return execute_apply_patch(
+                base_path=base_path,
+                patch=patch,
+                declared_patch_bytes=declared_patch_bytes,
+                schema_version=schema_version,
+                cancellation=cancellation,
+                deadline_at=operation.deadline_at,
+                limits=self._apply_patch_limits,
+                fault_injector=self._apply_patch_fault_injector,
+            )
 
         future = asyncio.get_running_loop().run_in_executor(
             self._file_operation_executor,
@@ -1593,7 +1556,6 @@ class RunnerOperations:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 start_new_session=True,
-                preexec_fn=_drop_to_workload_identity,
             )
         except OSError as exc:
             await self._final_error(operation, "PROCESS_START_FAILED", str(exc))
@@ -2364,7 +2326,6 @@ class RunnerOperations:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 start_new_session=True,
-                preexec_fn=_drop_to_workload_identity,
             )
         except OSError as exc:
             await self._final_error(operation, "git_command_failed", str(exc))
@@ -2544,33 +2505,6 @@ def _remaining_timeout_seconds(deadline_at: datetime | None) -> float | None:
     if deadline_at is None:
         return None
     return max((deadline_at - datetime.now(UTC)).total_seconds(), 0.001)
-
-
-def _drop_to_workload_identity() -> None:
-    """Drop privileged Runner subprocesses to the untrusted workload identity."""
-    if os.geteuid() == 0:
-        os.setgroups(())
-        os.setgid(_WORKLOAD_GID)
-        os.setuid(_WORKLOAD_UID)
-
-
-@contextlib.contextmanager
-def _workload_filesystem_identity(*, required: bool) -> Iterator[None]:
-    """Constrain native file workers to the untrusted workload filesystem identity."""
-    if not required or os.geteuid() != 0:
-        yield
-        return
-    if _setfsuid is None or _setfsgid is None:
-        raise RuntimeError(
-            "protected Runtime transfer staging requires Linux filesystem identities"
-        )
-    prior_gid = _setfsgid(_WORKLOAD_GID)
-    prior_uid = _setfsuid(_WORKLOAD_UID)
-    try:
-        yield
-    finally:
-        _setfsuid(prior_uid)
-        _setfsgid(prior_gid)
 
 
 def _git_command_error_message(result: _GitCommandResult) -> str:
@@ -3559,7 +3493,12 @@ def _excluded(
 
 def _resolve_lexical_path(raw_path: object, *, workspace: Workspace) -> Path:
     """Build an absolute path without following symlink targets."""
-    return workspace.resolve_lexical(raw_path)
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError("path is required")
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = workspace.root / path
+    return Path(os.path.normpath(str(path)))
 
 
 def _lexical_relative_path(path: Path, base: Path) -> str:

--- a/python/apps/azents-runtime-runner/src/azents_runtime_runner/transfer.py
+++ b/python/apps/azents-runtime-runner/src/azents_runtime_runner/transfer.py
@@ -2,18 +2,15 @@
 
 import asyncio
 import contextlib
-import ctypes
-import errno
 import hashlib
 import logging
 import os
-import re
+import secrets
 import stat
-import tempfile
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import Protocol
 
 import grpc
@@ -42,23 +39,7 @@ from azents_runtime_control.transfer import (
 _BUFFER_BYTES = MAX_TRANSFER_CHUNK_BYTES
 _DEFAULT_MAX_ACTIVE_TRANSFERS = 4
 _DEFAULT_MAX_TOMBSTONES = 256
-_WORKLOAD_UID = 1000
-_WORKLOAD_GID = 1000
-_PROTECTED_STAGE_MAX_AGE_SECONDS = 60 * 60
-_PROTECTED_STAGE_CLEANUP_LIMIT = 256
-_PROTECTED_STAGE_NAME = re.compile(r"\.transfer-attempt-[a-z0-9_]{8,}")
 _LOGGER = logging.getLogger(__name__)
-_AT_EMPTY_PATH = 0x1000
-_LIBC = ctypes.CDLL(None, use_errno=True)
-_LINKAT = _LIBC.linkat
-_LINKAT.argtypes = (
-    ctypes.c_int,
-    ctypes.c_char_p,
-    ctypes.c_int,
-    ctypes.c_char_p,
-    ctypes.c_int,
-)
-_LINKAT.restype = ctypes.c_int
 
 
 class RunnerTransferResultSink(Protocol):
@@ -126,7 +107,6 @@ class RunnerTransferManager:
         control: RunnerTransferResultSink,
         transfer: RunnerTransferClient,
         accepted_generation: Callable[[], int | None],
-        protected_staging_directory: Path | None = None,
         max_active_transfers: int = _DEFAULT_MAX_ACTIVE_TRANSFERS,
         max_tombstones: int = _DEFAULT_MAX_TOMBSTONES,
     ) -> None:
@@ -136,7 +116,6 @@ class RunnerTransferManager:
         self._control = control
         self._transfer = transfer
         self._accepted_generation = accepted_generation
-        self._protected_staging_directory = protected_staging_directory
         self._max_active_transfers = max_active_transfers
         self._max_tombstones = max_tombstones
         self._active: dict[_TransferKey, _ActiveTransfer] = {}
@@ -152,12 +131,7 @@ class RunnerTransferManager:
         self._closed = False
 
     async def start(self) -> None:
-        """Provide a lifecycle hook without pathname-backed transfer state."""
-        if self._protected_staging_directory is not None:
-            await asyncio.to_thread(
-                _cleanup_protected_staging_directory,
-                self._protected_staging_directory,
-            )
+        """Start bounded transfer-result publishing."""
         self._ensure_result_task()
 
     async def handle_intent(self, intent: RunnerTransferIntent) -> None:
@@ -272,22 +246,9 @@ class RunnerTransferManager:
             raise _TransferFailure(RunnerTransferFailure.PROTOCOL_VIOLATION)
         parent_fd, destination_name = _open_parent(intent.runtime_path, create=True)
         stage_fd: int | None = None
-        stage_dir_fd: int | None = None
         stage_name: str | None = None
         try:
-            if self._protected_staging_directory is None:
-                stage_fd = _open_unnamed_temporary_file(parent_fd)
-            else:
-                stage_dir_fd = _open_protected_staging_directory(
-                    self._protected_staging_directory
-                )
-                if os.fstat(stage_dir_fd).st_dev != os.fstat(parent_fd).st_dev:
-                    raise _TransferFailure(RunnerTransferFailure.DESTINATION_FAILED)
-                stage_fd, stage_path = tempfile.mkstemp(
-                    prefix=".transfer-attempt-",
-                    dir=f"/proc/self/fd/{stage_dir_fd}",
-                )
-                stage_name = Path(stage_path).name
+            stage_fd, stage_name = _open_temporary_file(parent_fd)
             offset = 0
             digest = hashlib.sha256()
             complete: RunnerDownloadComplete | None = None
@@ -324,34 +285,26 @@ class RunnerTransferManager:
             assert stage_fd is not None
             async with self._commit_lock:
                 _check_stop(intent, cancelled)
-                if stage_dir_fd is None or stage_name is None:
-                    _assert_empty_destination(parent_fd, destination_name)
-                    _link_from_file_descriptor(
-                        stage_fd,
-                        destination_name,
-                        dst_dir_fd=parent_fd,
-                    )
-                else:
-                    os.fchown(stage_fd, _WORKLOAD_UID, _WORKLOAD_GID)
-                    os.fchmod(stage_fd, 0o600)
-                if stage_dir_fd is not None and stage_name is not None and overwrite:
+                if overwrite:
+                    assert stage_name is not None
                     os.replace(
                         stage_name,
                         destination_name,
-                        src_dir_fd=stage_dir_fd,
+                        src_dir_fd=parent_fd,
                         dst_dir_fd=parent_fd,
                     )
                     stage_name = None
-                elif stage_dir_fd is not None and stage_name is not None:
+                else:
+                    assert stage_name is not None
                     _assert_empty_destination(parent_fd, destination_name)
                     os.link(
                         stage_name,
                         destination_name,
-                        src_dir_fd=stage_dir_fd,
+                        src_dir_fd=parent_fd,
                         dst_dir_fd=parent_fd,
                         follow_symlinks=False,
                     )
-                    os.unlink(stage_name, dir_fd=stage_dir_fd)
+                    os.unlink(stage_name, dir_fd=parent_fd)
                     stage_name = None
             return RunnerTransferResult(
                 identity=intent.identity,
@@ -365,13 +318,11 @@ class RunnerTransferManager:
                 failure=None,
             )
         finally:
-            if stage_name is not None and stage_dir_fd is not None:
+            if stage_name is not None:
                 with contextlib.suppress(FileNotFoundError):
-                    os.unlink(stage_name, dir_fd=stage_dir_fd)
+                    os.unlink(stage_name, dir_fd=parent_fd)
             if stage_fd is not None:
                 os.close(stage_fd)
-            if stage_dir_fd is not None:
-                os.close(stage_dir_fd)
             os.close(parent_fd)
 
     async def _upload(
@@ -385,6 +336,7 @@ class RunnerTransferManager:
         parent_fd, source_name = _open_parent(intent.runtime_path, create=False)
         source_fd: int | None = None
         snapshot_fd: int | None = None
+        snapshot_name: str | None = None
         try:
             source_fd = os.open(
                 source_name,
@@ -394,7 +346,7 @@ class RunnerTransferManager:
             before = _regular_identity(os.fstat(source_fd))
             if before.size != expected_size:
                 raise _TransferFailure(RunnerTransferFailure.INTEGRITY_FAILED)
-            snapshot_fd = _open_unnamed_temporary_file(parent_fd)
+            snapshot_fd, snapshot_name = _open_temporary_file(parent_fd)
             digest = hashlib.sha256()
             copied = 0
             while True:
@@ -466,6 +418,9 @@ class RunnerTransferManager:
                 failure=None,
             )
         finally:
+            if snapshot_name is not None:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(snapshot_name, dir_fd=parent_fd)
             if source_fd is not None:
                 os.close(source_fd)
             if snapshot_fd is not None:
@@ -699,10 +654,8 @@ def _open_parent(path: str, *, create: bool) -> tuple[int, str]:
             except FileNotFoundError:
                 if not create:
                     raise
-                created = False
                 try:
                     os.mkdir(component, 0o700, dir_fd=parent_fd)
-                    created = True
                 except FileExistsError:
                     pass
                 next_fd = os.open(
@@ -710,14 +663,6 @@ def _open_parent(path: str, *, create: bool) -> tuple[int, str]:
                     os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
                     dir_fd=parent_fd,
                 )
-                try:
-                    if created:
-                        if os.geteuid() == 0:
-                            os.fchown(next_fd, _WORKLOAD_UID, _WORKLOAD_GID)
-                        os.fchmod(next_fd, 0o755)
-                except BaseException:
-                    os.close(next_fd)
-                    raise
             os.close(parent_fd)
             parent_fd = next_fd
         return parent_fd, candidate.name
@@ -749,77 +694,20 @@ def _write_all(fd: int, data: bytes) -> None:
         view = view[written:]
 
 
-def _open_unnamed_temporary_file(parent_fd: int) -> int:
-    return os.open(
-        ".",
-        os.O_RDWR | os.O_TMPFILE,
-        0o600,
-        dir_fd=parent_fd,
-    )
-
-
-def _open_protected_staging_directory(path: Path) -> int:
-    if not path.is_absolute():
-        raise _TransferFailure(RunnerTransferFailure.DESTINATION_FAILED)
-    descriptor = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
-    metadata = os.fstat(descriptor)
-    if (
-        not stat.S_ISDIR(metadata.st_mode)
-        or metadata.st_uid != 0
-        or stat.S_IMODE(metadata.st_mode) != 0o700
-    ):
-        os.close(descriptor)
-        raise _TransferFailure(RunnerTransferFailure.DESTINATION_FAILED)
-    return descriptor
-
-
-def _cleanup_protected_staging_directory(path: Path) -> None:
-    """Remove bounded stale attempt files from one verified runtime staging boundary."""
-    descriptor = _open_protected_staging_directory(path)
-    try:
-        cutoff = datetime.now(UTC).timestamp() - _PROTECTED_STAGE_MAX_AGE_SECONDS
-        deleted = 0
-        for name in sorted(os.listdir(descriptor)):
-            if deleted >= _PROTECTED_STAGE_CLEANUP_LIMIT:
-                break
-            if _PROTECTED_STAGE_NAME.fullmatch(name) is None:
-                continue
-            metadata = os.stat(name, dir_fd=descriptor, follow_symlinks=False)
-            if (
-                not stat.S_ISREG(metadata.st_mode)
-                or metadata.st_nlink != 1
-                or metadata.st_mtime > cutoff
-            ):
-                continue
-            os.unlink(name, dir_fd=descriptor)
-            deleted += 1
-    finally:
-        os.close(descriptor)
-
-
-def _link_from_file_descriptor(
-    file_descriptor: int,
-    destination_name: str,
-    *,
-    dst_dir_fd: int,
-) -> None:
-    result = _LINKAT(
-        file_descriptor,
-        b"",
-        dst_dir_fd,
-        os.fsencode(destination_name),
-        _AT_EMPTY_PATH,
-    )
-    if result != 0:
-        error_number = ctypes.get_errno()
-        if error_number not in {errno.ENOENT, errno.EPERM}:
-            raise OSError(error_number, os.strerror(error_number), destination_name)
-        os.link(
-            f"/proc/self/fd/{file_descriptor}",
-            destination_name,
-            dst_dir_fd=dst_dir_fd,
-            follow_symlinks=True,
-        )
+def _open_temporary_file(parent_fd: int) -> tuple[int, str]:
+    for _ in range(16):
+        name = f".azents-transfer-{secrets.token_hex(16)}"
+        try:
+            descriptor = os.open(
+                name,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+        except FileExistsError:
+            continue
+        return descriptor, name
+    raise OSError("could not allocate a unique Runtime transfer staging file")
 
 
 def _local_io_failure(intent: RunnerTransferIntent) -> RunnerTransferFailure:

--- a/python/apps/azents-runtime-runner/src/azents_runtime_runner/workspace.py
+++ b/python/apps/azents-runtime-runner/src/azents_runtime_runner/workspace.py
@@ -1,21 +1,17 @@
 """Workspace path helpers for Runtime Runner operations."""
 
-import os
 from pathlib import Path
 
 
 class Workspace:
     """Resolve operation paths against the Runner process filesystem."""
 
-    def __init__(self, root: str, *, blocked_paths: tuple[Path, ...] = ()) -> None:
+    def __init__(self, root: str) -> None:
         """Initialize the default workspace root."""
         if not root:
             raise ValueError("workspace root is required")
         self.root = Path(root).resolve()
         self.root.mkdir(parents=True, exist_ok=True)
-        self._blocked_paths = tuple(
-            path.resolve(strict=False) for path in blocked_paths
-        )
 
     def resolve(self, raw_path: object) -> Path:
         """Resolve an absolute or workspace-relative path.
@@ -24,42 +20,13 @@ class Workspace:
         tools now intentionally operate on absolute runtime filesystem paths, while
         relative paths still resolve under the default workspace root.
         """
-        candidate = self._absolute_path(raw_path)
-        resolved = candidate.resolve(strict=False)
-        self._reject_blocked(resolved)
-        return resolved
-
-    def resolve_lexical(self, raw_path: object) -> Path:
-        """Return a normalized path while enforcing resolved blocked-path identity."""
-        candidate = Path(os.path.normpath(str(self._absolute_path(raw_path))))
-        self._reject_blocked(candidate.resolve(strict=False))
-        return candidate
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise ValueError("path is required")
+        candidate = Path(raw_path)
+        if not candidate.is_absolute():
+            candidate = self.root / candidate
+        return candidate.resolve(strict=False)
 
     def display_path(self, path: Path) -> str:
         """Return a stable absolute display path."""
         return str(path.resolve(strict=False))
-
-    @property
-    def has_blocked_paths(self) -> bool:
-        """Return whether this Runner has a protected filesystem boundary."""
-        return bool(self._blocked_paths)
-
-    def _absolute_path(self, raw_path: object) -> Path:
-        if not isinstance(raw_path, str) or not raw_path.strip():
-            raise ValueError("path is required")
-        candidate = Path(raw_path)
-        if candidate.is_absolute():
-            return candidate
-        return self.root / candidate
-
-    def _reject_blocked(self, resolved: Path) -> None:
-        if any(_is_within(resolved, blocked) for blocked in self._blocked_paths):
-            raise ValueError("path is reserved for Runtime transfer staging")
-
-
-def _is_within(path: Path, root: Path) -> bool:
-    try:
-        path.relative_to(root)
-    except ValueError:
-        return False
-    return True

--- a/python/apps/azents-runtime-runner/tests/main_test.py
+++ b/python/apps/azents-runtime-runner/tests/main_test.py
@@ -4,17 +4,14 @@
 
 import json
 import logging
-from pathlib import Path
 
 import pytest
 from pytest import MonkeyPatch
 
-import azents_runtime_runner.main as runner_main
 from azents_runtime_runner.main import (
     RunnerLimitConfig,
     StructuredLogFormatter,
     _execution_policy_evidence_from_env,
-    _protected_staging_directory_from_env,
     run_runtime_runner,
     runner_limit_config_from_env,
 )
@@ -87,35 +84,6 @@ async def test_runner_requires_explicit_transfer_endpoint(
 
     with pytest.raises(SystemExit, match="AZ_RUNTIME_TRANSFER_ENDPOINT"):
         await run_runtime_runner()
-
-
-def test_protected_staging_requires_provider_created_directory(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    staging = tmp_path / "missing-staging"
-    monkeypatch.setenv("AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY", str(staging))
-    monkeypatch.setattr(runner_main.os, "geteuid", lambda: 0)
-
-    with pytest.raises(SystemExit, match="AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"):
-        _protected_staging_directory_from_env()
-
-    assert not staging.exists()
-
-
-def test_protected_staging_rejects_symlink(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    target = tmp_path / "target"
-    target.mkdir()
-    staging = tmp_path / "staging"
-    staging.symlink_to(target, target_is_directory=True)
-    monkeypatch.setenv("AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY", str(staging))
-    monkeypatch.setattr(runner_main.os, "geteuid", lambda: 0)
-
-    with pytest.raises(SystemExit, match="AZ_RUNTIME_TRANSFER_STAGING_DIRECTORY"):
-        _protected_staging_directory_from_env()
 
 
 _LIMIT_ENV_NAMES = (

--- a/python/apps/azents-runtime-runner/tests/operations_test.py
+++ b/python/apps/azents-runtime-runner/tests/operations_test.py
@@ -22,43 +22,11 @@ from azents_runtime_control.runner import (
     RuntimeRunnerEventType,
 )
 
-import azents_runtime_runner.operations as runner_operations
 from azents_runtime_runner.operations import (
     RunnerOperations,
     _extract_glob_dir_prefix,  # pyright: ignore[reportPrivateUsage] -- Validate root-prefix parsing without traversing the host root.
 )
 from azents_runtime_runner.workspace import Workspace
-
-
-def test_workload_filesystem_identity_only_applies_with_protected_staging(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Ordinary Runner files retain their existing identity semantics."""
-    calls: list[tuple[str, int]] = []
-
-    def set_fsuid(value: int) -> int:
-        calls.append(("uid", value))
-        return 0
-
-    def set_fsgid(value: int) -> int:
-        calls.append(("gid", value))
-        return 0
-
-    monkeypatch.setattr(runner_operations.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(runner_operations, "_setfsuid", set_fsuid)
-    monkeypatch.setattr(runner_operations, "_setfsgid", set_fsgid)
-
-    with runner_operations._workload_filesystem_identity(  # pyright: ignore[reportPrivateUsage] -- Validate protected staging identity restriction.
-        required=False
-    ):
-        pass
-    assert calls == []
-
-    with runner_operations._workload_filesystem_identity(  # pyright: ignore[reportPrivateUsage] -- Validate protected staging identity restriction.
-        required=True
-    ):
-        pass
-    assert calls == [("gid", 1000), ("uid", 1000), ("uid", 0), ("gid", 0)]
 
 
 class _FakeClient:
@@ -207,32 +175,6 @@ async def test_file_write_read_and_list_stay_in_workspace(tmp_path: Path) -> Non
             "modified_at": modified_at,
         }
     ]
-
-
-@pytest.mark.asyncio
-async def test_file_delete_rejects_protected_staging_path(tmp_path: Path) -> None:
-    """Lexical native file operations cannot bypass the reserved staging boundary."""
-    staging = tmp_path / "transfer-staging"
-    staging.mkdir()
-    protected_file = staging / "protected.bin"
-    protected_file.write_bytes(b"protected")
-    client = _FakeClient()
-    operations = RunnerOperations(
-        client=client,
-        workspace=Workspace(str(tmp_path), blocked_paths=(staging,)),
-    )
-
-    await operations.handle(
-        _operation(
-            operation_type="file.delete",
-            payload={"path": str(protected_file)},
-        )
-    )
-
-    assert protected_file.read_bytes() == b"protected"
-    assert client.events[-1].event_type is RuntimeRunnerEventType.FINAL_ERROR
-    assert client.events[-1].payload["error_code"] == "INVALID_PATH"
-    await operations.close()
 
 
 @pytest.mark.asyncio

--- a/python/apps/azents-runtime-runner/tests/transfer_test.py
+++ b/python/apps/azents-runtime-runner/tests/transfer_test.py
@@ -5,10 +5,8 @@ import dataclasses
 import errno
 import hashlib
 import os
-import shutil
-import tempfile
 import threading
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -38,25 +36,9 @@ from azents_runtime_runner.transfer import RunnerTransferManager
 
 
 @pytest.fixture
-def tmpfs_path() -> Iterator[Path]:
-    """Provide an O_TMPFILE-capable parent filesystem for transfer tests."""
-    path = Path(tempfile.mkdtemp(dir="/dev/shm"))
-    try:
-        yield path
-    finally:
-        shutil.rmtree(path)
-
-
-@pytest.fixture
-def protected_tmpfs_staging(tmpfs_path: Path) -> Path:
-    """Provide the root-only staging boundary required by overwrite publication."""
-    if os.geteuid() != 0:
-        pytest.skip("requires root to verify workload identity denial")
-    staging = tmpfs_path / "transfer-staging"
-    staging.mkdir(mode=0o700)
-    os.chown(staging, 0, 0)
-    staging.chmod(0o700)
-    return staging
+def tmpfs_path(tmp_path: Path) -> Path:
+    """Provide an ordinary writable parent filesystem for transfer tests."""
+    return tmp_path
 
 
 class _Control:
@@ -252,10 +234,10 @@ async def test_upload_local_io_failure_emits_valid_integrity_result(
 
 
 @pytest.mark.asyncio
-async def test_download_fails_closed_without_replacing_existing_destination(
+async def test_download_atomically_replaces_existing_destination(
     tmpfs_path: Path,
 ) -> None:
-    """Same-UID staging never replaces an existing destination by pathname."""
+    """Verified content replaces an existing destination without privileged staging."""
     destination = tmpfs_path / "destination.bin"
     destination.write_bytes(b"old")
     data = b"new verified content"
@@ -271,39 +253,6 @@ async def test_download_fails_closed_without_replacing_existing_destination(
             )
         ),
         accepted_generation=lambda: 1,
-    )
-
-    await manager.handle_intent(_intent(destination, data=data))
-
-    result = await _result(control)
-    assert result.outcome is RunnerTransferOutcome.FAILED
-    assert result.failure is RunnerTransferFailure.DESTINATION_FAILED
-    assert destination.read_bytes() == b"old"
-    await manager.close()
-
-
-@pytest.mark.asyncio
-async def test_protected_staging_atomically_replaces_and_cleans_attempt(
-    tmpfs_path: Path,
-    protected_tmpfs_staging: Path,
-) -> None:
-    """Verified overwrite keeps the prior file visible until atomic replacement."""
-    destination = tmpfs_path / "destination.bin"
-    destination.write_bytes(b"old")
-    data = b"new verified content"
-    control = _Control()
-    manager = RunnerTransferManager(
-        control=control,
-        transfer=_Transfer(
-            (
-                RunnerDownloadChunk(offset=0, data=data),
-                RunnerDownloadComplete(
-                    actual_size=len(data), sha256=hashlib.sha256(data).hexdigest()
-                ),
-            )
-        ),
-        accepted_generation=lambda: 1,
-        protected_staging_directory=protected_tmpfs_staging,
     )
 
     await manager.handle_intent(_intent(destination, data=data))
@@ -312,172 +261,15 @@ async def test_protected_staging_atomically_replaces_and_cleans_attempt(
     assert result.outcome is RunnerTransferOutcome.SUCCEEDED
     assert result.destination_committed is True
     assert destination.read_bytes() == data
-    assert list(protected_tmpfs_staging.iterdir()) == []
+    assert not list(tmpfs_path.glob(".azents-transfer-*"))
     await manager.close()
-
-
-@pytest.mark.asyncio
-async def test_protected_staging_creates_workload_accessible_nested_destination(
-    tmpfs_path: Path,
-    protected_tmpfs_staging: Path,
-) -> None:
-    """Nested destination parents remain traversable after root publication."""
-    os.chown(tmpfs_path, 0, 0)
-    tmpfs_path.chmod(0o755)
-    workspace = tmpfs_path / "workspace"
-    workspace.mkdir(mode=0o755)
-    os.chown(workspace, 1000, 1000)
-    destination = workspace / "nested" / "destination.bin"
-    data = b"workload-readable"
-    control = _Control()
-    manager = RunnerTransferManager(
-        control=control,
-        transfer=_Transfer(
-            (
-                RunnerDownloadChunk(offset=0, data=data),
-                RunnerDownloadComplete(
-                    actual_size=len(data), sha256=hashlib.sha256(data).hexdigest()
-                ),
-            )
-        ),
-        accepted_generation=lambda: 1,
-        protected_staging_directory=protected_tmpfs_staging,
-    )
-
-    await manager.handle_intent(_intent(destination, data=data))
-
-    result = await _result(control)
-    parent_metadata = destination.parent.stat()
-    assert result.outcome is RunnerTransferOutcome.SUCCEEDED
-    assert parent_metadata.st_uid == 1000
-    assert parent_metadata.st_gid == 1000
-    assert parent_metadata.st_mode & 0o777 == 0o755
-
-    read_fd, write_fd = os.pipe()
-    process_id = os.fork()
-    if process_id == 0:
-        os.close(read_fd)
-        os.setgroups(())
-        os.setgid(1000)
-        os.setuid(1000)
-        try:
-            descriptor = os.open(destination, os.O_RDONLY)
-            try:
-                received = os.read(descriptor, len(data))
-            finally:
-                os.close(descriptor)
-            os.write(write_fd, received)
-        finally:
-            os.close(write_fd)
-        os._exit(0)
-    os.close(write_fd)
-    received = os.read(read_fd, len(data))
-    _, status = os.waitpid(process_id, 0)
-    os.close(read_fd)
-
-    assert os.waitstatus_to_exitcode(status) == 0
-    assert received == data
-    await manager.close()
-
-
-@pytest.mark.asyncio
-async def test_cross_device_protected_staging_fails_without_replacing_destination(
-    tmpfs_path: Path,
-    tmp_path: Path,
-) -> None:
-    """Overwrite refuses a protected staging boundary on another filesystem."""
-    if os.geteuid() != 0:
-        pytest.skip("requires root to prepare protected staging")
-    staging = tmp_path / "transfer-staging"
-    staging.mkdir(mode=0o700)
-    os.chown(staging, 0, 0)
-    staging.chmod(0o700)
-    if staging.stat().st_dev == tmpfs_path.stat().st_dev:
-        pytest.skip("test paths are on the same filesystem")
-    destination = tmpfs_path / "destination.bin"
-    destination.write_bytes(b"old")
-    data = b"new verified content"
-    control = _Control()
-    manager = RunnerTransferManager(
-        control=control,
-        transfer=_Transfer(
-            (
-                RunnerDownloadChunk(offset=0, data=data),
-                RunnerDownloadComplete(
-                    actual_size=len(data), sha256=hashlib.sha256(data).hexdigest()
-                ),
-            )
-        ),
-        accepted_generation=lambda: 1,
-        protected_staging_directory=staging,
-    )
-
-    await manager.handle_intent(_intent(destination, data=data))
-
-    result = await _result(control)
-    assert result.outcome is RunnerTransferOutcome.FAILED
-    assert result.failure is RunnerTransferFailure.DESTINATION_FAILED
-    assert destination.read_bytes() == b"old"
-    assert list(staging.iterdir()) == []
-    await manager.close()
-
-
-def test_workload_identity_cannot_access_protected_staging(
-    tmpfs_path: Path,
-    protected_tmpfs_staging: Path,
-) -> None:
-    """UID/GID 1000 cannot read, link, rename, delete, or precreate staging entries."""
-    workspace = tmpfs_path / "workspace"
-    workspace.mkdir(mode=0o755)
-    os.chown(workspace, 1000, 1000)
-    protected_file = protected_tmpfs_staging / "protected.bin"
-    protected_file.write_bytes(b"protected")
-    protected_file.chmod(0o600)
-    read_fd, write_fd = os.pipe()
-    process_id = os.fork()
-    if process_id == 0:
-        os.close(read_fd)
-        os.setgroups(())
-        os.setgid(1000)
-        os.setuid(1000)
-        outcomes: list[bool] = []
-        for operation in (
-            lambda: os.open(protected_file, os.O_RDONLY),
-            lambda: os.link(protected_file, workspace / "linked.bin"),
-            lambda: os.replace(protected_file, workspace / "renamed.bin"),
-            lambda: os.unlink(protected_file),
-            lambda: os.open(
-                protected_tmpfs_staging / "attacker.bin",
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o600,
-            ),
-        ):
-            try:
-                descriptor = operation()
-            except PermissionError:
-                outcomes.append(True)
-            else:
-                outcomes.append(False)
-                if isinstance(descriptor, int):
-                    os.close(descriptor)
-        os.write(write_fd, bytes(outcomes))
-        os.close(write_fd)
-        os._exit(0)
-    os.close(write_fd)
-    serialized_outcomes = os.read(read_fd, 5)
-    _, status = os.waitpid(process_id, 0)
-    os.close(read_fd)
-
-    assert os.waitstatus_to_exitcode(status) == 0
-    assert serialized_outcomes == bytes((True, True, True, True, True))
-    assert protected_file.read_bytes() == b"protected"
 
 
 @pytest.mark.asyncio
 async def test_untrusted_transfer_identifiers_cannot_escape_staging_directory(
     tmpfs_path: Path,
 ) -> None:
-    """Opaque unnamed staging ignores untrusted transfer identifiers."""
+    """Random staging names ignore untrusted transfer identifiers."""
     destination = tmpfs_path / "destination.bin"
     data = b"staged safely"
     control = _Control()
@@ -545,7 +337,7 @@ async def test_exact_duplicate_intent_reuses_one_completed_result(
 async def test_exact_cancel_emits_cancelled_result_without_publication(
     tmpfs_path: Path,
 ) -> None:
-    """Cancellation targets the matching active task without a staging pathname."""
+    """Cancellation targets the matching active task and cleans its staging file."""
     data = b"pending"
     started = asyncio.Event()
     release = asyncio.Event()
@@ -718,7 +510,7 @@ async def test_upload_snapshot_keeps_control_work_and_cancellation_responsive(
 async def test_successful_upload_leaves_no_mutable_snapshot_path(
     tmpfs_path: Path,
 ) -> None:
-    """A completed upload releases its unnamed snapshot when its fd closes."""
+    """A completed upload removes its same-directory snapshot."""
     source = tmpfs_path / "source.bin"
     data = b"upload bytes"
     source.write_bytes(data)
@@ -776,10 +568,10 @@ async def test_upload_rejects_fifo_without_blocking_control(tmpfs_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_download_uses_unnamed_stage_and_leaves_no_reclaimable_path(
+async def test_download_cleans_same_directory_stage_after_cancellation(
     tmpfs_path: Path,
 ) -> None:
-    """An interrupted download owns no mutable staging or journal pathname."""
+    """An interrupted download removes its randomly named staging file."""
     started = asyncio.Event()
     release = asyncio.Event()
     data = b"pending"
@@ -810,8 +602,7 @@ async def test_download_uses_unnamed_stage_and_leaves_no_reclaimable_path(
     await manager.handle_intent(intent)
     await asyncio.wait_for(started.wait(), timeout=1)
 
-    assert not list(tmpfs_path.glob(".azents-transfer-*"))
-    assert not list(tmpfs_path.glob(".azents-transfer-orphans"))
+    assert len(list(tmpfs_path.glob(".azents-transfer-*"))) == 1
     await manager.handle_cancel(
         RunnerTransferCancel(
             identity=intent.identity,
@@ -821,16 +612,17 @@ async def test_download_uses_unnamed_stage_and_leaves_no_reclaimable_path(
         )
     )
     assert (await _result(control)).outcome is RunnerTransferOutcome.CANCELLED
+    assert not list(tmpfs_path.glob(".azents-transfer-*"))
     release.set()
     await manager.close()
 
 
 @pytest.mark.asyncio
-async def test_download_fails_closed_when_parent_lacks_unnamed_temporary_file_support(
+async def test_download_fails_closed_when_staging_file_cannot_be_created(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An unsupported O_TMPFILE capability cannot trigger a mutable-name fallback."""
+    """A staging allocation failure leaves the destination unchanged."""
     destination = tmp_path / "destination.bin"
     data = b"safe"
     control = _Control()
@@ -843,13 +635,13 @@ async def test_download_fails_closed_when_parent_lacks_unnamed_temporary_file_su
         )
     )
 
-    def unsupported_unnamed_temporary_file(parent_fd: int) -> int:
+    def fail_temporary_file_creation(parent_fd: int) -> tuple[int, str]:
         del parent_fd
         raise OSError(errno.EOPNOTSUPP, "Operation not supported")
 
     monkeypatch.setattr(
-        "azents_runtime_runner.transfer._open_unnamed_temporary_file",
-        unsupported_unnamed_temporary_file,
+        "azents_runtime_runner.transfer._open_temporary_file",
+        fail_temporary_file_creation,
     )
     manager = RunnerTransferManager(
         control=control,

--- a/python/apps/azents-runtime-runner/tests/workspace_test.py
+++ b/python/apps/azents-runtime-runner/tests/workspace_test.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 from azents_runtime_runner.workspace import Workspace
 
 
@@ -18,18 +16,3 @@ def test_workspace_allows_absolute_paths_outside_default_root(tmp_path: Path) ->
     outside = tmp_path / "secret.txt"
 
     assert workspace.resolve(str(outside)) == outside
-
-
-def test_workspace_blocks_protected_staging_through_direct_and_symlink_paths(
-    tmp_path: Path,
-) -> None:
-    workspace_root = tmp_path / "agent"
-    staging = tmp_path / "transfer-staging"
-    staging.mkdir()
-    alias = tmp_path / "staging-alias"
-    alias.symlink_to(staging, target_is_directory=True)
-    workspace = Workspace(str(workspace_root), blocked_paths=(staging,))
-
-    for path in (staging / "attempt", alias / "attempt"):
-        with pytest.raises(ValueError, match="reserved for Runtime transfer staging"):
-            workspace.resolve_lexical(str(path))


### PR DESCRIPTION
## Summary

- run Runtime Runner as UID/GID 1000 in Docker and Kubernetes providers
- remove root-owned transfer staging, Runner identity switching, Linux capabilities, Kubernetes init container, PVC subPath staging layout, and the staging environment contract
- keep verified same-filesystem atomic download publication with ordinary randomly named temporary files
- update the Runtime Control living spec and generated indexes

## Root cause

Runtime Runner startup required a root-owned `0700` staging directory and effective UID 0. The Kubernetes provider created that directory in a privileged initializer and then ran the Runner as root with `SETUID`/`SETGID`. That provider-specific hardening became a mandatory Runner contract, so a correctly packaged non-root or plain-Python Runner exited before connecting to Runtime Control.

## Impact

The Runner no longer needs root, fixed Linux identities, or provider-created staging. Docker and Kubernetes providers use the same non-root Runner contract. Download integrity still verifies the complete size and SHA-256 before atomic publication, including overwrite.

## Validation

- Runtime Runner: Ruff, formatting, Pyright, 140 tests passed
- Kubernetes Provider: Ruff, Pyright, 70 tests passed
- Docker Provider: Ruff, Pyright, 22 tests passed
- docs index validation and pre-commit hooks passed
- focused deterministic E2E built the new Runner and Docker Provider images, started and connected the non-root Runtime, and completed a real `exec_command` with persisted stdout, exit code, and process metadata
- that E2E later failed in its second model turn because the deterministic proxy reported `Strict mode: no fixture matched`
- External Channel file-transfer E2E also started and connected the new Runtime, then timed out before its first model request with empty proxy evidence; it did not reach the transfer assertion