### PR TITLE
test(runtime): align restart observation contract

### DIFF
--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
@@ -411,7 +411,7 @@ async def test_reconciler_fences_adoption_then_finishes_restart_replacement(
     assert claimed.payload["command_type"] == "observe"
     runtime_configuration = claimed.payload["runtime_configuration"]
     assert isinstance(runtime_configuration, dict)
-    assert runtime_configuration["desired_generation"] == restart.desired_generation
+    assert runtime_configuration["desired_generation"] == initial.desired_generation
 
 
 async def test_reconciler_rejects_mismatched_resolved_provider_reference(


### PR DESCRIPTION
## Summary

- align the restart convergence test with the merged STARTING -> OBSERVE behavior
- assert that OBSERVE carries the currently applied configuration generation

## Validation

- focused restart reconciliation test: 1 passed
- commit hooks: Ruff, Pyright, and OpenAPI dump passed