### PR TITLE
Allow platform-owned runtime egress exceptions

### DIFF
--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -205,7 +205,7 @@ class KubernetesRuntimeProvider:
             *config.network_hard_cap_denied_cidrs,
         ):
             _ip_network(cidr)
-        _validate_network_hard_cap_extra_egress(config)
+        _validate_extra_egress_ip_blocks(config.network_hard_cap_extra_egress)
         _immutable_image_reference(config.engine_image, "engine image")
         self._api = api
         self._config = config
@@ -1335,14 +1335,11 @@ def _permitted_egress_rules(
     return (*rules, *config.network_hard_cap_extra_egress)
 
 
-def _validate_network_hard_cap_extra_egress(
-    config: KubernetesRuntimeProviderConfig,
+def _validate_extra_egress_ip_blocks(
+    rules: tuple[NetworkPolicyEgressRule, ...],
 ) -> None:
-    allowed = tuple(
-        _ip_network(value) for value in config.network_hard_cap_allowed_cidrs
-    )
-    denied = tuple(_ip_network(value) for value in config.network_hard_cap_denied_cidrs)
-    for rule in config.network_hard_cap_extra_egress:
+    """Validate Platform-owned extra egress IPBlock syntax."""
+    for rule in rules:
         for peer in rule.peers:
             if peer.ip_block is None:
                 continue
@@ -1358,25 +1355,6 @@ def _validate_network_hard_cap_extra_egress(
                     "Provider extra egress IPBlock exceptions must be strict "
                     "subnets of their CIDR."
                 )
-            if allowed and not any(
-                _subnet_of_same_family(network, allowed_network)
-                for allowed_network in allowed
-            ):
-                raise UnsupportedRuntimeConfiguration(
-                    "Provider extra egress IPBlock exceeds the network hard cap."
-                )
-            for denied_network in denied:
-                overlap = _network_intersection(network, denied_network)
-                if overlap is None:
-                    continue
-                if not any(
-                    _subnet_of_same_family(overlap, exception)
-                    for exception in exceptions
-                ):
-                    raise UnsupportedRuntimeConfiguration(
-                        "Provider extra egress IPBlock bypasses a denied network "
-                        "hard cap."
-                    )
 
 
 def _network_intersection(

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -1388,33 +1388,43 @@ async def test_direct_network_policy_is_bounded_by_deployment_hard_cap() -> None
     assert optional_rules == (extra_egress,)
 
 
-def test_provider_rejects_extra_ip_egress_outside_network_hard_cap() -> None:
+@pytest.mark.asyncio
+async def test_platform_extra_ip_egress_is_part_of_provider_boundary() -> None:
+    api = FakeKubernetesApi()
     extra_egress = NetworkPolicyEgressRule(
         peers=(
             NetworkPolicyPeer(
                 namespace_selector=None,
                 pod_selector=None,
                 ip_block=IpBlock(
-                    cidr="0.0.0.0/0",
+                    cidr="192.168.68.144/32",
                     except_cidrs=(),
                 ),
             ),
         ),
-        ports=(),
+        ports=(NetworkPolicyPort(protocol="TCP", port=443),),
     )
 
-    with pytest.raises(
-        UnsupportedRuntimeConfiguration,
-        match="exceeds the network hard cap",
-    ):
-        _provider(
-            FakeKubernetesApi(),
-            network_hard_cap_allowed_cidrs=("10.10.0.0/16",),
-            network_hard_cap_extra_egress=(extra_egress,),
+    provider = _provider(
+        api,
+        network_hard_cap_denied_cidrs=("192.168.0.0/16",),
+        network_hard_cap_extra_egress=(extra_egress,),
+    )
+
+    await provider.start(
+        _command(
+            RuntimeLifecycleCommandType.START,
+            runtime_configuration=_runtime_configuration(),
         )
+    )
+
+    network_policy = api.network_policies[
+        ("azents-runtime", "azents-runtime-runtime-1-execution")
+    ]
+    assert extra_egress in network_policy.spec.egress
 
 
-def test_provider_rejects_extra_ip_egress_that_bypasses_denied_hard_cap() -> None:
+def test_provider_rejects_invalid_extra_ip_egress_exception() -> None:
     extra_egress = NetworkPolicyEgressRule(
         peers=(
             NetworkPolicyPeer(
@@ -1422,7 +1432,7 @@ def test_provider_rejects_extra_ip_egress_that_bypasses_denied_hard_cap() -> Non
                 pod_selector=None,
                 ip_block=IpBlock(
                     cidr="10.10.0.0/16",
-                    except_cidrs=(),
+                    except_cidrs=("10.10.0.0/16",),
                 ),
             ),
         ),
@@ -1431,11 +1441,10 @@ def test_provider_rejects_extra_ip_egress_that_bypasses_denied_hard_cap() -> Non
 
     with pytest.raises(
         UnsupportedRuntimeConfiguration,
-        match="bypasses a denied network hard cap",
+        match="exceptions must be strict subnets",
     ):
         _provider(
             FakeKubernetesApi(),
-            network_hard_cap_denied_cidrs=("10.10.1.0/24",),
             network_hard_cap_extra_egress=(extra_egress,),
         )
 


### PR DESCRIPTION
## Summary

- treat deployment-configured `extraEgress` rules as part of the Platform Provider network boundary
- retain IPBlock CIDR and strict-exception validation
- add regression coverage for a narrow Platform-owned `192.168.68.144/32:443` exception within a broader denied CIDR

## Root cause

The Kubernetes Provider startup validator treated Platform-owned `extraEgress` IPBlocks as lower-authority policy and rejected any overlap with Provider `allowedCidrs` or `deniedCidrs`. The Home deployment intentionally denies `192.168.0.0/16` by default while allowing `192.168.68.144/32:443` as an explicit Platform service exception. The validator therefore crashed the Provider before it could register its current Pod Profile capability contract, leaving the Admin UI to evaluate compatibility against a stale contract.

## Impact

Platform administrators can again define narrow service exceptions as part of the Provider boundary. Pod Profile and Workspace network policies remain bounded by the Provider-owned configuration.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -q` — 71 passed
- focused Provider regression suite — 47 passed
