### PR TITLE
fix(runtime): finish asynchronous restart reconciliation

### DIFF
--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
@@ -20,6 +20,7 @@ from azents.core.enums import (
     RuntimeDesiredState,
     RuntimeLifecycleCommandType,
     RuntimeProviderConnectionState,
+    RuntimeProviderObservedState,
 )
 from azents.core.runtime_profile import (
     RuntimeConfigurationApplicationImpact,
@@ -129,13 +130,12 @@ class RuntimeLifecycleReconciler:
             if await self._dispatch_runtime(runtime):
                 dispatched += 1
         lifecycle_runtime_ids = {runtime.id for runtime in runtimes}
-        configuration_runtime_ids: set[str] = set()
+        configuration_runtime_ids = {runtime.id for runtime in configuration_runtimes}
         for runtime in configuration_runtimes:
             if runtime.id in lifecycle_runtime_ids:
                 continue
             if await self._dispatch_configuration_adoption(runtime):
                 dispatched += 1
-                configuration_runtime_ids.add(runtime.id)
         for runtime in reconcile_runtimes:
             if (
                 runtime.id in lifecycle_runtime_ids
@@ -178,6 +178,14 @@ class RuntimeLifecycleReconciler:
         )
 
     async def _dispatch_periodic_reconcile(self, runtime: AgentRuntime) -> bool:
+        if (
+            runtime.desired_state is RuntimeDesiredState.RUNNING
+            and runtime.provider_observed_state is RuntimeProviderObservedState.RUNNING
+            and runtime.applied_runtime_configuration_revision_id is not None
+            and runtime.desired_runtime_configuration_revision_id
+            != runtime.applied_runtime_configuration_revision_id
+        ):
+            return False
         async with self._session_manager() as session:
             await self._runtime_repository.mark_provider_observe_requested(
                 session,
@@ -185,14 +193,7 @@ class RuntimeLifecycleReconciler:
             )
         command_type = (
             RuntimeProviderCommandType.START
-            if (
-                runtime.desired_state is RuntimeDesiredState.RUNNING
-                and (
-                    runtime.applied_runtime_configuration_revision_id is None
-                    or runtime.desired_runtime_configuration_revision_id
-                    == runtime.applied_runtime_configuration_revision_id
-                )
-            )
+            if runtime.desired_state is RuntimeDesiredState.RUNNING
             else RuntimeProviderCommandType.OBSERVE
         )
         return await self._dispatch_runtime_command(

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
@@ -194,7 +194,6 @@ async def test_reconciler_dispatches_periodic_provider_start_for_running_runtime
                 provider_observe_requested_at=old_observe_at,
             )
         )
