### PR TITLE
fix(runtime): observe desired restart configuration

### DIFF
--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler.py
@@ -429,8 +429,8 @@ class RuntimeLifecycleReconciler:
             runtime.desired_runtime_configuration_revision_id
             if require_ready
             else (
-                runtime.applied_runtime_configuration_revision_id
-                or runtime.desired_runtime_configuration_revision_id
+                runtime.desired_runtime_configuration_revision_id
+                or runtime.applied_runtime_configuration_revision_id
             )
         )
         if revision_id is None:

--- a/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
+++ b/python/apps/azents/src/azents/runtime/control_protocol/reconciler_test.py
@@ -411,7 +411,7 @@ async def test_reconciler_fences_adoption_then_finishes_restart_replacement(
     assert claimed.payload["command_type"] == "observe"
     runtime_configuration = claimed.payload["runtime_configuration"]
     assert isinstance(runtime_configuration, dict)
-    assert runtime_configuration["desired_generation"] == initial.desired_generation
+    assert runtime_configuration["desired_generation"] == restart.desired_generation
 
 
 async def test_reconciler_rejects_mismatched_resolved_provider_reference(


### PR DESCRIPTION
## Summary

- send the desired Runtime configuration revision while observing a restart generation
- restore the restart convergence assertion to the desired generation

## Root cause

After STARTING Runtimes changed from repeated START to OBSERVE, Runtime Control preferred the previous applied configuration revision. The Provider validates configuration evidence against the command desired generation, so generation 480 commands carrying generation 479 evidence failed with ValueError.

## Validation

- focused restart convergence test: 1 passed
- commit hooks: Ruff, Pyright, and OpenAPI dump passed
- live evidence: repeated OBSERVE rejected 479 evidence for desired generation 480