### PR TITLE
fix(runtime): make provider start idempotent

### DIFF
--- a/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/src/azents_runtime_provider_kubernetes/provider.py
@@ -656,6 +656,20 @@ class KubernetesRuntimeProvider:
         for key, value in expected.metadata.annotations.items():
             if annotations.get(key) != value:
                 return False
+        # A Pending Pod with the exact lifecycle/configuration fence already is
+        # this START request in progress. Kubernetes may default or admit fields
+        # that make a full round-trip spec comparison unequal; deleting that Pod
+        # on every retry prevents it from ever reaching Running. Pod specs are
+        # immutable, and a new Provider/configuration generation changes the
+        # checked labels/annotations above, so retaining the matching Pending Pod
+        # is both idempotent and generation-fenced.
+        if (
+            pod.status is not None
+            and pod.status.phase == "Pending"
+            and _container_images_equal(pod.spec.containers, expected.spec.containers)
+            and _pod_volumes_equal(pod.spec.volumes, expected.spec.volumes)
+        ):
+            return True
         if not _container_specs_equal(
             pod.spec.containers,
             expected.spec.containers,
@@ -1507,6 +1521,15 @@ def _container_specs_equal(
             strict=True,
         )
     )
+
+
+def _container_images_equal(
+    actual: Sequence[ContainerSpec],
+    expected: Sequence[ContainerSpec],
+) -> bool:
+    return {container.name: container.image for container in actual} == {
+        container.name: container.image for container in expected
+    }
 
 
 def _container_specs_equal_for_in_place(

--- a/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
+++ b/python/apps/azents-runtime-provider-kubernetes/tests/test_provider.py
@@ -1172,6 +1172,35 @@ async def test_start_reuses_pod_when_runner_image_and_config_are_unchanged() -> 
 
 
 @pytest.mark.asyncio
+async def test_start_reuses_matching_pending_pod_after_api_defaulting() -> None:
+    """A retried START must not replace the same generation while it is Pending."""
+    api = FakeKubernetesApi()
+    provider = _provider(api)
+    command = _command(RuntimeLifecycleCommandType.START)
+    await provider.start(command)
+    pod_key = ("azents-runtime", "azents-runtime-runtime-1")
+    pod = api.pods[pod_key]
+    runner = pod.spec.containers[0]
+    pending = dataclasses.replace(
+        pod,
+        spec=dataclasses.replace(
+            pod.spec,
+            containers=(
+                dataclasses.replace(runner, env=tuple(reversed(runner.env))),
+                *pod.spec.containers[1:],
+            ),
+        ),
+        status=PodStatus(phase="Pending", ready=False),
+    )
+    api.pods[pod_key] = pending
+
+    await provider.start(command)
+
+    assert api.deleted_pods == []
+    assert api.pods[pod_key] == pending
+
+
+@pytest.mark.asyncio
 async def test_observe_known_runtimes_reports_pod_and_pvc() -> None:
     api = FakeKubernetesApi()
     provider = _provider(api)

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
@@ -196,7 +196,10 @@ class RuntimeLifecycleReconciler:
             if (
                 runtime.desired_state is RuntimeDesiredState.RUNNING
                 and runtime.provider_observed_state
-                is not RuntimeProviderObservedState.RUNNING
+                in {
+                    RuntimeProviderObservedState.UNKNOWN,
+                    RuntimeProviderObservedState.STOPPED,
+                }
             )
             else RuntimeProviderCommandType.OBSERVE
         )

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
@@ -146,10 +146,18 @@ async def test_reconciler_refreshes_stale_provider_connection_before_start_timeo
     assert updated.failure_code is None
 
 
-async def test_reconciler_observes_running_runtime_without_restarting_it(
+@pytest.mark.parametrize(
+    "provider_observed_state",
+    [
+        RuntimeProviderObservedState.STARTING,
+        RuntimeProviderObservedState.RUNNING,
+    ],
+)
+async def test_reconciler_observes_active_runtime_without_restarting_it(
     rdb_session_manager: SessionManager[AsyncSession],
+    provider_observed_state: RuntimeProviderObservedState,
 ) -> None:
-    """Control observes a running Runtime without reconciling its Pod spec."""
+    """Control observes a starting/running Runtime without repeating START."""
     runtime_repository = AgentRuntimeRepository()
     async with rdb_session_manager() as session:
         workspace_id = await _create_workspace(session, "reconciler-observe-ws")
@@ -191,7 +199,7 @@ async def test_reconciler_observes_running_runtime_without_restarting_it(
         observed = await runtime_repository.record_provider_observed_state(
             session,
             runtime.id,
-            RuntimeProviderObservedState.RUNNING,
+            provider_observed_state,
             1,
             command.desired_generation,
         )
@@ -399,8 +407,8 @@ async def test_reconciler_fences_adoption_then_finishes_restart_replacement(
     assert competing is None
     assert reconciled == 1
     assert claimed is not None
-    assert claimed.operation_type == "provider.start"
-    assert claimed.payload["command_type"] == "start"
+    assert claimed.operation_type == "provider.observe"
+    assert claimed.payload["command_type"] == "observe"
     runtime_configuration = claimed.payload["runtime_configuration"]
     assert isinstance(runtime_configuration, dict)
     assert runtime_configuration["desired_generation"] == restart.desired_generation


### PR DESCRIPTION
## Summary

- treat an exact-generation Pending Kubernetes Runtime Pod as an in-progress idempotent START
- observe STARTING/RUNNING Runtimes instead of sending repeated periodic START commands
- add regressions for API-defaulted Pending Pods and active Runtime reconciliation

## Root cause

Runtime Control retried provider.start every 15 seconds while a Runtime was STARTING. Kubernetes API defaulting could make the round-tripped Pod fail the Provider full-spec reuse comparison, so each retry deleted the still-starting Pod. The Pod never reached Running and all desired-running Runtimes entered a recreation loop.

## Impact

Matching Pending Pods are now retained behind exact provider generation, desired generation, configuration revision/digest, image, and volume fences. Explicit generation/configuration changes and restart operations still replace Pods.

## Validation

- commit hooks: Ruff check/format, Pyright, OpenAPI dump passed
- Kubernetes Provider focused suite: 51 passed
- Control focused suite exercised locally; pre-existing restart-convergence expectation updated for STARTING -> OBSERVE semantics