### PR TITLE
Update AWS Toolkit IAM guidance

### DIFF
--- a/docs/azents/INDEX.md
+++ b/docs/azents/INDEX.md
@@ -23,7 +23,7 @@ Design documents are accumulated records and are not listed individually in this
 | [Model Catalog Domain Spec](spec/domain/model-catalog.md) | model-catalog | - | 2026-08-01 | 18 |
 | [Runtime Provider](spec/domain/runtime-provider.md) | runtime-provider | - | 2026-08-03 | 15 |
 | [System Settings](spec/domain/system-settings.md) | system-settings | @Hardtack | 2026-07-30 | 5 |
-| [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-08-03 | 80 |
+| [Toolkit](spec/domain/toolkit.md) | toolkit | @Hardtack | 2026-08-03 | 81 |
 | [User & Authentication](spec/domain/user-auth.md) | user-auth | @Hardtack | 2026-07-20 | 8 |
 | [Workspace & Membership](spec/domain/workspace.md) | workspace | @Hardtack | 2026-08-03 | 56 |
 

--- a/docs/azents/spec/INDEX.md
+++ b/docs/azents/spec/INDEX.md
@@ -20,7 +20,7 @@ Details of all living specs. Synchronized from frontmatter.
 | model-catalog | [Model Catalog Domain Spec](domain/model-catalog.md) | - | 2026-08-01 | 18 |
 | runtime-provider | [Runtime Provider](domain/runtime-provider.md) | - | 2026-08-03 | 15 |
 | system-settings | [System Settings](domain/system-settings.md) | @Hardtack | 2026-07-30 | 5 |
-| toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-08-03 | 80 |
+| toolkit | [Toolkit](domain/toolkit.md) | @Hardtack | 2026-08-03 | 81 |
 | user-auth | [User & Authentication](domain/user-auth.md) | @Hardtack | 2026-07-20 | 8 |
 | workspace | [Workspace & Membership](domain/workspace.md) | @Hardtack | 2026-08-03 | 56 |
 

--- a/docs/azents/spec/domain/toolkit.md
+++ b/docs/azents/spec/domain/toolkit.md
@@ -53,7 +53,7 @@ api_routes:
   - /toolkit/v1
   - /shell-environment/v1
 last_verified_at: 2026-08-03
-spec_version: 80
+spec_version: 81
 ---
 
 # Toolkit
@@ -212,6 +212,8 @@ azents-web provides workspace-scoped toolkit management screens.
 - `/w/[handle]/toolkit/[toolkitId]/setup` — connection status check and authorize redirect for toolkit requiring per-user OAuth/setup.
 
 `features/toolkits` form branches config fields per toolkit type for GitHub, Kubernetes, MCP, Google Analytics, Notion, Sentry, GCP, AWS, Shell, and EnvVar. `features/toolkit-setup` executes setup action returned by backend, and if account link must come first it follows `next_toolkit` handoff from [`../flow/account-linking.md`](../../design/account-260315-account-linking.md).
+
+The AWS Toolkit form describes the current AWS Managed MCP authorization model for its Access Key + SigV4 connection. It directs managers to grant only the downstream AWS service API permissions the Agent needs. It does not require the deprecated `aws-mcp:InvokeMcp`, `aws-mcp:CallReadOnlyTool`, or `aws-mcp:CallReadWriteTool` actions, which have no effect. MCP-specific restrictions use the `aws:ViaAWSMCPService` or `aws:CalledViaAWSMCP` IAM condition context keys.
 
 ### GitHub Multi-Installation Routing
 
@@ -737,6 +739,9 @@ and never becomes the Channel Work source of truth.
 
 ## Changelog
 
+- **2026-08-03** (spec_version 81) — Replaced the AWS Toolkit setup form's
+  deprecated MCP-specific IAM action list with downstream AWS service
+  permissions and managed MCP condition-key guidance.
 - **2026-08-03** (spec_version 80) — Added the global managed `skill-creator`
   Skill for creating and repairing filesystem Skills through Runtime tools.
 - **2026-08-03** (spec_version 79) — Derived Runtime tool guidance, filesystem Skill roots, AGENTS.md, Claude rules, and `present_file` boundaries from the current Runner-reported Agent Workspace while removing fixed absolute paths from static schemas and prompts.

--- a/typescript/apps/azents-web/src/features/toolkits/components/AwsConfigFields.tsx
+++ b/typescript/apps/azents-web/src/features/toolkits/components/AwsConfigFields.tsx
@@ -10,6 +10,7 @@
 import {
   Accordion,
   Alert,
+  Anchor,
   Button,
   Code,
   NumberInput,
@@ -99,12 +100,6 @@ export function AwsConfigFields({
       credentials,
     });
   }, [handle, toolkitConfigId, config, credentials, testConnectionMutation]);