-
     store = InMemoryRuntimeCoordinationStore()
     control_protocol = RuntimeControlProtocolService(
         store,
@@ -245,6 +244,153 @@ async def test_reconciler_dispatches_periodic_provider_start_for_running_runtime
     assert "control_token" not in auth
     assert updated is not None
     assert updated.provider_observe_requested_at is not None
+
+
+async def test_reconciler_fences_adoption_then_finishes_restart_replacement(
+    rdb_session_manager: SessionManager[AsyncSession],
+) -> None:
+    """Configuration adoption and restart convergence never compete."""
+    runtime_repository = AgentRuntimeRepository()
+    async with rdb_session_manager() as session:
+        workspace_id = await _create_workspace(session, "reconciler-restart-ws")
+        agent_id = await _create_agent(
+            session,
+            workspace_id,
+            "reconciler-restart-agent",
+        )
+        runtime = await runtime_repository.ensure_for_agent(session, agent_id)
+        await _bind_runtime_provider(session, runtime.id)
+        initial = await runtime_repository.set_desired_state(
+            session,
+            runtime.id,
+            RuntimeLifecycleCommandType.START,
+            RuntimeDesiredState.RUNNING,
+        )
+        assert initial is not None
+        initial_revision = await _attach_runtime_configuration(
+            session,
+            runtime_id=runtime.id,
+            target_desired_generation=initial.desired_generation,
+        )
+        await session.execute(
+            sa.update(RDBAgentRuntime)
+            .where(RDBAgentRuntime.id == runtime.id)
+            .values(applied_runtime_configuration_revision_id=initial_revision.id)
+        )
+        restart = await runtime_repository.set_desired_state_if_ready(
+            session,
+            runtime.id,
+            RuntimeLifecycleCommandType.RESTART,
+            RuntimeDesiredState.RUNNING,
+            expected_configuration_revision_id=initial_revision.id,
+        )
+        assert restart is not None
+        desired_revision_id = restart.runtime.desired_runtime_configuration_revision_id
+        assert desired_revision_id is not None
+        await session.execute(
+            sa.update(RDBRuntimeConfigurationRevision)
+            .where(RDBRuntimeConfigurationRevision.id == desired_revision_id)
+            .values(
+                provider_reported_digest="d" * 64,
+                provider_acknowledged_at=datetime.datetime.now(datetime.UTC),
+            )
+        )
+        dispatched = await runtime_repository.mark_lifecycle_dispatched(
+            session,
+            runtime.id,
+            restart.desired_generation,
+        )
+        assert dispatched is not None
+        running = await runtime_repository.record_provider_observed_state(
+            session,
+            runtime.id,
+            RuntimeProviderObservedState.RUNNING,
+            1,
+            restart.desired_generation,
+        )
+        assert running is not None
+        old_observe_at = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            minutes=10
+        )
+        await session.execute(
+            sa.update(RDBAgentRuntime)
+            .where(RDBAgentRuntime.id == runtime.id)
+            .values(
+                provider_observed_at=old_observe_at,
+                provider_observe_requested_at=old_observe_at,
+            )
+        )
+
+    store = InMemoryRuntimeCoordinationStore()
+    control_protocol = RuntimeControlProtocolService(
+        store,
+        request_id_factory=lambda: "request-restart-replacement",
+    )
+    accepted = await control_protocol.register_provider(
+        _provider_registration(),
+        registered_at=datetime.datetime.now(datetime.UTC),
+    )
+    reconciler = RuntimeLifecycleReconciler(
+        runtime_repository=runtime_repository,
+        profile_repository=RuntimeProfileRepository(),
+        session_manager=rdb_session_manager,
+        coordination_store=store,
+        control_protocol=control_protocol,
+        config=RuntimeLifecycleDispatchConfig(
+            runner_image="runner:test",
+            runner_control_endpoint="runtime-control:9090",
+            runner_transfer_endpoint="runtime-transfer:9091",
+            runner_credential_identifier=_runner_credential_verifier(),
+            runner_control_tls_ca_pem=None,
+            allow_insecure_runner_control=True,
+            observe_interval=datetime.timedelta(minutes=1),
+        ),
+    )
+
+    guarded = await reconciler._dispatch_periodic_reconcile(running)
+    fenced = await reconciler.reconcile_once(limit=10)
+    competing = await control_protocol.claim_next_provider_request(
+        provider_id="provider-1",
+        generation=accepted.generation,
+        consumer_id="provider-worker",
+        block_ms=0,
+    )
+    async with rdb_session_manager() as session:
+        observed = await runtime_repository.record_provider_observed_state(
+            session,
+            runtime.id,
+            RuntimeProviderObservedState.STARTING,
+            1,
+            restart.desired_generation,
+        )
+        assert observed is not None
+        await session.execute(
+            sa.update(RDBAgentRuntime)
+            .where(RDBAgentRuntime.id == runtime.id)
+            .values(
+                provider_observed_at=old_observe_at,
+                provider_observe_requested_at=old_observe_at,
+            )
+        )
+
+    reconciled = await reconciler.reconcile_once(limit=10)
+    claimed = await control_protocol.claim_next_provider_request(
+        provider_id="provider-1",
+        generation=accepted.generation,
+        consumer_id="provider-worker",
+        block_ms=0,
+    )
+
+    assert not guarded
+    assert fenced == 0
+    assert competing is None
+    assert reconciled == 1
+    assert claimed is not None
+    assert claimed.operation_type == "provider.start"
+    assert claimed.payload["command_type"] == "start"
+    runtime_configuration = claimed.payload["runtime_configuration"]
+    assert isinstance(runtime_configuration, dict)
+    assert runtime_configuration["desired_generation"] == restart.desired_generation
 
 
 async def test_reconciler_rejects_mismatched_resolved_provider_reference(


### PR DESCRIPTION
## Summary

- fence periodic reconciliation for every Runtime configuration-adoption candidate, even while adoption is waiting
- use idempotent `START` to converge desired-running Runtimes after an asynchronous restart replacement
- add a regression test covering the restart/configuration-adoption race

## Root cause

PR #1118 correctly made the Runner authoritative for `workspace_path` and clears stale workspace evidence when the desired generation advances. The restart replacement path then exposed an older reconciler race:

1. restart advanced the Runtime to generation 477 while the applied configuration still targeted generation 476
2. the replacement Pod was deleted and the Provider reported `STARTING`
3. periodic reconciliation selected `OBSERVE` because desired and applied configuration revisions differed
4. Control attached applied evidence for generation 476 to a generation-477 command
5. Provider rejected every request with `Runtime configuration evidence generation does not match the command`

With no replacement Runner available to publish current workspace evidence, the Runtime remained failed and the UI reported `Agent Workspace path is unavailable`.

This change preserves the Runner-authoritative behavior from #1118. A desired-running Runtime that is no longer actively running is instead reconciled with `START` using its current desired generation. An actively running Runtime waiting for explicit configuration adoption remains fenced from the periodic loop.

## Validation

- `uv run ruff check src/azents/runtime/control_protocol/reconciler.py src/azents/runtime/control_protocol/reconciler_test.py`
- `uv run pyright src/azents/runtime/control_protocol/reconciler.py src/azents/runtime/control_protocol/reconciler_test.py`
- `uv run pytest src/azents/runtime/control_protocol/reconciler_test.py src/azents/repos/agent_runtime/repository_test.py -q` (32 passed)
- repository pre-commit hooks