-
-  const iamActions = [
-    "aws-mcp:InvokeMcp",
-    "aws-mcp:CallReadOnlyTool",
-    "aws-mcp:CallReadWriteTool (when write allowed)",
-  ];
 
   return (
     <Stack gap="md">
@@ -202,23 +197,33 @@ export function AwsConfigFields({
         variant="light"
         color="blue"
         icon={<IconInfoCircle size={16} />}
-        title="Required IAM Permissions"
+        title="IAM Permissions"
       >
-        <Text size="xs" mb="xs">
-          Grant these permissions to your IAM user
-          {roleArn ? " or the assumed role" : ""}:
+        <Text size="xs">
+          Grant the IAM user{roleArn ? " or assumed role" : ""} only the AWS
+          service API permissions the agent needs, such as{" "}
+          <Code>cloudwatch:GetMetricData</Code>, <Code>ce:GetCostAndUsage</Code>
+          , or <Code>ec2:DescribeInstances</Code>.
         </Text>
-        <Stack gap={2}>
-          {iamActions.map((action) => (
-            <Text key={action} size="xs">
-              <Code>{action}</Code>
-            </Text>
-          ))}
-          <Text size="xs" c="dimmed" mt="xs">
-            + actual AWS API permissions (e.g., cloudwatch:GetMetricData,
-            ce:GetCostAndUsage, ec2:DescribeInstances)
-          </Text>
-        </Stack>
+        <Text size="xs" mt="xs">
+          AWS MCP Server uses those existing service permissions. The deprecated{" "}
+          <Code>aws-mcp:InvokeMcp</Code>, <Code>aws-mcp:CallReadOnlyTool</Code>,
+          and <Code>aws-mcp:CallReadWriteTool</Code> actions are not required
+          and have no effect; remove them from existing policies.
+        </Text>
+        <Text size="xs" mt="xs">
+          To restrict requests made through managed MCP servers, use the{" "}
+          <Code>aws:ViaAWSMCPService</Code> or <Code>aws:CalledViaAWSMCP</Code>{" "}
+          IAM condition context keys. See{" "}
+          <Anchor
+            href="https://docs.aws.amazon.com/agent-toolkit/latest/userguide/security_iam_service-with-iam.html"
+            target="_blank"
+            rel="noreferrer"
+          >
+            AWS MCP Server IAM guidance
+          </Anchor>
+          .
+        </Text>
       </Alert>
 
       <Stack gap="xs">


### PR DESCRIPTION
## Summary

- replace the AWS Toolkit setup guide's obsolete `aws-mcp:*` permission list with the downstream AWS service permissions that actually authorize calls
- explain that `aws-mcp:InvokeMcp`, `aws-mcp:CallReadOnlyTool`, and `aws-mcp:CallReadWriteTool` are deprecated, have no effect, and should be removed from existing policies
- document the `aws:ViaAWSMCPService` and `aws:CalledViaAWSMCP` condition keys for MCP-specific restrictions
- sync the Toolkit living spec and generated documentation indexes

## Why

AWS changed the managed MCP authorization model after preview. The server now forwards requests to downstream AWS services, which authorize them using the principal's existing service-level IAM permissions. The previous MCP-specific IAM actions are no longer required and have no effect.

Official reference: https://docs.aws.amazon.com/agent-toolkit/latest/userguide/security_iam_service-with-iam.html

## Impact

Workspace managers configuring an AWS Toolkit now receive current least-privilege guidance and can remove ineffective preview-era permissions from their IAM policies.

## Validation

- `pnpm run lint --filter=@azents/web`
- `pnpm run typecheck --filter=@azents/web`
- `uv run python scripts/gen_docs_index.py --docs-root docs/azents --project-name azents --check`
- `git diff --check`
- repository pre-commit hooks
